### PR TITLE
Missing include for lexical_cast.

### DIFF
--- a/reporting/performance/table_helper.hpp
+++ b/reporting/performance/table_helper.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <string>
 #include <boost/version.hpp>
+#include <boost/lexical_cast.hpp>
 
 //
 // Also include headers for whatever else we may be testing:


### PR DESCRIPTION
Hidden because this file is usually included after something else that
includes lexical_cast.