### PR TITLE
Correct spelling of "suppress"

### DIFF
--- a/include/boost/math/special_functions/fpclassify.hpp
+++ b/include/boost/math/special_functions/fpclassify.hpp
@@ -309,7 +309,7 @@ namespace detail {
       if(std::numeric_limits<T>::is_specialized)
          return isfinite_impl(x, generic_tag<true>());
 #endif
-       (void)x; // warning supression.
+       (void)x; // warning suppression.
        return true;
     }
 
@@ -453,7 +453,7 @@ namespace detail {
       if(std::numeric_limits<T>::is_specialized)
          return isinf_impl(x, generic_tag<true>());
 #endif
-        (void)x; // warning supression.
+        (void)x; // warning suppression.
         return false;
     }
 
@@ -541,7 +541,7 @@ namespace detail {
       if(std::numeric_limits<T>::is_specialized)
          return isnan_impl(x, generic_tag<true>());
 #endif
-        (void)x; // warning supression
+        (void)x; // warning suppression
         return false;
     }
 

--- a/test/test_hypergeometric_dist.cpp
+++ b/test/test_hypergeometric_dist.cpp
@@ -224,7 +224,7 @@ void do_test_hypergeometric_quantile(const T& data, const char* type_name, const
          value_type cp = data[i][5];
          value_type ccp = data[i][6];
          //
-         // A bit of warning supression:
+         // A bit of warning suppression:
          //
          (void)x;
          (void)n;
@@ -335,7 +335,7 @@ void test_spot(unsigned x, unsigned n, unsigned r, unsigned N,
                RealType p, RealType cp, RealType ccp, RealType tol)
 {
    //
-   // A bit of warning supression:
+   // A bit of warning suppression:
    //
    (void)x;
    (void)n;


### PR DESCRIPTION
"Suppress" is spelled with two P's, even in British English.