### PR TITLE
Missing include <boost/utility/enable_if.hpp>

### DIFF
--- a/include/boost/math/special_functions/detail/bernoulli_details.hpp
+++ b/include/boost/math/special_functions/detail/bernoulli_details.hpp
@@ -8,6 +8,7 @@
 #define BOOST_MATH_BERNOULLI_DETAIL_HPP
 
 #include <boost/config.hpp>
+#include <boost/utility/enable_if.hpp>
 #include <boost/detail/lightweight_mutex.hpp>
 #include <boost/math/tools/toms748_solve.hpp>
 


### PR DESCRIPTION
I think there is a missing #include in bernoulli_details.hpp for enable_if_c. At least, the unit tests failed for me (Ubuntu 12.04) and this fixes it.
