### PR TITLE
Fix indefinite hang with polynomial *= itself

### DIFF
--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -417,15 +417,12 @@ public:
           *this = zero;
           return *this;
       }
-      int i = value.size() - 1;
-      if (!i)
-          return multiplication(value[0]);
-      polynomial base(*this);
-      m_data.resize(size() + i);
-      for(; i >= 0; --i)
-         for(int j = base.size() - 1; j >= 0; --j)
-            m_data[i+j] += base[j] * value[i];
-      return subtraction(base);
+      std::vector<T> prod(size() + value.size() - 1);
+      for (size_type i = 0; i < value.size(); ++i)
+         for (size_type j = 0; j < size(); ++j)
+            prod[i+j] += m_data[j] * value[i];
+      m_data.swap(prod);
+      return *this;
    }
 
    template <typename U>

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -408,7 +408,7 @@ public:
        return *this;
    }
    template <class U>
-   polynomial& operator *=(const polynomial<U> value)
+   polynomial& operator *=(const polynomial<U>& value)
    {
       // TODO: FIXME: use O(N log(N)) algorithm!!!
       polynomial const zero = zero_element(std::multiplies<polynomial>());
@@ -417,21 +417,15 @@ public:
           *this = zero;
           return *this;
       }
+      int i = value.size() - 1;
+      if (!i)
+          return multiplication(value[0]);
       polynomial base(*this);
-      this->multiplication(value[0]);
-      for(size_type i = 1; i < value.size(); ++i)
-      {
-         polynomial t(base);
-         t.multiplication(value[i]);
-         size_type s = size() - i;
-         for(size_type j = 0; j < s; ++j)
-         {
-            m_data[i+j] += t[j];
-         }
-         for(size_type j = s; j < t.size(); ++j)
-            m_data.push_back(t[j]);
-      }
-      return *this;
+      m_data.resize(size() + i);
+      for(; i >= 0; --i)
+         for(int j = base.size() - 1; j >= 0; --j)
+            m_data[i+j] += base[j] * value[i];
+      return subtraction(base);
    }
 
    template <typename U>

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -417,7 +417,7 @@ public:
           *this = zero;
           return *this;
       }
-      std::vector<T> prod(size() + value.size() - 1);
+      std::vector<T> prod(size() + value.size() - 1, T(0));
       for (size_type i = 0; i < value.size(); ++i)
          for (size_type j = 0; j < size(); ++j)
             prod[i+j] += m_data[j] * value[i];

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -408,7 +408,7 @@ public:
        return *this;
    }
    template <class U>
-   polynomial& operator *=(const polynomial<U>& value)
+   polynomial& operator *=(const polynomial<U> value)
    {
       // TODO: FIXME: use O(N log(N)) algorithm!!!
       polynomial const zero = zero_element(std::multiplies<polynomial>());


### PR DESCRIPTION
This code:
```C++
#include <boost/math/tools/polynomial.hpp>

int main() {
    double acoef[] = {1., 2.};
    boost::math::tools::polynomial<double> a(acoef, 1);
    a *= a;
    return 0;
}
```
will hang indefinitely (either with Boost 1.59.0, or with the current develop branch.)
This is because `polynomial::operator *=(const polynomial<U>& value)` goes through the elements of `value` in a loop, pushing back some new elements on `m_data`; when `value` is `*this`, this grows the list we are looping through, so it goes on forever.

A one-character fix is to delete the `&` in the function signature.