### PR TITLE
Addition of the barycentric rational interpolant.

### DIFF
--- a/doc/internals/barycentric_rational_interpolation.qbk
+++ b/doc/internals/barycentric_rational_interpolation.qbk
@@ -1,0 +1,45 @@
+[section:barycentric Barycentric Rational Interpolation]
+
+[h4 Synopsis]
+
+``
+#include <boost/math/tools/barycentric_rational_interpolation.hpp>
+``
+
+
+[h4 Description]
+
+Barycentric rational interpolation is a high-precision interpolation routine for non-uniformly spaced samples.
+It requires [bigo](N) time for construction, and [bigo](N) time for each evaluation.
+Linear time evaluation is not optimal; for instance the cubic b spline can be evaluated in constant time.
+However, using the cubic b spline requires uniformly spaced samples, which are not always available.
+
+Use of the routine requires a vector of independent variables x[0], x[1], .... x[n-1] where x[i+1] > x[i],
+and a vector of dependent variables y[0], y[1], ... , y[n-1].
+The call is trivial:
+
+    __boost::math::tools::barycentric_rational<double>(x.data(), y.data(), y.size());
+
+This implicitly calls the constructor with approximation order 3, and hence the accuracy is [bigo](h^4).
+In general, if you require an approximation order d, then the error is [bigo](h^d+1).
+
+Although this algorithm is robust, it can surprise you. The main way this occurs is if there is some i such that x[i] - x[i-1] is many orders of magnitude smaller than x[i+1] - x[i].
+This can cause a large "swing" where the interpolant makes a fast dive to hit y[i], but then flies very high since it is unconstrained until y[i+1], which is far away.
+
+The precise quantification of this idea is encoded in the "local mesh ratio", discussed in Floater's paper on the barycentric rational interpolation.
+
+See
+
+* [@http://www.mn.uio.no/math/english/people/aca/michaelf/papers/rational.pdf Barycentric rational interpolation with no poles and a high rate of interpolation ]
+* Floater, M.S. & Hormann, K. Numer. Math. (2007) 107: 315. doi:10.1007/s00211-007-0093-y
+
+
+[endsect] [/section:barycentric Barycentric Rational Interpolation]
+
+[/
+  Copyright 2017 Nick Thompson
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt).
+]

