### PR TITLE
Additional polynomial units tests & small normalization bug

### DIFF
--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -311,6 +311,7 @@ public:
     operator=(std::initializer_list<T> l)
     {
         m_data.assign(std::begin(l), std::end(l));
+        normalize();
         return *this;
     }
 #endif

--- a/test/test_polynomial.cpp
+++ b/test/test_polynomial.cpp
@@ -61,8 +61,19 @@ BOOST_AUTO_TEST_CASE( test_initializer_list_construction )
     polynomial<double> a(begin(d3a), end(d3a));
     polynomial<double> b = {10, -6, -4, 3};
     polynomial<double> c{{10, -6, -4, 3}};
+    polynomial<double> d{{10, -6, -4, 3, 0, 0}};
     BOOST_CHECK_EQUAL(a, b);
     BOOST_CHECK_EQUAL(b, c);
+    BOOST_CHECK_EQUAL(d.degree(), 3u);
+}
+
+BOOST_AUTO_TEST_CASE( test_initializer_list_assignment )
+{
+    polynomial<double> a(begin(d3a), end(d3a));
+    polynomial<double> b;
+    b = {10, -6, -4, 3, 0, 0};
+    BOOST_CHECK_EQUAL(b.degree(), 3u);
+    BOOST_CHECK_EQUAL(a, b);
 }
 #endif
 

--- a/test/test_polynomial.cpp
+++ b/test/test_polynomial.cpp
@@ -216,3 +216,20 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_non_integral_arithmetic_relations, T, non_int
     BOOST_CHECK_EQUAL(a * T(0.5), a / T(2));
 }
 
+BOOST_AUTO_TEST_CASE_TEMPLATE( test_self_multiply_assign, T, all_test_types )
+{
+    polynomial<T> a(d3a.begin(), d3a.end());
+    polynomial<T> const b(a);
+    boost::array<double, 7> const d3a_sq = {{100, -120, -44, 108, -20, -24, 9}};
+    polynomial<T> const asq(d3a_sq.begin(), d3a_sq.end());
+
+    a *= a;
+
+    BOOST_CHECK_EQUAL(a, b*b);
+    BOOST_CHECK_EQUAL(a, asq);
+
+    a *= a;
+
+    BOOST_CHECK_EQUAL(a, b*b*b*b);
+}
+


### PR DESCRIPTION
I added a unit test for the polynomial self-multiply-assignment problem fixed in pull request #35.

Also, I added a missing call to `normalize()` in `operator=(std::initializer_list<T> l)`, which allowed polynomials to exist with zero leading coefficients, and added tests to check that polynomials constructed and assigned with initalizer lists are normalized (which fail before commit 4302398, and succeed afterward.)