### PR TITLE
pow function for polynomials

### DIFF
--- a/doc/internals/polynomial.qbk
+++ b/doc/internals/polynomial.qbk
@@ -104,6 +104,9 @@
    template <class T>
    bool operator != (const polynomial<T> &a, const polynomial<T> &b);
 
+   template <class T>
+   polynomial<T> pow(polynomial<T> base, int exp);
+
    template <class charT, class traits, class T>
    std::basic_ostream<charT, traits>& operator <<
       (std::basic_ostream<charT, traits>& os, const polynomial<T>& poly);

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -649,29 +649,13 @@ template <class T>
 polynomial<T> pow(polynomial<T> base, int exp)
 {
     if (exp < 0)
-    {
-        if (base.size() == 1)
-        {
-            using std::pow;
-            T res(pow(base[0], exp)); // Use ADL to find the right pow
-            if (res == T(0)) // integral
-                return policies::raise_domain_error(
-                        "boost::math::tools::pow<%1%>",
-                        "Negative powers not supported for integer constants.",
-                        base, policies::policy<>());
-            return polynomial<T>(res);
-        }
         return policies::raise_domain_error(
                 "boost::math::tools::pow<%1%>",
-                "Negative powers are not supported for non-constant polynomials.",
+                "Negative powers are not supported for polynomials.",
                 base, policies::policy<>());
         // if the policy is ignore_error or errno_on_error, raise_domain_error
         // will return std::numeric_limits<polynomial<T>>::quiet_NaN(), which
         // defaults to polynomial<T>(), which is the zero polynomial
-        /* ARG, but throw_on_error (default) requires boost::math::policies::digits<T,policy>
-         * which requires std::numeric_limits<T> to be specialized,
-         * just to try to format val into %1% in message, which isn't even there!! */
-    }
     polynomial<T> result(T(1));
     if (exp & 1)
         result = base;

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -409,7 +409,7 @@ public:
        return *this;
    }
    template <class U>
-   polynomial& operator *=(const polynomial<U> value)
+   polynomial& operator *=(const polynomial<U>& value)
    {
       // TODO: FIXME: use O(N log(N)) algorithm!!!
       polynomial const zero = zero_element(std::multiplies<polynomial>());

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -647,7 +647,16 @@ bool even(polynomial<T> const &a)
 template <class T>
 polynomial<T> pow(polynomial<T> base, int exp)
 {
-    BOOST_ASSERT(exp >= 0);
+    if (exp < 0)
+       throw std::domain_error("Negative powers are not supported for polynomials.");
+    /* Consider:
+       if (base.size() == 1)
+        {
+            using std::pow;
+            return polynomial<T>(T(pow(base[0], exp))); // Use ADL to find the right pow
+        }
+        But this wouldn't work for integral T
+     */
     polynomial<T> result(T(1));
     if (exp & 1) result = base;
     /* "Exponentiation by squaring" */

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -409,7 +409,7 @@ public:
        return *this;
    }
    template <class U>
-   polynomial& operator *=(const polynomial<U>& value)
+   polynomial& operator *=(const polynomial<U> value)
    {
       // TODO: FIXME: use O(N log(N)) algorithm!!!
       polynomial const zero = zero_element(std::multiplies<polynomial>());
@@ -642,6 +642,21 @@ template <class T>
 bool even(polynomial<T> const &a)
 {
     return !odd(a);
+}
+
+template <class T>
+polynomial<T> pow(polynomial<T> base, int exp)
+{
+    BOOST_ASSERT(exp >= 0);
+    polynomial<T> result(T(1));
+    if (exp & 1) result = base;
+    /* "Exponentiation by squaring" */
+    while (exp >>= 1)
+    {
+        base *= base;
+        if (exp & 1) result *= base;
+    }
+    return result;
 }
 
 template <class charT, class traits, class T>

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -19,6 +19,7 @@
 #include <boost/lambda/lambda.hpp>
 #include <boost/math/tools/rational.hpp>
 #include <boost/math/tools/real_cast.hpp>
+#include <boost/math/policies/error_handling.hpp>
 #include <boost/math/special_functions/binomial.hpp>
 #include <boost/operators.hpp>
 
@@ -648,22 +649,38 @@ template <class T>
 polynomial<T> pow(polynomial<T> base, int exp)
 {
     if (exp < 0)
-       throw std::domain_error("Negative powers are not supported for polynomials.");
-    /* Consider:
-       if (base.size() == 1)
+    {
+        if (base.size() == 1)
         {
             using std::pow;
-            return polynomial<T>(T(pow(base[0], exp))); // Use ADL to find the right pow
+            T res(pow(base[0], exp)); // Use ADL to find the right pow
+            if (res == T(0)) // integral
+                return policies::raise_domain_error(
+                        "boost::math::tools::pow<%1%>",
+                        "Negative powers not supported for integer constants.",
+                        base, policies::policy<>());
+            return polynomial<T>(res);
         }
-        But this wouldn't work for integral T
-     */
+        return policies::raise_domain_error(
+                "boost::math::tools::pow<%1%>",
+                "Negative powers are not supported for non-constant polynomials.",
+                base, policies::policy<>());
+        // if the policy is ignore_error or errno_on_error, raise_domain_error
+        // will return std::numeric_limits<polynomial<T>>::quiet_NaN(), which
+        // defaults to polynomial<T>(), which is the zero polynomial
+        /* ARG, but throw_on_error (default) requires boost::math::policies::digits<T,policy>
+         * which requires std::numeric_limits<T> to be specialized,
+         * just to try to format val into %1% in message, which isn't even there!! */
+    }
     polynomial<T> result(T(1));
-    if (exp & 1) result = base;
+    if (exp & 1)
+        result = base;
     /* "Exponentiation by squaring" */
     while (exp >>= 1)
     {
         base *= base;
-        if (exp & 1) result *= base;
+        if (exp & 1)
+            result *= base;
     }
     return result;
 }

--- a/test/test_polynomial.cpp
+++ b/test/test_polynomial.cpp
@@ -298,3 +298,26 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_odd_even, T, all_test_types)
     BOOST_CHECK_EQUAL(odd(b), false);
     BOOST_CHECK_EQUAL(even(b), true);
 }