--- a/doc/internals/barycentric_rational_interpolation.qbk
+++ b/doc/internals/barycentric_rational_interpolation.qbk
@@ -1,46 +1,3 @@
-[section:barycentric Barycentric Rational Interpolation]
-
-[h4 Synopsis]
-
-``
-#include <boost/math/tools/barycentric_rational_interpolation.hpp>
-``
-
-
-[h4 Description]
-
-Barycentric rational interpolation is a high-precision interpolation class for non-uniformly spaced samples.
-It requires [bigo](N) time for construction, and [bigo](N) time for each evaluation.
-Linear time evaluation is not optimal; for instance the cubic b spline can be evaluated in constant time.
-However, using the cubic b spline requires uniformly spaced samples, which are not always available.
-
-Use of the class requires a vector of independent variables x[0], x[1], .... x[n-1] where x[i+1] > x[i],
-and a vector of dependent variables y[0], y[1], ... , y[n-1].
-The call is trivial:
-
-    __boost::math::tools::barycentric_rational<double> interpolant(x.data(), y.data(), y.size());
-
-This implicitly calls the constructor with approximation order 3, and hence the accuracy is [bigo](h^4).
-In general, if you require an approximation order d, then the error is [bigo](h^d+1).
-A call to the constructor with an explicit approximation order could be
-
-    __boost::math::tools::barycentric_rational<double>(x.data(), y.data(), y.size(), 5);
-
-To evaluate the interpolant,
-
-Although this algorithm is robust, it can surprise you. The main way this occurs is if there is some i such that x[i] - x[i-1] is many orders of magnitude smaller than x[i+1] - x[i].
-This can cause a large "swing" where the interpolant makes a fast dive to hit y[i], but then flies very high since it is unconstrained until y[i+1], which is far away.
-
-The precise quantification of this idea is encoded in the "local mesh ratio", discussed in Floater's paper on the barycentric rational interpolation.
-
-See
-
-* [@http://www.mn.uio.no/math/english/people/aca/michaelf/papers/rational.pdf Barycentric rational interpolation with no poles and a high rate of interpolation ]
-* Floater, M.S. & Hormann, K. Numer. Math. (2007) 107: 315. doi:10.1007/s00211-007-0093-y
-
-
-[endsect] [/section:barycentric Barycentric Rational Interpolation]
-
 [/
   Copyright 2017 Nick Thompson
 
@@ -48,3 +5,57 @@ See
   (See accompanying file LICENSE_1_0.txt or copy at
   http://www.boost.org/LICENSE_1_0.txt).
 ]
+
+[section:barycentric Barycentric Rational Interpolation]
+
+[heading Synopsis]
+
+``
+#include <boost/math/tools/barycentric_rational_interpolation.hpp>
+
+namespace boost{ namespace math{
+    template<class Real>
+    class barycentric_rational
+    {
+    public:
+        barycentric_rational(const Real* const x, const Real* const y, size_t n, size_t approximation_order = 3);
+
+        Real operator()(Real x) const;
+    };
+
+}}
+``
+
+
+[heading Description]
+
+Barycentric rational interpolation is a high-accuracy interpolation method for non-uniformly spaced samples.
+It requires [bigo](N) time for construction, and [bigo](N) time for each evaluation.
+Linear time evaluation is not optimal; for instance the cubic B-spline can be evaluated in constant time.
+However, using the cubic b spline requires uniformly spaced samples, which are not always available.
+
+Use of the class requires a vector of independent variables x[0], x[1], .... x[n-1] where x[i+1] > x[i],
+and a vector of dependent variables y[0], y[1], ... , y[n-1].
+The call is trivial:
+
+    boost::math::tools::barycentric_rational<double> interpolant(x.data(), y.data(), y.size());
+
+This implicitly calls the constructor with approximation order 3, and hence the accuracy is [bigo](h[super 4]).
+In general, if you require an approximation order /d/, then the error is [bigo](h[super d+1]).
+A call to the constructor with an explicit approximation order could be
+
+    boost::math::tools::barycentric_rational<double> interpolant(x.data(), y.data(), y.size(), 5);
+
+To evaluate the interpolant, simply use
+
+    double x = 2.3;
+    double y = interpolant(x);
+
+Although this algorithm is robust, it can surprise you.
+The main way this occurs is if the sample spacing at the endpoints is much larger than the spacing in the center.
+This is to be expected; all interpolants perform better in the opposite regime, where samples are clustered at the endpoints and somewhat uniformly spaced throughout the center.
+
+
+The reference used for implementation of this algorithm is [@https://web.archive.org/save/_embed/http://www.mn.uio.no/math/english/people/aca/michaelf/papers/rational.pdf Barycentric rational interpolation with no poles and a high rate of interpolation].
+
+[endsect] [/section:barycentric Barycentric Rational Interpolation]

--- a/doc/internals/barycentric_rational_interpolation.qbk
+++ b/doc/internals/barycentric_rational_interpolation.qbk
@@ -9,19 +9,24 @@
 
 [h4 Description]
 
-Barycentric rational interpolation is a high-precision interpolation routine for non-uniformly spaced samples.
+Barycentric rational interpolation is a high-precision interpolation class for non-uniformly spaced samples.
 It requires [bigo](N) time for construction, and [bigo](N) time for each evaluation.
 Linear time evaluation is not optimal; for instance the cubic b spline can be evaluated in constant time.
 However, using the cubic b spline requires uniformly spaced samples, which are not always available.
 
-Use of the routine requires a vector of independent variables x[0], x[1], .... x[n-1] where x[i+1] > x[i],
+Use of the class requires a vector of independent variables x[0], x[1], .... x[n-1] where x[i+1] > x[i],
 and a vector of dependent variables y[0], y[1], ... , y[n-1].
 The call is trivial:
 
-    __boost::math::tools::barycentric_rational<double>(x.data(), y.data(), y.size());
+    __boost::math::tools::barycentric_rational<double> interpolant(x.data(), y.data(), y.size());
 
 This implicitly calls the constructor with approximation order 3, and hence the accuracy is [bigo](h^4).
 In general, if you require an approximation order d, then the error is [bigo](h^d+1).
+A call to the constructor with an explicit approximation order could be
+
+    __boost::math::tools::barycentric_rational<double>(x.data(), y.data(), y.size(), 5);
+
+To evaluate the interpolant,
 
 Although this algorithm is robust, it can surprise you. The main way this occurs is if there is some i such that x[i] - x[i-1] is many orders of magnitude smaller than x[i+1] - x[i].
 This can cause a large "swing" where the interpolant makes a fast dive to hit y[i], but then flies very high since it is unconstrained until y[i+1], which is far away.

--- a/doc/math.qbk
+++ b/doc/math.qbk
@@ -640,6 +640,7 @@ and as a CD ISBN 0-9504833-2-X  978-0-9504833-2-0, Classification 519.2-dc22.
 [include internals/minimax.qbk]
 [include internals/relative_error.qbk] [/ uncertainty of floating-point calculations.]
 [include internals/test_data.qbk]
+[include internals/barycentric_rational_interpolation.qbk]
 [endsect] [/section:internals]
 
 [endmathpart] [/mathpart internals Internal Details: Series, Rationals and Continued Fractions, Testing, and Development Tools]

--- a/example/barycentric_interpolation_example.cpp
+++ b/example/barycentric_interpolation_example.cpp
@@ -1,0 +1,86 @@
+
+// Copyright Nick Thompson, 2017
+
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or
+// copy at http://www.boost.org/LICENSE_1_0.txt).
+
+#include <iostream>
+#include <limits>
+#include <vector>
+
+//[barycentric_rational_example
+
+/*`This example shows how to use barycentric rational interpolation, using Walter Kohn's classic paper
+  "Solution of the Schrodinger Equation in Periodic Lattices with an Application to Metallic Lithium"
+  In this paper, Kohn need to repeatedly solve an ODE (the radial Schrodinger equation) given a potential
+  which is only known at non-equally samples data.
+
+  If he'd only had the barycentric rational interpolant of boost::math!
+  First, include the header:
+*/
+
+#include <boost/math/tools/barycentric_rational_interpolation.hpp>
+//] [/barycentric_rational_example]
+
+int main()
+{
+    // The lithium potential is given in Kohn's paper, Table I:
+    std::vector<double> r(45);
+    std::vector<double> mrV(45);
+
+    r[0] = 0.02; mrV[0] = 5.727;
+    r[1] = 0.04, mrV[1] = 5.544;
+    r[2] = 0.06, mrV[2] = 5.450;
+    r[3] = 0.08, mrV[3] = 5.351;
+    r[4] = 0.10, mrV[4] = 5.253;
+    r[5] = 0.12, mrV[5] = 5.157;
+    r[6] = 0.14, mrV[6] = 5.058;
+    r[7] = 0.16, mrV[7] = 4.960;
+    r[8] = 0.18, mrV[8] = 4.862;
+    r[9] = 0.20, mrV[9] = 4.762;
+    r[10] = 0.24, mrV[10] = 4.563;
+    r[11] = 0.28, mrV[11] = 4.360;
+    r[12] = 0.32, mrV[12] = 4.1584;
+    r[13] = 0.36, mrV[13] = 3.9463;
+    r[14] = 0.40, mrV[14] = 3.7360;
+    r[15] = 0.44, mrV[15] = 3.5429;
+    r[16] = 0.48, mrV[16] = 3.3797;
+    r[17] = 0.52, mrV[17] = 3.2417;
+    r[18] = 0.56, mrV[18] = 3.1209;
+    r[19] = 0.60, mrV[19] = 3.0138;
+    r[20] = 0.68, mrV[20] = 2.8342;
+    r[21] = 0.76, mrV[21] = 2.6881;
+    r[22] = 0.84, mrV[22] = 2.5662;
+    r[23] = 0.92, mrV[23] = 2.4242;
+    r[24] = 1.00, mrV[24] = 2.3766;
+    r[25] = 1.08, mrV[25] = 2.3058;
+    r[26] = 1.16, mrV[26] = 2.2458;
+    r[27] = 1.24, mrV[27] = 2.2035;
+    r[28] = 1.32, mrV[28] = 2.1661;
+    r[29] = 1.40, mrV[29] = 2.1350;
+    r[30] = 1.48, mrV[30] = 2.1090;
+    r[31] = 1.64, mrV[31] = 2.0697;
+    r[32] = 1.80, mrV[32] = 2.0466;
+    r[33] = 1.96, mrV[33] = 2.0325;
+    r[34] = 2.12, mrV[34] = 2.0288;
+    r[35] = 2.28, mrV[35] = 2.0292;
+    r[36] = 2.44, mrV[36] = 2.0228;
+    r[37] = 2.60, mrV[37] = 2.0124;
+    r[38] = 2.76, mrV[38] = 2.0065;
+    r[39] = 2.92, mrV[39] = 2.0031;
+    r[40] = 3.08, mrV[40] = 2.0015;
+    r[41] = 3.24, mrV[41] = 2.0008;
+    r[42] = 3.40, mrV[42] = 2.0004;
+    r[43] = 3.56, mrV[43] = 2.0002;
+    r[44] = 3.72, mrV[44] = 2.0001;
+
+    // Now we want to interpolate this potential at any r:
+    boost::math::tools::barycentric_rational<double> b(r.data(), mrV.data(), r.size());
+
+    for (size_t i = 1; i < 8; ++i)
+    {
+        double r = i*0.5;
+        std::cout <<  "(r, V) = (" << r << ", " << -b(r)/r << ")\n";
+    }
+}

--- a/example/barycentric_interpolation_example.cpp
+++ b/example/barycentric_interpolation_example.cpp
@@ -13,14 +13,15 @@
 
 /*`This example shows how to use barycentric rational interpolation, using Walter Kohn's classic paper
   "Solution of the Schrodinger Equation in Periodic Lattices with an Application to Metallic Lithium"
-  In this paper, Kohn need to repeatedly solve an ODE (the radial Schrodinger equation) given a potential
+  In this paper, Kohn needs to repeatedly solve an ODE (the radial Schrodinger equation) given a potential
   which is only known at non-equally samples data.
 
   If he'd only had the barycentric rational interpolant of boost::math!
-  First, include the header:
+  References:
+  Kohn, W., and N. Rostoker. "Solution of the Schrödinger equation in periodic lattices with an application to metallic lithium." Physical Review 94.5 (1954): 1111.
 */
 
-#include <boost/math/tools/barycentric_rational_interpolation.hpp>
+#include <boost/math/interpolators/barycentric_rational.hpp>
 //] [/barycentric_rational_example]
 
 int main()
@@ -76,7 +77,7 @@ int main()
     r[44] = 3.72, mrV[44] = 2.0001;
 
     // Now we want to interpolate this potential at any r:
-    boost::math::tools::barycentric_rational<double> b(r.data(), mrV.data(), r.size());
+    boost::math::barycentric_rational<double> b(r.data(), mrV.data(), r.size());
 
     for (size_t i = 1; i < 8; ++i)
     {

--- a/include/boost/math/interpolators/barycentric_rational.hpp
+++ b/include/boost/math/interpolators/barycentric_rational.hpp
@@ -1,0 +1,60 @@
+/*
+ *  Copyright Nick Thompson, 2017
+ *  Use, modification and distribution are subject to the
+ *  Boost Software License, Version 1.0. (See accompanying file
+ *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ *
+ *  Given N samples (t_i, y_i) which are irregularly spaced, this routine constructs an
+ *  interpolant s which is constructed in O(N) time, occupies O(N) space, and can be evaluated in O(N) time.
+ *  The interpolation is stable, unless one point is incredibly close to another, and the next point is incredibly far.
+ *  The measure of this stability is the "local mesh ratio", which can be queried from the routine.
+ *  Pictorially, the following t_i spacing is bad (has a high local mesh ratio)
+ *  ||             |      | |                           |
+ *  and this t_i spacing is good (has a low local mesh ratio)
+ *  |   |      |    |     |    |        |    |  |    |
+ *
+ *
+ *  If f is C^{d+2}, then the interpolant is O(h^(d+1)) accurate, where d is the interpolation order.
+ *  A disadvantage of this interpolant is that it does not reproduce rational functions; for example, 1/(1+x^2) is not interpolated exactly.
+ *
+ *  References:
+ *  Floater, Michael S., and Kai Hormann. "Barycentric rational interpolation with no poles and high rates of approximation." Numerische Mathematik 107.2 (2007): 315-331.
+ *  Press, William H., et al. "Numerical recipes third edition: the art of scientific computing." Cambridge University Press 32 (2007): 10013-2473.
+ */
+
+#ifndef BOOST_MATH_INTERPOLATORS_BARYCENTRIC_RATIONAL_HPP
+#define BOOST_MATH_INTERPOLATORS_BARYCENTRIC_RATIONAL_HPP
+
+#include <memory>
+#include <boost/math/interpolators/detail/barycentric_rational_detail.hpp>
+
+namespace boost{ namespace math{
+
+template<class Real>
+class barycentric_rational
+{
+public:
+    barycentric_rational(const Real* const x, const Real* const y, size_t n, size_t approximation_order = 3);
+
+    Real operator()(Real x) const;
+
+private:
+    std::shared_ptr<detail::barycentric_rational_imp<Real>> m_imp;
+};
+
+template<class Real>
+barycentric_rational<Real>::barycentric_rational(const Real* const x, const Real* const y, size_t n, size_t approximation_order):
+ m_imp(std::make_shared<detail::barycentric_rational_imp<Real>>(x, y, n, approximation_order))
+{
+    return;
+}
+
+template<class Real>
+Real barycentric_rational<Real>::operator()(Real x) const
+{
+    return m_imp->operator()(x);
+}
+
+
+}}
+#endif

--- a/include/boost/math/interpolators/detail/barycentric_rational_detail.hpp
+++ b/include/boost/math/interpolators/detail/barycentric_rational_detail.hpp
@@ -3,46 +3,25 @@
  *  Use, modification and distribution are subject to the
  *  Boost Software License, Version 1.0. (See accompanying file
  *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
- *
- *  Given N samples (t_i, y_i) which are irregularly spaced, this routine constructs an
- *  interpolant s which is constructed in O(N) time, occupies O(N) space, and can be evaluated in O(N) time.
- *  The interpolation is stable, unless one point is incredibly close to another, and the next point is incredibly far.
- *  The measure of this stability is the "local mesh ratio", which can be queried from the routine.
- *  Pictorially, the following t_i spacing is bad (has a high local mesh ratio)
- *  ||             |      | |                           |
- *  and this t_i spacing is good (has a low local mesh ratio)
- *  |   |      |    |     |    |        |    |  |    |
- *
- *
- *  If f is C^{d+2}, then the interpolant is O(h^(d+1)) accurate, where d is the interpolation order.
- *  A disadvantage of this interpolant is that it does not reproduce rational functions; for example, 1/(1+x^2) is not interpolated exactly.
- *
- *  This routine follows "Barycentric Rational Approximation with no Poles and High Rate of Approximation"
- *  by Michael S. Floater, Kai Hormann
- *  http://www.mn.uio.no/math/english/people/aca/michaelf/papers/rational.pdf
- *  Official Citation:
- *  Floater, M.S. & Hormann, K. Numer. Math. (2007) 107: 315. doi:10.1007/s00211-007-0093-y
- *
- *  Floater's algorithm has been discussed in detail in Numerical Recipes, 3rd edition, section 3.4.1.
  */
 
-#ifndef BOOST_MATH_TOOLS_BARYCENTRIC_RATIONAL_INTERPOLATION_HPP
-#define BOOST_MATH_TOOLS_BARYCENTRIC_RATIONAL_INTERPOLATION_HPP
+#ifndef BOOST_MATH_INTERPOLATORS_BARYCENTRIC_RATIONAL_DETAIL_HPP
+#define BOOST_MATH_INTERPOLATORS_BARYCENTRIC_RATIONAL_DETAIL_HPP
 
 #include <vector>
 #include <boost/type_index.hpp>
 #include <boost/format.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 
-namespace boost{ namespace math{ namespace tools{
+namespace boost{ namespace math{ namespace detail{
 
 template<class Real>
-class barycentric_rational
+class barycentric_rational_imp
 {
 public:
-    barycentric_rational(const Real* const x, const Real* const y, size_t n, size_t approximation_order = 3);
+    barycentric_rational_imp(const Real* const x, const Real* const y, size_t n, size_t approximation_order = 3);
 
-    Real operator()(Real t) const;
+    Real operator()(Real x) const;
 
     // The barycentric weights are not really that interesting; except to the unit tests!
     Real weight(size_t i) const { return m_w[i]; }
@@ -59,7 +38,7 @@ private:
 };
 
 template<class Real>
-barycentric_rational<Real>::barycentric_rational(const Real* const x, const Real* const y, size_t n, size_t approximation_order)
+barycentric_rational_imp<Real>::barycentric_rational_imp(const Real* const x, const Real* const y, size_t n, size_t approximation_order)
 {
     using std::abs;
 
@@ -143,7 +122,7 @@ barycentric_rational<Real>::barycentric_rational(const Real* const x, const Real
 }
 
 template<class Real>
-Real barycentric_rational<Real>::operator()(Real x) const
+Real barycentric_rational_imp<Real>::operator()(Real x) const
 {
     Real numerator = 0;
     Real denominator = 0;
@@ -171,6 +150,5 @@ Real barycentric_rational<Real>::operator()(Real x) const
  * However, this requires a lot of machinery which is not built into the library at present.
  * So we wait until there is a requirement to interpolate the derivative.
  */
-
 }}}
 #endif

--- a/include/boost/math/tools/barycentric_rational_interpolation.hpp
+++ b/include/boost/math/tools/barycentric_rational_interpolation.hpp
@@ -42,7 +42,7 @@ class barycentric_rational
 public:
     barycentric_rational(const Real* const x, const Real* const y, size_t n, size_t approximation_order = 3);
 
-    Real interpolate_at(Real t) const;
+    Real operator()(Real t) const;
 
     // The barycentric weights are not really that interesting; except to the unit tests!
     Real weight(size_t i) const { return m_w[i]; }
@@ -86,13 +86,13 @@ barycentric_rational<Real>::barycentric_rational(const Real* const x, const Real
         // But if we're going to do a memcpy, we can do some error checking which is inexpensive relative to the copy:
         if(boost::math::isnan(x[i]))
         {
-            auto fmtr = boost::format("x[%1%] is a NAN") % i;
+            boost::format fmtr = boost::format("x[%1%] is a NAN") % i;
             throw std::domain_error(fmtr.str());
         }
 
         if(boost::math::isnan(y[i]))
         {
-            auto fmtr = boost::format("y[%1%] is a NAN") % i;
+            boost::format fmtr = boost::format("y[%1%] is a NAN") % i;
             throw std::domain_error(fmtr.str());
         }
 
@@ -124,7 +124,8 @@ barycentric_rational<Real>::barycentric_rational(const Real* const x, const Real
                 Real diff = m_x[k] - m_x[j];
                 if (abs(diff) < std::numeric_limits<Real>::epsilon())
                 {
-                    auto fmtr = boost::format("Spacing between  x[%1%] and x[%2%] is %3%, which is smaller than the epsilon of %4%") % k % i % diff % boost::typeindex::type_id<Real>().pretty_name();
+                    boost::format fmtr = boost::format("Spacing between  x[%1%] and x[%2%] is %3%, which is smaller than the epsilon of %4%") % k % i % diff % boost::typeindex::type_id<Real>().pretty_name();
+                    std::cout << typeid(fmtr).name() << std::endl;
                     throw std::logic_error(fmtr.str());
                 }
                 inv_product *= diff;
@@ -142,7 +143,7 @@ barycentric_rational<Real>::barycentric_rational(const Real* const x, const Real
 }
 
 template<class Real>
-Real barycentric_rational<Real>::interpolate_at(Real x) const
+Real barycentric_rational<Real>::operator()(Real x) const
 {
     Real numerator = 0;
     Real denominator = 0;

--- a/include/boost/math/tools/barycentric_rational_interpolation.hpp
+++ b/include/boost/math/tools/barycentric_rational_interpolation.hpp
@@ -104,7 +104,6 @@ barycentric_rational<Real>::barycentric_rational(const Real* const x, const Real
     for(int64_t k = 0; k < n; ++k)
     {
         int64_t i_min = std::max(k - (int64_t) approximation_order, (int64_t) 0);
-        //int64_t i_max = std::max(k, (int64_t) n - (int64_t) approximation_order - (int64_t) 1);
         int64_t i_max = k;
         if (k >= n - approximation_order)
         {

--- a/include/boost/math/tools/barycentric_rational_interpolation.hpp
+++ b/include/boost/math/tools/barycentric_rational_interpolation.hpp
@@ -1,0 +1,176 @@
+/*
+ *  Copyright Nick Thompson, 2017
+ *  Use, modification and distribution are subject to the
+ *  Boost Software License, Version 1.0. (See accompanying file
+ *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ *
+ *  Given N samples (t_i, y_i) which are irregularly spaced, this routine constructs an
+ *  interpolant s which is constructed in O(N) time, occupies O(N) space, and can be evaluated in O(N) time.
+ *  The interpolation is stable, unless one point is incredibly close to another, and the next point is incredibly far.
+ *  The measure of this stability is the "local mesh ratio", which can be queried from the routine.
+ *  Pictorially, the following t_i spacing is bad (has a high local mesh ratio)
+ *  ||             |      | |                           |
+ *  and this t_i spacing is good (has a low local mesh ratio)
+ *  |   |      |    |     |    |        |    |  |    |
+ *
+ *
+ *  If f is C^{d+2}, then the interpolant is O(h^(d+1)) accurate, where d is the interpolation order.
+ *  A disadvantage of this interpolant is that it does not reproduce rational functions; for example, 1/(1+x^2) is not interpolated exactly.
+ *
+ *  This routine follows "Barycentric Rational Approximation with no Poles and High Rate of Approximation"
+ *  by Michael S. Floater, Kai Hormann
+ *  http://www.mn.uio.no/math/english/people/aca/michaelf/papers/rational.pdf
+ *  Official Citation:
+ *  Floater, M.S. & Hormann, K. Numer. Math. (2007) 107: 315. doi:10.1007/s00211-007-0093-y
+ *
+ *  Floater's algorithm has been discussed in detail in Numerical Recipes, 3rd edition, section 3.4.1.
+ */
+
+#ifndef BOOST_MATH_TOOLS_BARYCENTRIC_RATIONAL_INTERPOLATION_HPP
+#define BOOST_MATH_TOOLS_BARYCENTRIC_RATIONAL_INTERPOLATION_HPP
+
+#include <vector>
+#include <boost/type_index.hpp>
+#include <boost/format.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+
+namespace boost{ namespace math{ namespace tools{
+
+template<class Real>
+class barycentric_rational
+{
+public:
+    barycentric_rational(const Real* const x, const Real* const y, size_t n, size_t approximation_order = 3);
+
+    Real interpolate_at(Real t) const;
+
+    // The barycentric weights are not really that interesting; except to the unit tests!
+    Real weight(size_t i) const { return m_w[i]; }
+
+private:
+    // Technically, we do not need to copy over y to m_y, or x to m_x.
+    // We could simply store a pointer. However, in doing so,
+    // we'd need to make sure the user managed the lifetime of m_y,
+    // and didn't alter its data. Since we are unlikely to run out of
+    // memory for a linearly scaling algorithm, it seems best just to make a copy.
+    std::vector<Real> m_y;
+    std::vector<Real> m_x;
+    std::vector<Real> m_w;
+};
+
+template<class Real>
+barycentric_rational<Real>::barycentric_rational(const Real* const x, const Real* const y, size_t n, size_t approximation_order)
+{
+    using std::abs;
+
+    if (approximation_order >= n)
+    {
+        throw std::domain_error("Approximation order must be < data length.");
+    }
+
+    if (x == nullptr)
+    {
+        throw std::domain_error("Independent variable passed to barycentric_rational is a nullptr");
+    }
+
+    if (y == nullptr)
+    {
+        throw std::domain_error("Dependent variable passed to barycentric_rational is a nullptr");
+    }
+
+    // Big sad memcpy to make sure the object is easy to use.
+    m_x.resize(n);
+    m_y.resize(n);
+    for(size_t i = 0; i < n; ++i)
+    {
+        // But if we're going to do a memcpy, we can do some error checking which is inexpensive relative to the copy:
+        if(boost::math::isnan(x[i]))
+        {
+            auto fmtr = boost::format("x[%1%] is a NAN") % i;
+            throw std::domain_error(fmtr.str());
+        }
+
+        if(boost::math::isnan(y[i]))
+        {
+            auto fmtr = boost::format("y[%1%] is a NAN") % i;
+            throw std::domain_error(fmtr.str());
+        }
+
+        m_x[i] = x[i];
+        m_y[i] = y[i];
+    }
+
+    m_w.resize(n, 0);
+    for(int64_t k = 0; k < n; ++k)
+    {
+        int64_t i_min = std::max(k - (int64_t) approximation_order, (int64_t) 0);
+        //int64_t i_max = std::max(k, (int64_t) n - (int64_t) approximation_order - (int64_t) 1);
+        int64_t i_max = k;
+        if (k >= n - approximation_order)
+        {
+            i_max = n - approximation_order - 1;
+        }
+
+        for(int64_t i = i_min; i <= i_max; ++i)
+        {
+            Real inv_product = 1;
+            int64_t j_max = std::min(i + approximation_order, n - 1);
+            for(int64_t j = i; j <= j_max; ++j)
+            {
+                if (j == k)
+                {
+                    continue;
+                }
+
+                Real diff = m_x[k] - m_x[j];
+                if (abs(diff) < std::numeric_limits<Real>::epsilon())
+                {
+                    auto fmtr = boost::format("Spacing between  x[%1%] and x[%2%] is %3%, which is smaller than the epsilon of %4%") % k % i % diff % boost::typeindex::type_id<Real>().pretty_name();
+                    throw std::logic_error(fmtr.str());
+                }
+                inv_product *= diff;
+            }
+            if (i % 2 == 0)
+            {
+                m_w[k] += 1/inv_product;
+            }
+            else
+            {
+                m_w[k] -= 1/inv_product;
+            }
+        }
+    }
+}
+
+template<class Real>
+Real barycentric_rational<Real>::interpolate_at(Real x) const
+{
+    Real numerator = 0;
+    Real denominator = 0;
+    for(size_t i = 0; i < m_x.size(); ++i)
+    {
+        // Presumably we should see if the accuracy is improved by using ULP distance of say, 5 here, instead of testing for floating point equality.
+        // However, it has been shown that if x approx x_i, but x != x_i, then inaccuracy in the numerator cancels the inaccuracy in the denominator,
+        // and the result is fairly accurate. See: http://epubs.siam.org/doi/pdf/10.1137/S0036144502417715
+        if (x == m_x[i])
+        {
+            return m_y[i];
+        }
+        Real t = m_w[i]/(x - m_x[i]);
+        numerator += t*m_y[i];
+        denominator += t;
+    }
+    return numerator/denominator;
+}
+
+/*
+ * A formula for computing the derivative of the barycentric representation is given in
+ * "Some New Aspects of Rational Interpolation", by Claus Schneider and Wilhelm Werner,
+ * Mathematics of Computation, v47, number 175, 1986.
+ * http://www.ams.org/journals/mcom/1986-47-175/S0025-5718-1986-0842136-8/S0025-5718-1986-0842136-8.pdf
+ * However, this requires a lot of machinery which is not built into the library at present.
+ * So we wait until there is a requirement to interpolate the derivative.
+ */
+
+}}}
+#endif

--- a/test/test_barycentric_rational.cpp
+++ b/test/test_barycentric_rational.cpp
@@ -5,7 +5,7 @@
 #include <boost/type_index.hpp>
 #include <boost/test/included/unit_test.hpp>
 #include <boost/test/floating_point_comparison.hpp>
-#include <boost/math/tools/barycentric_rational_interpolation.hpp>
+#include <boost/math/interpolators/barycentric_rational.hpp>
 #include <boost/multiprecision/cpp_bin_float.hpp>
 #ifdef __GNUC__
 #ifndef __clang__
@@ -32,7 +32,7 @@ void test_interpolation_condition()
         y[i] = dis(gen);
     }
 
-    boost::math::tools::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size());
+    boost::math::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size());
 
     for (size_t i = 0; i < x.size(); ++i)
     {
@@ -59,7 +59,7 @@ void test_interpolation_condition_high_order()
     }
 
     // Order 5 approximation:
-    boost::math::tools::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size(), 5);
+    boost::math::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size(), 5);
 
     for (size_t i = 0; i < x.size(); ++i)
     {
@@ -88,7 +88,7 @@ void test_constant()
         y[i] = y[0];
     }
 
-    boost::math::tools::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size());
+    boost::math::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size());
 
     for (size_t i = 0; i < x.size(); ++i)
     {
@@ -118,7 +118,7 @@ void test_constant_high_order()
     }
 
     // Set interpolation order to 7:
-    boost::math::tools::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size(), 7);
+    boost::math::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size(), 7);
 
     for (size_t i = 0; i < x.size(); ++i)
     {
@@ -146,7 +146,7 @@ void test_runge()
         y[i] = 1/(1+25*x[i]*x[i]);
     }
 
-    boost::math::tools::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size(), 5);
+    boost::math::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size(), 5);
 
     for (size_t i = 0; i < x.size(); ++i)
     {
@@ -174,7 +174,7 @@ void test_weights()
         y[i] = 1/(1+25*x[i]*x[i]);
     }
 
-    boost::math::tools::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size(), 0);
+    boost::math::detail::barycentric_rational_imp<Real> interpolator(x.data(), y.data(), y.size(), 0);
 
     for (size_t i = 0; i < x.size(); ++i)
     {
@@ -190,7 +190,7 @@ void test_weights()
     }
 
     // d = 1:
-    interpolator = boost::math::tools::barycentric_rational<Real>(x.data(), y.data(), y.size(), 1);
+    interpolator = boost::math::detail::barycentric_rational_imp<Real>(x.data(), y.data(), y.size(), 1);
 
     for (size_t i = 1; i < x.size() -1; ++i)
     {

--- a/test/test_barycentric_rational.cpp
+++ b/test/test_barycentric_rational.cpp
@@ -1,0 +1,250 @@
+#define BOOST_TEST_MODULE barycentric_rational
+
+#include <random>
+#include <boost/random/uniform_real_distribution.hpp>
+#include <boost/type_index.hpp>
+#include <boost/test/included/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+#include <boost/math/tools/barycentric_rational_interpolation.hpp>
+#include <boost/multiprecision/cpp_bin_float.hpp>
+#ifdef __GNUC__
+#ifndef __clang__
+#include <boost/multiprecision/float128.hpp>
+#endif
+#endif
+
+using boost::multiprecision::cpp_bin_float_50;
+
+template<class Real>
+void test_interpolation_condition()
+{
+    std::cout << "Testing interpolation condition for barycentric interpolation on type " << boost::typeindex::type_id<Real>().pretty_name()  << "\n";
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    boost::random::uniform_real_distribution<Real> dis(0.1, 1);
+    std::vector<Real> x(500);
+    std::vector<Real> y(500);
+    x[0] = dis(gen);
+    y[0] = dis(gen);
+    for (size_t i = 1; i < x.size(); ++i)
+    {
+        x[i] = x[i-1] + dis(gen);
+        y[i] = dis(gen);
+    }
+
+    boost::math::tools::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size());
+
+    for (size_t i = 0; i < x.size(); ++i)
+    {
+        auto z = interpolator.interpolate_at(x[i]);
+        BOOST_CHECK_CLOSE(z, y[i], 100*std::numeric_limits<Real>::epsilon());
+    }
+}
+
+template<class Real>
+void test_interpolation_condition_high_order()
+{
+    std::cout << "Testing interpolation condition in high order for barycentric interpolation on type " << boost::typeindex::type_id<Real>().pretty_name()  << "\n";
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    boost::random::uniform_real_distribution<Real> dis(0.1, 1);
+    std::vector<Real> x(500);
+    std::vector<Real> y(500);
+    x[0] = dis(gen);
+    y[0] = dis(gen);
+    for (size_t i = 1; i < x.size(); ++i)
+    {
+        x[i] = x[i-1] + dis(gen);
+        y[i] = dis(gen);
+    }
+
+    // Order 5 approximation:
+    boost::math::tools::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size(), 5);
+
+    for (size_t i = 0; i < x.size(); ++i)
+    {
+        auto z = interpolator.interpolate_at(x[i]);
+        BOOST_CHECK_CLOSE(z, y[i], 100*std::numeric_limits<Real>::epsilon());
+    }
+}
+
+
+template<class Real>
+void test_constant()
+{
+    std::cout << "Testing that constants are interpolated correctly using barycentric interpolation on type " << boost::typeindex::type_id<Real>().pretty_name() << "\n";
+
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    boost::random::uniform_real_distribution<Real> dis(0.1, 1);
+    std::vector<Real> x(500);
+    std::vector<Real> y(500);
+    Real constant = dis(gen);
+    x[0] = dis(gen);
+    y[0] = constant;
+    for (size_t i = 1; i < x.size(); ++i)
+    {
+        x[i] = x[i-1] + dis(gen);
+        y[i] = y[0];
+    }
+
+    boost::math::tools::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size());
+
+    for (size_t i = 0; i < x.size(); ++i)
+    {
+        // Don't evaluate the constant at x[i]; that's already tested in the interpolation condition test.
+        auto z = interpolator.interpolate_at(x[i] + dis(gen));
+        BOOST_CHECK_CLOSE(z, constant, 10000*std::numeric_limits<Real>::epsilon());
+    }
+}
+
+template<class Real>
+void test_constant_high_order()
+{
+    std::cout << "Testing that constants are interpolated correctly in high order using barycentric interpolation on type " << boost::typeindex::type_id<Real>().pretty_name() << "\n";
+
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    boost::random::uniform_real_distribution<Real> dis(0.1, 1);
+    std::vector<Real> x(500);
+    std::vector<Real> y(500);
+    Real constant = dis(gen);
+    x[0] = dis(gen);
+    y[0] = constant;
+    for (size_t i = 1; i < x.size(); ++i)
+    {
+        x[i] = x[i-1] + dis(gen);
+        y[i] = y[0];
+    }
+
+    // Set interpolation order to 7:
+    boost::math::tools::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size(), 7);
+
+    for (size_t i = 0; i < x.size(); ++i)
+    {
+        auto z = interpolator.interpolate_at(x[i] + dis(gen));
+        BOOST_CHECK_CLOSE(z, constant, 10000*std::numeric_limits<Real>::epsilon());
+    }
+}
+
+
+template<class Real>
+void test_runge()
+{
+    std::cout << "Testing interpolation of Runge's 1/(1+25x^2) function using barycentric interpolation on type " << boost::typeindex::type_id<Real>().pretty_name() << "\n";
+
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    boost::random::uniform_real_distribution<Real> dis(0.005, 0.01);
+    std::vector<Real> x(500);
+    std::vector<Real> y(500);
+    x[0] = -2;
+    y[0] = 1/(1+25*x[0]*x[0]);
+    for (size_t i = 1; i < x.size(); ++i)
+    {
+        x[i] = x[i-1] + dis(gen);
+        y[i] = 1/(1+25*x[i]*x[i]);
+    }
+
+    boost::math::tools::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size(), 5);
+
+    for (size_t i = 0; i < x.size(); ++i)
+    {
+        auto t = x[i] + dis(gen);
+        auto z = interpolator.interpolate_at(t);
+        BOOST_CHECK_CLOSE(z, 1/(1+25*t*t), 0.001);
+    }
+}
+
+template<class Real>
+void test_weights()
+{
+    std::cout << "Testing weights are calculated correctly using barycentric interpolation on type " << boost::typeindex::type_id<Real>().pretty_name() << "\n";
+
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    boost::random::uniform_real_distribution<Real> dis(0.005, 0.01);
+    std::vector<Real> x(500);
+    std::vector<Real> y(500);
+    x[0] = -2;
+    y[0] = 1/(1+25*x[0]*x[0]);
+    for (size_t i = 1; i < x.size(); ++i)
+    {
+        x[i] = x[i-1] + dis(gen);
+        y[i] = 1/(1+25*x[i]*x[i]);
+    }
+
+    boost::math::tools::barycentric_rational<Real> interpolator(x.data(), y.data(), y.size(), 0);
+
+    for (size_t i = 0; i < x.size(); ++i)
+    {
+        auto w = interpolator.weight(i);
+        if (i % 2 == 0)
+        {
+            BOOST_CHECK_CLOSE(w, 1, 0.00001);
+        }
+        else
+        {
+            BOOST_CHECK_CLOSE(w, -1, 0.00001);
+        }
+    }
+
+    // d = 1:
+    interpolator = boost::math::tools::barycentric_rational<Real>(x.data(), y.data(), y.size(), 1);
+
+    for (size_t i = 1; i < x.size() -1; ++i)
+    {
+        auto w = interpolator.weight(i);
+        auto w_expect = 1/(x[i] - x[i - 1]) + 1/(x[i+1] - x[i]);
+        if (i % 2 == 0)
+        {
+            BOOST_CHECK_CLOSE(w, -w_expect, 0.00001);
+        }
+        else
+        {
+            BOOST_CHECK_CLOSE(w, w_expect, 0.00001);
+        }
+    }
+
+}
+
+
+BOOST_AUTO_TEST_CASE(barycentric_rational)
+{
+    test_weights<double>();
+    test_constant<float>();
+    test_constant<double>();
+    test_constant<long double>();
+    test_constant<cpp_bin_float_50>();
+
+    test_constant_high_order<float>();
+    test_constant_high_order<double>();
+    test_constant_high_order<long double>();
+    test_constant_high_order<cpp_bin_float_50>();
+
+    test_interpolation_condition<float>();
+    test_interpolation_condition<double>();
+    test_interpolation_condition<long double>();
+    test_interpolation_condition<cpp_bin_float_50>();
+
+    test_interpolation_condition_high_order<float>();
+    test_interpolation_condition_high_order<double>();
+    test_interpolation_condition_high_order<long double>();
+    test_interpolation_condition_high_order<cpp_bin_float_50>();
+
+    test_runge<float>();
+    test_runge<double>();
+    test_runge<long double>();
+    test_runge<cpp_bin_float_50>();
+
+    #ifdef __GNUC__
+        #ifndef __clang__
+        test_interpolation_condition<boost::multiprecision::float128>();
+        test_constant<boost::multiprecision::float128>();
+        test_constant_high_order<boost::multiprecision::float128>();
+        test_interpolation_condition_high_order<boost::multiprecision::float128>();
+        test_runge<boost::multiprecision::float128>();
+        #endif
+    #endif
+
+}

