### PR TITLE
Fix missing include enable_if.hpp

### DIFF
--- a/include/boost/math/special_functions/detail/bernoulli_details.hpp
+++ b/include/boost/math/special_functions/detail/bernoulli_details.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/config.hpp>
 #include <boost/detail/lightweight_mutex.hpp>
+#include <boost/utility/enable_if.hpp>
 #include <boost/math/tools/toms748_solve.hpp>
 
 #ifdef BOOST_HAS_THREADS


### PR DESCRIPTION
I think there is a missing #include in bernoulli_details.hpp for enable_if_c, which is used in line 179. The unit tests failed for me and this fixes it. (Apologies for a malformed pull request earlier; used to Darcs, git baffles me.)
