### PR TITLE
gcd: example of gcd_binary for polynomial (WIP)

### DIFF
--- a/include/boost/math/common_factor_rt.hpp
+++ b/include/boost/math/common_factor_rt.hpp
@@ -180,7 +180,7 @@ namespace detail
                 // Remove factors from the even one
                 while ( even(*r[ which ]) )
                 {
-                    *r[ which ] >>= 1;
+                    *r[ which ] >>= 1u;
                 }
 #endif
 

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -302,6 +302,11 @@ public:
       }
    }
    
+   operator bool() const
+    {
+        return *this == static_cast<polynomial>(0);
+    }
+   
 #ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
     polynomial(std::initializer_list<T> l) : polynomial(std::begin(l), std::end(l))
     {
@@ -640,6 +645,7 @@ polynomial<T> operator - (polynomial<T> a)
 }
 
 template <class T>
+
 bool odd(polynomial<T> const &a)
 {
     return a.size() > 0 && a[0] != static_cast<T>(0);
@@ -649,6 +655,12 @@ template <class T>
 bool even(polynomial<T> const &a)
 {
     return !odd(a);
+}
+
+template <class T>
+bool Stein_gcd_less(polynomial<T> const &a, polynomial<T> const &b)
+{
+    return a.size() < b.size();
 }
 
 template <class charT, class traits, class T>

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -448,7 +448,22 @@ public:
        return *this;
    }
 
-   /** Remove zero coefficients 'from the top', that is for which there are no
+   template <typename U>
+   polynomial& operator >>=(U const &n)
+   {
+       BOOST_ASSERT(n <= m_data.size());
+       m_data.erase(m_data.begin(), m_data.begin() + n);
+       return *this;
+    }
+
+    template <typename U>
+    polynomial& operator <<=(U const &n)
+    {
+        m_data.insert(m_data.begin(), n, static_cast<T>(0));
+        return *this;
+    }
+    
+    /** Remove zero coefficients 'from the top', that is for which there are no
     *        non-zero coefficients of higher degree. */
    void normalize()
    {
@@ -598,6 +613,22 @@ template <class T>
 bool operator == (const polynomial<T> &a, const polynomial<T> &b)
 {
     return a.data() == b.data();
+}
+
+template <typename T, typename U>
+polynomial<T> operator >> (const polynomial<T>& a, const U& b)
+{
+    polynomial<T> result(a);
+    result >>= b;
+    return result;
+}
+
+template <typename T, typename U>
+polynomial<T> operator << (const polynomial<T>& a, const U& b)
+{
+    polynomial<T> result(a);
+    result <<= b;
+    return result;
 }
 
 // Unary minus (negate).

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -454,14 +454,14 @@ public:
        BOOST_ASSERT(n <= m_data.size());
        m_data.erase(m_data.begin(), m_data.begin() + n);
        return *this;
-    }
+   }
 
-    template <typename U>
-    polynomial& operator <<=(U const &n)
-    {
-        m_data.insert(m_data.begin(), n, static_cast<T>(0));
-        return *this;
-    }
+   template <typename U>
+   polynomial& operator <<=(U const &n)
+   {
+       m_data.insert(m_data.begin(), n, static_cast<T>(0));
+       return *this;
+   }
     
     /** Remove zero coefficients 'from the top', that is for which there are no
     *        non-zero coefficients of higher degree. */

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -639,6 +639,18 @@ polynomial<T> operator - (polynomial<T> a)
     return a;
 }
 
+template <class T>
+bool odd(polynomial<T> const &a)
+{
+    return a.size() > 0 && a[0] != static_cast<T>(0);
+}
+
+template <class T>
+bool even(polynomial<T> const &a)
+{
+    return !odd(a);
+}
+
 template <class charT, class traits, class T>
 inline std::basic_ostream<charT, traits>& operator << (std::basic_ostream<charT, traits>& os, const polynomial<T>& poly)
 {

--- a/reporting/performance/test_gcd.cpp
+++ b/reporting/performance/test_gcd.cpp
@@ -72,6 +72,6 @@ int main()
     typedef unsigned int_type;
     pair<int_type, int_type> test_data{1836311903, 2971215073}; // 46th and 47th Fibonacci numbers. 47th is prime.
     typedef pair< function<int_type(int_type, int_type)>, string> f_test;
-    array<f_test, 2> test_functions{{{gcd_euclidean<int_type>, "gcd_euclidean"}, {gcd_binary<int_type>, "gcd_binary"}}};
+    array<f_test, 2> test_functions{{{gcd_euclidean<int_type>, "gcd_euclidean"}, {gcd_Stein<int_type>, "gcd_Stein"}}};
     for_each(begin(test_functions), end(test_functions), test_function_template<int_type>(test_data));
 }

