### PR TITLE
Fixing skewness formula (triangular distribution)

### DIFF
--- a/include/boost/math/distributions/triangular.hpp
+++ b/include/boost/math/distributions/triangular.hpp
@@ -475,7 +475,7 @@ namespace boost{ namespace math
       return result;
     }
     return root_two<RealType>() * (lower + upper - 2 * mode) * (2 * lower - upper - mode) * (lower - 2 * upper + mode) /
-      (5 * pow((lower * lower + upper + upper + mode * mode - lower * upper - lower * mode - upper * mode), RealType(3)/RealType(2)));
+      (5 * pow((lower * lower + upper * upper + mode * mode - lower * upper - lower * mode - upper * mode), RealType(3)/RealType(2)));
   } // RealType skewness(const triangular_distribution<RealType, Policy>& dist)
 
   template <class RealType, class Policy>


### PR DESCRIPTION
I noticed a problem in the skewness of the triangular distribution.
The formula is now correct (very likely it was typo).

You can find more information here:
https://en.wikipedia.org/wiki/Triangular_distribution