+
+BOOST_AUTO_TEST_CASE_TEMPLATE( test_pow, T, all_test_types )
+{
+    polynomial<T> a(d3a.begin(), d3a.end());
+    polynomial<T> const one = identity_element(std::multiplies< polynomial<T> >());
+    boost::array<double, 7> const d3a_sqr = {{100, -120, -44, 108, -20, -24, 9}};
+    boost::array<double, 10> const d3a_cub =
+        {{1000, -1800, -120, 2124, -1032, -684, 638, -18, -108, 27}};
+    polynomial<T> const asqr(d3a_sqr.begin(), d3a_sqr.end());
+    polynomial<T> const acub(d3a_cub.begin(), d3a_cub.end());
+
+    BOOST_CHECK_EQUAL(pow(a, 0), one);
+    BOOST_CHECK_EQUAL(pow(a, 1), a);
+    BOOST_CHECK_EQUAL(pow(a, 2), asqr);
+    BOOST_CHECK_EQUAL(pow(a, 3), acub);
+    BOOST_CHECK_EQUAL(pow(a, 4), pow(asqr, 2));
+    BOOST_CHECK_EQUAL(pow(a, 5), asqr * acub);
+    BOOST_CHECK_EQUAL(pow(a, 6), pow(acub, 2));
+    BOOST_CHECK_EQUAL(pow(a, 7), acub * acub * a);
+
+    BOOST_CHECK_THROW(pow(a, -1), std::domain_error);
+    BOOST_CHECK_EQUAL(pow(one, 137), one);
+}