--- a/test/test_gcd.cpp
+++ b/test/test_gcd.cpp
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_signed, T, signed_integral_test_types)
     BOOST_CHECK_EQUAL(a, static_cast<T>(34));
 }
 
-typedef boost::mpl::list<unsigned, unsigned long> unsigned_integral_test_types;
+typedef boost::mpl::list<unsigned, unsigned long, boost::multiprecision::uint128_t> unsigned_integral_test_types;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_unsigned, T, unsigned_integral_test_types)
 {

--- a/test/test_polynomial.cpp
+++ b/test/test_polynomial.cpp
@@ -247,3 +247,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_left_shift, T, all_test_types )
     a = a << 4u;
     BOOST_CHECK_EQUAL(a, c);
 }
+
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_odd_even, T, all_test_types)
+{
+    polynomial<T> const zero = zero_element(multiplies< polynomial<T> >());
+    BOOST_CHECK_EQUAL(odd(zero), false);
+    BOOST_CHECK_EQUAL(even(zero), true);
+    polynomial<T> const a(d0a.begin(), d0a.end());
+    BOOST_CHECK_EQUAL(odd(a), true);
+    BOOST_CHECK_EQUAL(even(a), false);
+    polynomial<T> const b(d0a1.begin(), d0a1.end());
+    BOOST_CHECK_EQUAL(odd(b), false);
+    BOOST_CHECK_EQUAL(even(b), true);
+}

--- a/test/test_polynomial.cpp
+++ b/test/test_polynomial.cpp
@@ -38,6 +38,8 @@ boost::array<double, 3> const d2a = {{-2, 2, 3}};
 boost::array<double, 3> const d2b = {{-7, 5, 6}};
 boost::array<double, 3> const d2c = {{31, -21, -22}};
 boost::array<double, 1> const d0a = {{6}};
+boost::array<double, 2> const d0a1 = {{0, 6}};
+boost::array<double, 6> const d0a5 = {{0, 0, 0, 0, 0, 6}};
 boost::array<double, 1> const d0b = {{3}};
 
 boost::array<int, 9> const d8 = {{-5, 2, 8, -3, -3, 0, 1, 0, 1}};
@@ -216,3 +218,32 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_non_integral_arithmetic_relations, T, non_int
     BOOST_CHECK_EQUAL(a * T(0.5), a / T(2));
 }
 
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_right_shift, T, all_test_types )
+{
+    polynomial<T> a(d8b.begin(), d8b.end());
+    polynomial<T> const aa(a);
+    polynomial<T> const b(d8b.begin() + 1, d8b.end());
+    polynomial<T> const c(d8b.begin() + 5, d8b.end());
+    a >>= 0u;
+    BOOST_CHECK_EQUAL(a, aa);
+    a >>= 1u;
+    BOOST_CHECK_EQUAL(a, b);
+    a = a >> 4u;
+    BOOST_CHECK_EQUAL(a, c);
+}
+
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_left_shift, T, all_test_types )
+{
+    polynomial<T> a(d0a.begin(), d0a.end());
+    polynomial<T> const aa(a);
+    polynomial<T> const b(d0a1.begin(), d0a1.end());
+    polynomial<T> const c(d0a5.begin(), d0a5.end());
+    a <<= 0u;
+    BOOST_CHECK_EQUAL(a, aa);    
+    a <<= 1u;
+    BOOST_CHECK_EQUAL(a, b);
+    a = a << 4u;
+    BOOST_CHECK_EQUAL(a, c);
+}


### PR DESCRIPTION
**Don't merge this PR, it's just for demonstration.**

This includes the PR for polynomial shift, so if you ignore those changes and concentrate on `gcd_Stein` (nee binary) you'll see that I have abstracted out the concept of odd/even and the concept of less-than wrt to Stein gcd.

One could also make the shift operator more abstract, but I don't see the need at the moment.
