### PR TITLE
missing include <limits>

### DIFF
--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -21,6 +21,9 @@
 #if (defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__))
 #  include <math.h>
 #endif
+#ifndef BOOST_NO_LIMITS_COMPILE_TIME_CONSTANTS
+#  include <limits>
+#endif
 
 #include <boost/math/tools/user.hpp>
 


### PR DESCRIPTION
Introduced in e6996e11

compile error will occur like following.

```
In file included from libs/math/config/has_long_double_support.cpp:6:0:
./boost/math/tools/config.hpp:309:11: error: ‘numeric_limits’ is not a member of ‘std’
       || (std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::is_integer)
           ^
./boost/math/tools/config.hpp:309:32: error: expected primary-expression before ‘>’ token
       || (std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::is_integer)
                                ^
./boost/math/tools/config.hpp:309:33: error: ‘::is_specialized’ has not been declared
       || (std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::is_integer)
                                 ^
./boost/math/tools/config.hpp:309:53: error: ‘numeric_limits’ is not a member of ‘std’
       || (std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::is_integer)
                                                     ^
./boost/math/tools/config.hpp:309:74: error: expected primary-expression before ‘>’ token
       || (std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::is_integer)
                                                                          ^
./boost/math/tools/config.hpp:309:75: error: ‘::is_integer’ has not been declared
       || (std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::is_integer)
```