--- a/test/test_polynomial.cpp
+++ b/test/test_polynomial.cpp
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE( test_initializer_list_assignment )
 
 BOOST_AUTO_TEST_CASE( test_degree )
 {
-    polynomial<double> const zero = zero_element(std::multiplies< polynomial<double> >());
+    polynomial<double> const zero;
     polynomial<double> const a(d3a.begin(), d3a.end());
     BOOST_CHECK_THROW(zero.degree(), std::logic_error);
     BOOST_CHECK_EQUAL(a.degree(), 3u);
@@ -100,8 +100,8 @@ BOOST_AUTO_TEST_CASE( test_division_over_field )
     polynomial<double> const e(d2c.begin(), d2c.end());
     polynomial<double> const f(d0b.begin(), d0b.end());
     polynomial<double> const g(d3c.begin(), d3c.end());
-    polynomial<double> const zero = zero_element(std::multiplies< polynomial<double> >());
-    polynomial<double> const one = identity_element(std::multiplies< polynomial<double> >());
+    polynomial<double> const zero;
+    polynomial<double> const one(1.0);
 
     answer<double> result = quotient_remainder(a, b);
     BOOST_CHECK_EQUAL(result.quotient, q);
@@ -129,8 +129,8 @@ BOOST_AUTO_TEST_CASE( test_division_over_field )
 
 BOOST_AUTO_TEST_CASE( test_division_over_ufd )
 {
-    polynomial<int> const zero = zero_element(std::multiplies< polynomial<int> >());
-    polynomial<int> const one = identity_element(std::multiplies< polynomial<int> >());
+    polynomial<int> const zero;
+    polynomial<int> const one(1);
     polynomial<int> const aa(d8.begin(), d8.end());
     polynomial<int> const bb(d6.begin(), d6.end());
     polynomial<int> const q(d2.begin(), d2.end());
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_addition, T, all_test_types )
 {
     polynomial<T> const a(d3a.begin(), d3a.end());
     polynomial<T> const b(d1a.begin(), d1a.end());
-    polynomial<T> const zero = zero_element(multiplies< polynomial<T> >());
+    polynomial<T> const zero;
     
     polynomial<T> result = a + b; // different degree
     boost::array<T, 4> tmp = {{8, -5, -4, 3}};
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_addition, T, all_test_types )
 BOOST_AUTO_TEST_CASE_TEMPLATE( test_subtraction, T, all_test_types )
 {
     polynomial<T> const a(d3a.begin(), d3a.end());
-    polynomial<T> const zero = zero_element(multiplies< polynomial<T> >());
+    polynomial<T> const zero;
 
     BOOST_CHECK_EQUAL(a - T(0), a);
     BOOST_CHECK_EQUAL(T(0) - a, -a);
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_multiplication, T, all_test_types )
 {
     polynomial<T> const a(d3a.begin(), d3a.end());
     polynomial<T> const b(d1a.begin(), d1a.end());
-    polynomial<T> const zero = zero_element(multiplies< polynomial<T> >());
+    polynomial<T> const zero;
     boost::array<T, 7> const d3a_sq = {{100, -120, -44, 108, -20, -24, 9}};
     polynomial<T> const a_sq(d3a_sq.begin(), d3a_sq.end());
     
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_left_shift, T, all_test_types )
     BOOST_CHECK_EQUAL(a, b);
     a = a << 4u;
     BOOST_CHECK_EQUAL(a, c);
-    polynomial<T> zero = zero_element(multiplies< polynomial<T> >());
+    polynomial<T> zero;
     // Multiplying zero by x should still be zero.
     zero <<= 1u;
     BOOST_CHECK_EQUAL(zero, zero_element(multiplies< polynomial<T> >()));
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_left_shift, T, all_test_types )
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_odd_even, T, all_test_types)
 {
-    polynomial<T> const zero = zero_element(multiplies< polynomial<T> >());
+    polynomial<T> const zero;
     BOOST_CHECK_EQUAL(odd(zero), false);
     BOOST_CHECK_EQUAL(even(zero), true);
     polynomial<T> const a(d0a.begin(), d0a.end());
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_odd_even, T, all_test_types)
 BOOST_AUTO_TEST_CASE_TEMPLATE( test_pow, T, all_test_types )
 {
     polynomial<T> a(d3a.begin(), d3a.end());
-    polynomial<T> const one = identity_element(std::multiplies< polynomial<T> >());
+    polynomial<T> const one(T(1));
     boost::array<double, 7> const d3a_sqr = {{100, -120, -44, 108, -20, -24, 9}};
     boost::array<double, 10> const d3a_cub =
         {{1000, -1800, -120, 2124, -1032, -684, 638, -18, -108, 27}};


### PR DESCRIPTION
I would like to propose a function
```C++
template <class T>
polynomial<T> pow(polynomial<T> base, int exp);
```
This can be found via argument-dependent lookup, so that polynomials can be used more generically.

This raises a domain exception (according to the default policy) if the exponent is negative. I thought of trying `pow(base[0], exp)` in the case that `base` is a constant (degree-0 polynomial) and `exp` is negative. This works fine when `T` is `double`, or when `T` is `int` and `base[0]` is ±1.
But it fails if `pow(T, int)` cannot be found, and gives a huge swath of errors if `T` is from Boost.Multiprecision, and perhaps isn't worth the trouble.