--- a/test/test_barycentric_rational.cpp
+++ b/test/test_barycentric_rational.cpp
@@ -36,7 +36,7 @@ void test_interpolation_condition()
 
     for (size_t i = 0; i < x.size(); ++i)
     {
-        auto z = interpolator.interpolate_at(x[i]);
+        auto z = interpolator(x[i]);
         BOOST_CHECK_CLOSE(z, y[i], 100*std::numeric_limits<Real>::epsilon());
     }
 }
@@ -63,7 +63,7 @@ void test_interpolation_condition_high_order()
 
     for (size_t i = 0; i < x.size(); ++i)
     {
-        auto z = interpolator.interpolate_at(x[i]);
+        auto z = interpolator(x[i]);
         BOOST_CHECK_CLOSE(z, y[i], 100*std::numeric_limits<Real>::epsilon());
     }
 }
@@ -79,7 +79,7 @@ void test_constant()
     boost::random::uniform_real_distribution<Real> dis(0.1, 1);
     std::vector<Real> x(500);
     std::vector<Real> y(500);
-    Real constant = dis(gen);
+    Real constant = -8;
     x[0] = dis(gen);
     y[0] = constant;
     for (size_t i = 1; i < x.size(); ++i)
@@ -93,8 +93,8 @@ void test_constant()
     for (size_t i = 0; i < x.size(); ++i)
     {
         // Don't evaluate the constant at x[i]; that's already tested in the interpolation condition test.
-        auto z = interpolator.interpolate_at(x[i] + dis(gen));
-        BOOST_CHECK_CLOSE(z, constant, 10000*std::numeric_limits<Real>::epsilon());
+        auto z = interpolator(x[i] + dis(gen));
+        BOOST_CHECK_CLOSE(z, constant, 100*sqrt(std::numeric_limits<Real>::epsilon()));
     }
 }
 
