### PR TITLE
Fix boost::math::polynomial::evaluate for the zero polynomial

### DIFF
--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -337,7 +337,7 @@ public:
    }
    T evaluate(T z)const
    {
-      return boost::math::tools::evaluate_polynomial(&m_data[0], z, m_data.size());;
+      return m_data.size() > 0 ? boost::math::tools::evaluate_polynomial(&m_data[0], z, m_data.size()) : 0;
    }
    std::vector<T> chebyshev()const
    {


### PR DESCRIPTION
Due to a recent change in the representation of the zero polynomial (739c056f2b17c047cbeaed9a083275a7aff017a1), I think the evaluate function is broken for the zero polynomial.

Currently if the evaluate method is called on a zero polynomial, it returns:
```
/usr/include/boost/math/tools/rational.hpp:191: U boost::math::tools::evaluate_polynomial(const T*, const U&, std::size_t) [with T = double; U = double; std::size_t = long unsigned int]: Assertion `count > 0' failed.
```
I opened a ticket regarding the same at https://svn.boost.org/trac/boost/ticket/12532 since I was not sure which is the preferred medium.
