### PR TITLE
Fix a lognormal mode formula in the documentation

### DIFF
--- a/doc/distributions/lognormal.qbk
+++ b/doc/distributions/lognormal.qbk
@@ -102,7 +102,7 @@ and /q = 1-p/.
 [[quantile from the complement][Using the relation: x = exp(quantile(complement(normal_distribtion<RealType>(m, s), q)))]]
 [[mean][e[super m + s[super 2 ] / 2 ] ]]
 [[variance][(e[super s[super 2] ] - 1) * e[super 2m + s[super 2 ] ] ]]
-[[mode][e[super m + s[super 2 ] ] ]]
+[[mode][e[super m - s[super 2 ] ] ]]
 [[skewness][sqrt(e[super s[super 2] ] - 1) * (2 + e[super s[super 2] ]) ]]
 [[kurtosis][e[super 4s[super 2] ] + 2e[super 3s[super 2] ] + 3e[super 2s[super 2] ] - 3]]
 [[kurtosis excess][e[super 4s[super 2] ] + 2e[super 3s[super 2] ] + 3e[super 2s[super 2] ] - 6 ]]


### PR DESCRIPTION
Mode of lognormal distribution has to be: ![mode](https://wikimedia.org/api/rest_v1/media/math/render/svg/979e828a58964d542c7ba1ff57e6ac0bcdd4f343)
Wiki [source](https://en.wikipedia.org/wiki/Log-normal_distribution).