### PR TITLE
Qualify std:: for isnan in some situation.

### DIFF
--- a/include/boost/math/special_functions/fpclassify.hpp
+++ b/include/boost/math/special_functions/fpclassify.hpp
@@ -133,6 +133,10 @@ inline bool is_nan_helper(T, const boost::false_type&)
 #if defined(BOOST_MATH_HAS_QUADMATH_H)
 inline bool is_nan_helper(__float128 f, const boost::true_type&) { return ::isnanq(f); }
 inline bool is_nan_helper(__float128 f, const boost::false_type&) { return ::isnanq(f); }
+#elif defined(BOOST_GNU_STDLIB) && BOOST_GNU_STDLIB && \
+      _GLIBCXX_USE_C99_MATH && !_GLIBCXX_USE_C99_FP_MACROS_DYNAMIC
+inline bool is_nan_helper(__float128 f, const boost::true_type&) { return std::isnan(static_cast<double>(f)); }
+inline bool is_nan_helper(__float128 f, const boost::false_type&) { return std::isnan(static_cast<double>(f)); }
 #else
 inline bool is_nan_helper(__float128 f, const boost::true_type&) { return ::isnan(static_cast<double>(f)); }
 inline bool is_nan_helper(__float128 f, const boost::false_type&) { return ::isnan(static_cast<double>(f)); }


### PR DESCRIPTION
Because isnan is implemented as a macro and libstdc++ undef it within <cmath> (at least FreeBSD 10).

See `Flast-FreeBSD10-gcc-4.8.5~gnu++11` column on http://www.boost.org/development/tests/develop/developer/math.html (e.g. [bessel_zeros_example_1](http://www.boost.org/development/tests/develop/developer/output/Flast-FreeBSD10-gcc-4-8-5~gnu++11-boost-bin-v2-libs-math-example-bessel_zeros_example_1-test-gcc-4-8-5-debug.html)).