@@ -108,7 +108,7 @@ void test_constant_high_order()
     boost::random::uniform_real_distribution<Real> dis(0.1, 1);
     std::vector<Real> x(500);
     std::vector<Real> y(500);
-    Real constant = dis(gen);
+    Real constant = 5;
     x[0] = dis(gen);
     y[0] = constant;
     for (size_t i = 1; i < x.size(); ++i)
@@ -122,8 +122,8 @@ void test_constant_high_order()
 
     for (size_t i = 0; i < x.size(); ++i)
     {
-        auto z = interpolator.interpolate_at(x[i] + dis(gen));
-        BOOST_CHECK_CLOSE(z, constant, 10000*std::numeric_limits<Real>::epsilon());
+        auto z = interpolator(x[i] + dis(gen));
+        BOOST_CHECK_CLOSE(z, constant, 1000*sqrt(std::numeric_limits<Real>::epsilon()));
     }
 }
 
@@ -151,8 +151,8 @@ void test_runge()
     for (size_t i = 0; i < x.size(); ++i)
     {
         auto t = x[i] + dis(gen);
-        auto z = interpolator.interpolate_at(t);
-        BOOST_CHECK_CLOSE(z, 1/(1+25*t*t), 0.001);
+        auto z = interpolator(t);
+        BOOST_CHECK_CLOSE(z, 1/(1+25*t*t), 0.01);
     }
 }
 


### PR DESCRIPTION
This commit can be regarded as a "friend" to the cubic b spline, filling out the feature set.
Whereas the cubic b spline interpolates uniformly spaced data, the barycentric rational interpolant can interpolate arbitrarily spaced data.
The price that is paid is that evaluation of the interpolant is O(N), rather than O(1) for the cubic b spline interpolant.

The routine supports essentially arbitrary approximation order d; with error of O(h^d+1).
It is cppcheck-clean, run under AddressSanitizer and UndefinedBehaviorSanitizer, and works with boost::multiprecision.

References:

1) Floater, M.S. & Hormann, K. Numer. Math. (2007) 107: 315. doi:10.1007/s00211-007-0093-y

2) Numerical Recipes, Section 3.4.1