### PR TITLE
Legendre stieltjes

### DIFF
--- a/doc/sf/legendre.qbk
+++ b/doc/sf/legendre.qbk
@@ -7,36 +7,42 @@
 ``
 
    namespace boost{ namespace math{
-   
+
    template <class T>
    ``__sf_result`` legendre_p(int n, T x);
-   
+
    template <class T, class ``__Policy``>
    ``__sf_result`` legendre_p(int n, T x, const ``__Policy``&);
-   
+
+   template <class T>
+   ``__sf_result`` legendre_p_prime(int n, T x);
+
+   template <class T, class ``__Policy``>
+   ``__sf_result`` legendre_p_prime(int n, T x, const ``__Policy``&);
+
    template <class T>
    ``__sf_result`` legendre_p(int n, int m, T x);
-   
+
    template <class T, class ``__Policy``>
    ``__sf_result`` legendre_p(int n, int m, T x, const ``__Policy``&);
-   
+
    template <class T>
    ``__sf_result`` legendre_q(unsigned n, T x);
-   
+
    template <class T, class ``__Policy``>
    ``__sf_result`` legendre_q(unsigned n, T x, const ``__Policy``&);
-   
+
    template <class T1, class T2, class T3>
    ``__sf_result`` legendre_next(unsigned l, T1 x, T2 Pl, T3 Plm1);
-   
+
    template <class T1, class T2, class T3>
    ``__sf_result`` legendre_next(unsigned l, unsigned m, T1 x, T2 Pl, T3 Plm1);
 
-   
+
    }} // namespaces
-   
+
 The return type of these functions is computed using the __arg_promotion_rules:
-note than when there is a single template argument the result is the same type 
+note than when there is a single template argument the result is the same type
 as that argument or `double` if the template argument is an integer type.
 
 [optional_policy]
@@ -45,10 +51,10 @@ as that argument or `double` if the template argument is an integer type.
 
    template <class T>
    ``__sf_result`` legendre_p(int l, T x);
-   
+
    template <class T, class ``__Policy``>
    ``__sf_result`` legendre_p(int l, T x, const ``__Policy``&);
-   
+
 Returns the Legendre Polynomial of the first kind:
 
 [equation legendre_0]
@@ -59,17 +65,25 @@ Negative orders are handled via the reflection formula:
 
 P[sub -l-1](x) = P[sub l](x)
 
-The following graph illustrates the behaviour of the first few 
+The following graph illustrates the behaviour of the first few
 Legendre Polynomials:
 
 [graph legendre_p]
-   
+
+    template <class T>
+    ``__sf_result`` legendre_p_prime(int n, T x);
+
+    template <class T, class ``__Policy``>
+    ``__sf_result`` legendre_p_prime(int n, T x, const ``__Policy``&);
+
+Returns the derivatives of the Legendre polynomials.
+
    template <class T>
    ``__sf_result`` legendre_p(int l, int m, T x);
-   
+
    template <class T, class ``__Policy``>
    ``__sf_result`` legendre_p(int l, int m, T x, const ``__Policy``&);
-   
+
 Returns the associated Legendre polynomial of the first kind:
 
 [equation legendre_1]
@@ -84,31 +98,31 @@ Negative values of /l/ and /m/ are handled via the identity relations:
 includes a leading Condon-Shortley phase term of (-1)[super m].  This
 matches the definition given by Abramowitz and Stegun (8.6.6) and that
 used by [@http://mathworld.wolfram.com/LegendrePolynomial.html Mathworld]
-and [@http://documents.wolfram.com/mathematica/functions/LegendreP 
+and [@http://documents.wolfram.com/mathematica/functions/LegendreP
 Mathematica's LegendreP function].  However, uses in the literature
 do not always include this phase term, and strangely the specification
-for the associated Legendre function in the C++ TR1 (assoc_legendre) 
-also omits it, in spite of stating that it uses Abramowitz and Stegun 
+for the associated Legendre function in the C++ TR1 (assoc_legendre)
+also omits it, in spite of stating that it uses Abramowitz and Stegun
 as the final arbiter on these matters.
 
-See: 
+See:
 
-[@http://mathworld.wolfram.com/LegendrePolynomial.html 
-Weisstein, Eric W. "Legendre Polynomial." 
+[@http://mathworld.wolfram.com/LegendrePolynomial.html
+Weisstein, Eric W. "Legendre Polynomial."
 From MathWorld--A Wolfram Web Resource].
 
-Abramowitz, M. and Stegun, I. A. (Eds.). "Legendre Functions" and 
-"Orthogonal Polynomials." Ch. 22 in Chs. 8 and 22 in Handbook of 
-Mathematical Functions with Formulas, Graphs, and Mathematical Tables, 
-9th printing. New York: Dover, pp. 331-339 and 771-802, 1972. 
+Abramowitz, M. and Stegun, I. A. (Eds.). "Legendre Functions" and
+"Orthogonal Polynomials." Ch. 22 in Chs. 8 and 22 in Handbook of
+Mathematical Functions with Formulas, Graphs, and Mathematical Tables,
+9th printing. New York: Dover, pp. 331-339 and 771-802, 1972.
  ]
-   
+
    template <class T>
    ``__sf_result`` legendre_q(unsigned n, T x);
-   
+
    template <class T, class ``__Policy``>
    ``__sf_result`` legendre_q(unsigned n, T x, const ``__Policy``&);
-   
+
 Returns the value of the Legendre polynomial that is the second solution
 to the Legendre differential equation, for example:
 
@@ -120,10 +134,10 @@ The following graph illustrates the first few Legendre functions of the
 second kind:
 
 [graph legendre_q]
-   
+
    template <class T1, class T2, class T3>
    ``__sf_result`` legendre_next(unsigned l, T1 x, T2 Pl, T3 Plm1);
-   
+
 Implements the three term recurrence relation for the Legendre
 polynomials, this function can be used to create a sequence of
 values evaluated at the same /x/, and for rising /l/.  This recurrence
@@ -143,7 +157,7 @@ values using:
    // Double check values:
    for(unsigned l = 1; l < 10; ++l)
       assert(v[l] == legendre_p(l, x));
-      
+
 Formally the arguments are:
 
 [variablelist
@@ -152,7 +166,7 @@ Formally the arguments are:
 [[Pl][The value of the polynomial evaluated at degree /l/.]]
 [[Plm1][The value of the polynomial evaluated at degree /l-1/.]]
 ]
-   
+
    template <class T1, class T2, class T3>
    ``__sf_result`` legendre_next(unsigned l, unsigned m, T1 x, T2 Pl, T3 Plm1);
 
@@ -175,7 +189,7 @@ values using:
    // Double check values:
    for(unsigned l = 1; l < 10; ++l)
       assert(v[l] == legendre_p(10 + l, m, x));
-      
+
 Formally the arguments are:
 
 [variablelist
@@ -185,12 +199,12 @@ Formally the arguments are:
 [[Pl][The value of the polynomial evaluated at degree /l/.]]
 [[Plm1][The value of the polynomial evaluated at degree /l-1/.]]
 ]
-   
+
 [h4 Accuracy]
 
-The following table shows peak errors (in units of epsilon) 
-for various domains of input arguments.  
-Note that only results for the widest floating point type on the system are 
+The following table shows peak errors (in units of epsilon)
+for various domains of input arguments.
+Note that only results for the widest floating point type on the system are
 given as narrower types have __zero_error.
 
 [table_legendre_p]
@@ -206,7 +220,7 @@ are likely to grow arbitrarily large when the function is very close to a root.
 
 [h4 Testing]
 
-A mixture of spot tests of values calculated using functions.wolfram.com, 
+A mixture of spot tests of values calculated using functions.wolfram.com,
 and randomly generated test data are
 used: the test data was computed using
 [@http://shoup.net/ntl/doc/RR.txt NTL::RR] at 1000-bit precision.
@@ -219,10 +233,9 @@ but cannot guarantee low relative error near one of the roots of the
 polynomials.
 
 [endsect][/section:beta_function The Beta Function]
-[/ 
+[/
   Copyright 2006 John Maddock and Paul A. Bristow.
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE_1_0.txt or copy at
   http://www.boost.org/LICENSE_1_0.txt).
 ]
-

--- a/doc/sf/legendre.qbk
+++ b/doc/sf/legendre.qbk
@@ -21,10 +21,10 @@
    ``__sf_result`` legendre_p_prime(int n, T x, const ``__Policy``&);
 
    template <class T, class ``__Policy``>
-   T legendre_p_zeros(int l, int k, const ``__Policy``&);
+   std::vector<T> legendre_p_zeros(int l, const ``__Policy``&);
 
    template <class T>
-   T legendre_p_zeros(int l, int k);
+   std::vector<T> legendre_p_zeros(int l);
 
    template <class T>
    ``__sf_result`` legendre_p(int n, int m, T x);
@@ -85,23 +85,21 @@ Legendre Polynomials:
 Returns the derivatives of the Legendre polynomials.
 
     template <class T, class ``__Policy``>
-    T legendre_p_zeros(int l, int k, const ``__Policy``&);
+    std::vector<T> legendre_p_zeros(int l, const ``__Policy``&);
 
     template <class T>
-    T legendre_p_zeros(int l, int k);
+    std::vector<T> legendre_p_zeros(int l);
 
 The zeros of the Legendre polynomials are calculated by Newton's method using an initial guess given by Tricomi with root bracketing provided by Szego.
-Although the use of Newton's method is believed to be less robust than (say) the Golub & Welsch algorithm,
-all zeros are computed to 1 ULP up to `l = 100`, and 2 ULP up to `l = 350` in double precision.
 
 Since the Legendre polynomials are alternatively even and odd, only the non-negative zeros are returned.
-For the odd Legendre polynomials, the identity `legendre_p_zeros<double>(2*l+1, 0) == 0` holds.
-The rest of the zeros are returned in increasing order, so that `legendre_p_zeros<double>(l, k) < legendre_p_zeros<double>(l, k+1)`.
-For each `l`, `k` may take the values 0 to `ceil(l*0.5)`, as the other zeros are symmetric about zero.
+For the odd Legendre polynomials, the first zero is always zero.
+The rest of the zeros are returned in increasing order.
 
-Note that the arguments to the routine are integers, and the output is a real-type. Hence the template argument is mandatory.
+Note that the argument to the routine is an integer, and the output is a floating-point type.
+Hence the template argument is mandatory.
 The time to extract a single root is linear in `l` (this is scaling to evaluate the Legendre polynomials), so recovering all roots is [bigo](`l`[super 2]).
-Algorithms with better linear scaling [@ http://dx.doi.org/10.1137/06067016X exist] for recovering all roots, but they are complicated.
+Algorithms with linear scaling [@ http://dx.doi.org/10.1137/06067016X exist] for recovering all roots, but requires tooling not currently built into boost.math.
 This implementation proceeds under the assumption that calculating zeros of these functions will not be a bottleneck for any workflow.
 
    template <class T>

--- a/doc/sf/legendre.qbk
+++ b/doc/sf/legendre.qbk
@@ -20,6 +20,12 @@
    template <class T, class ``__Policy``>
    ``__sf_result`` legendre_p_prime(int n, T x, const ``__Policy``&);
 
+   template <class T, class ``__Policy``>
+   T legendre_p_zeros(int l, int k, const ``__Policy``&);
+
+   template <class T>
+   T legendre_p_zeros(int l, int k);
+
    template <class T>
    ``__sf_result`` legendre_p(int n, int m, T x);
 
@@ -77,6 +83,26 @@ Legendre Polynomials:
     ``__sf_result`` legendre_p_prime(int n, T x, const ``__Policy``&);
 
 Returns the derivatives of the Legendre polynomials.
+
+    template <class T, class ``__Policy``>
+    T legendre_p_zeros(int l, int k, const ``__Policy``&);
+
+    template <class T>
+    T legendre_p_zeros(int l, int k);
+
+The zeros of the Legendre polynomials are calculated by Newton's method using an initial guess given by Tricomi with root bracketing provided by Szego.
+Although the use of Newton's method is believed to be less robust than (say) the Golub & Welsch algorithm,
+all zeros are computed to 1 ULP up to `l = 100`, and 2 ULP up to `l = 350` in double precision.
+
+Since the Legendre polynomials are alternatively even and odd, only the non-negative zeros are returned.
+For the odd Legendre polynomials, the identity `legendre_p_zeros<double>(2*l+1, 0) == 0` holds.
+The rest of the zeros are returned in increasing order, so that `legendre_p_zeros<double>(l, k) < legendre_p_zeros<double>(l, k+1)`.
+For each `l`, `k` may take the values 0 to `ceil(l*0.5)`, as the other zeros are symmetric about zero.
+
+Note that the arguments to the routine are integers, and the output is a real-type. Hence the template argument is mandatory.
+The time to extract a single root is linear in `l` (this is scaling to evaluate the Legendre polynomials), so recovering all roots is [bigo](`l`[super 2]).
+Algorithms with better linear scaling [@ http://dx.doi.org/10.1137/06067016X exist] for recovering all roots, but they are complicated.
+This implementation proceeds under the assumption that calculating zeros of these functions will not be a bottleneck for any workflow.
 
    template <class T>
    ``__sf_result`` legendre_p(int l, int m, T x);

--- a/doc/sf/legendre_stieltjes.qbk
+++ b/doc/sf/legendre_stieltjes.qbk
@@ -3,7 +3,7 @@
 [h4 Synopsis]
 
     ``
-    #include <boost/math/special_functions/legendre_p_stieltjes.hpp>
+    #include <boost/math/special_functions/legendre_stieltjes.hpp>
     ``
 
     namespace boost{ namespace math{
@@ -63,3 +63,9 @@ Example usage:
     double norm = std::sqrt(E.norm_sq());
 
 [endsect]
+[/
+  Copyright 2017 Nick Thompson
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt).
+]

--- a/doc/sf/legendre_stieltjes.qbk
+++ b/doc/sf/legendre_stieltjes.qbk
@@ -1,0 +1,65 @@
+[section:legendre_stieltjes Legendre-Stieltjes Polynomials]
+
+[h4 Synopsis]
+
+    ``
+    #include <boost/math/special_functions/legendre_p_stieltjes.hpp>
+    ``
+
+    namespace boost{ namespace math{
+
+    template <class T>
+    class legendre_stieltjes
+    {
+    public:
+        legendre_stieltjes(size_t m);
+
+        Real norm_sq() const;
+
+        Real operator()(Real x) const;
+
+        Real prime(Real x) const;
+
+        std::vector<Real> zeros() const;
+    }
+
+    }}
+
+[h4 Description]
+
+The Legendre-Stieltjes polynomials are a family of polynomials used to generate Gauss-Konrod quadrature formulas.
+Gauss-Konrod quadratures are algorithms which extend a Gaussian quadrature in such a way that all abscissas
+are reused when computed a higher-order estimate of the integral, allowing efficient calculation of an error estimate.
+The Legendre-Stieltjes polynomials assist with this task because their zeros /interlace/ the zeros of the Legendre polynomials,
+meaning that between any two zeros of a Legendre polynomial of degree n, there exists a zero of the Legendre-Stieltjes polynomial
+of degree n+1.
+
+The Legendre-Stieltjes polynomials /E/[sub n+1] are defined by the property that they have /n/ vanishing moments against the oscillatory measure P[sub n], i.e., \u222B[sub -1][super 1] E[sub n+1](x)P[sub n](x) x[super k] dx = 0 for /k = 0, 1, ..., n/.
+The first few are
+
+* E[sub 1](x) = P[sub 1](x)
+* E[sub 2](x) = P[sub 2](x) - 2P[sub 0](x)/5
+* E[sub 3](x) = P[sub 3](x) - 9P[sub 1](x)/14
+* E[sub 4](x) = P[sub 4](x) - 20P[sub 2](x)/27 + 14P[sub 0](x)/891
+* E[sub 5](x) = P[sub 5](x) - 35P[sub 3](x)/44 + 135P[sub 1](x)/12584
+
+where P[sub i] are the Legendre polynomials.
+The scaling follows [@http://www.ams.org/journals/mcom/1968-22-104/S0025-5718-68-99866-9/S0025-5718-68-99866-9.pdf Patterson],
+who expanded the Legendre-Stieltjes polynomials in a Legendre series and took the coefficient of the highest-order Legendre polynomial in the series to be unity.
+
+The Legendre-Stieltjes polynomials do not satisfy three-term recurrence relations or have a particulary simple representation.
+Hence the constructor call determines what, in fact, the polynomial is.
+Once the constructor comes back, the polynomial can be evaluated via the Legendre series.
+
+Example usage:
+
+    // Call to the constructor determines the coefficients in the Legendre expansion
+    legendre_stieltjes<double> E(12);
+    // Evaluate the polynomial at a point:
+    double x = E(0.3);
+    // Evaluate the derivative at a point:
+    double x_p = E.prime(0.3);
+    // Use the norm_sq to change between scalings, if desired:
+    double norm = std::sqrt(E.norm_sq());
+
+[endsect]

--- a/example/legendre_stieltjes_example.cpp
+++ b/example/legendre_stieltjes_example.cpp
@@ -1,0 +1,94 @@
+#include <iostream>
+#include <string>
+#include <boost/math/constants/constants.hpp>
+#include <boost/multiprecision/cpp_bin_float.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+#include <boost/math/special_functions/legendre.hpp>
+#include <boost/math/special_functions/legendre_stieltjes.hpp>
+
+using boost::math::legendre_p;
+using boost::math::legendre_p_zeros;
+using boost::math::legendre_p_prime;
+using boost::math::legendre_stieltjes;
+using boost::multiprecision::cpp_bin_float_quad;
+using boost::multiprecision::cpp_dec_float_100;
+
+template<class Real>
+void gauss_konrod_rule(size_t order)
+{
+    std::cout << std::setprecision(std::numeric_limits<Real>::digits10);
+    std::cout << std::fixed;
+    auto gauss_nodes = boost::math::legendre_p_zeros<Real>(order);
+    auto E = legendre_stieltjes<Real>(order + 1);
+    std::vector<Real> gauss_weights(gauss_nodes.size(), std::numeric_limits<Real>::quiet_NaN());
+    std::vector<Real> gauss_konrod_weights(gauss_nodes.size(), std::numeric_limits<Real>::quiet_NaN());
+    for (size_t i = 0; i < gauss_nodes.size(); ++i)
+    {
+        Real node = gauss_nodes[i];
+        Real lp = legendre_p_prime<Real>(order, node);
+        gauss_weights[i] = 2/( (1-node*node)*lp*lp);
+        // P_n(x) = (2n)!/(2^n (n!)^2) pi_n(x), where pi_n is the monic Legendre polynomial.
+        gauss_konrod_weights[i] = gauss_weights[i] + static_cast<Real>(2)/(static_cast<Real>(order+1)*legendre_p_prime(order, node)*E(node));
+    }
+
+    std::cout << "Gauss Nodes:\n";
+    for (auto const & node : gauss_nodes)
+    {
+        std::cout << node << "\n";
+    }
+
+    std::cout << "Gauss Weights:\n";
+    for (auto const & weight : gauss_weights)
+    {
+        std::cout << weight << "\n";
+    }
+
+    std::cout << "Gauss-Konrod weights: \n";
+    for (auto const & w : gauss_konrod_weights)
+    {
+        std::cout << w << "\n";
+    }
+
+    auto konrod_nodes = E.zeros();
+    std::vector<Real> konrod_weights(konrod_nodes.size());
+    for (size_t i = 0; i < konrod_weights.size(); ++i)
+    {
+        Real node = konrod_nodes[i];
+        konrod_weights[i] = static_cast<Real>(2)/(static_cast<Real>(order+1)*legendre_p(order, node)*E.prime(node));
+    }
+
+    std::cout << "Konrod nodes:\n";
+    for (auto node : konrod_nodes)
+    {
+        std::cout << node << "\n";
+    }
+
+    std::cout << "Konrod weights: \n";
+    for (auto const & w : gauss_konrod_weights)
+    {
+        std::cout << w << "\n";
+    }
+
+}
+
+int main()
+{
+    std::cout << "Gauss-Konrod 7-15 Rule:\n";
+    gauss_konrod_rule<cpp_dec_float_100>(7);
+
+    std::cout << "\n\nGauss-Konrod 10-21 Rule:\n";
+    gauss_konrod_rule<cpp_dec_float_100>(10);
+
+    std::cout << "\n\nGauss-Konrod 15-31 Rule:\n";
+    gauss_konrod_rule<cpp_dec_float_100>(15);
+
+    std::cout << "\n\nGauss-Konrod 20-41 Rule:\n";
+    gauss_konrod_rule<cpp_dec_float_100>(20);
+
+    std::cout << "\n\nGauss-Konrod 25-51 Rule:\n";
+    gauss_konrod_rule<cpp_dec_float_100>(25);
+
+    std::cout << "\n\nGauss-Konrod 30-61 Rule:\n";
+    gauss_konrod_rule<cpp_dec_float_100>(30);
+
+}

--- a/example/legendre_stieltjes_example.cpp
+++ b/example/legendre_stieltjes_example.cpp
@@ -1,3 +1,9 @@
+// Copyright Nick Thompson 2017.
+// Use, modification and distribution are subject to the
+// Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <iostream>
 #include <string>
 #include <boost/math/constants/constants.hpp>

--- a/include/boost/math/special_functions/legendre.hpp
+++ b/include/boost/math/special_functions/legendre.hpp
@@ -12,6 +12,7 @@
 #endif
 
 #include <utility>
+#include <vector>
 #include <boost/math/special_functions/math_fwd.hpp>
 #include <boost/math/special_functions/factorials.hpp>
 #include <boost/math/tools/roots.hpp>
@@ -121,81 +122,68 @@ T legendre_p_prime_imp(unsigned l, T x, const Policy& pol, T* Pn = nullptr)
 }
 
 template <class T, class Policy>
-T legendre_p_zeros_imp(int n_in, int k_in, const Policy& pol)
+std::vector<T> legendre_p_zeros_imp(int n, const Policy& pol)
 {
     using std::cos;
     using std::sin;
-    using std::floor;
     using std::ceil;
     using std::sqrt;
     using boost::math::constants::pi;
     using boost::math::constants::half;
     using boost::math::tools::newton_raphson_iterate;
 
-    static const char* function = "boost::math::legrendre_p_zeros<%1%>(int, int)";
-    if (n_in == 0)
+    BOOST_ASSERT(n >= 0);
+    std::vector<T> zeros;
+    if (n == 0)
     {
-       return policies::raise_domain_error<T>(
-          function,
-          "The %1%-th Legendre polynomial has no zeros.\n",  n_in, pol);
+        // There are no zeros of P_0(x) = 1.
+        return zeros;
     }
-    // If n is odd, and k is zero, then the root is zero.
-    // Taking this branch as a special case is reasonable, because
-    // the root bracketing gives us an interval [0, 0] with floating point rounding
-    // error on both positive and negative. This can lead to weird behavior, such as
-    // upper_bound < lower_bound.
-    if ( (n_in & 1) && k_in == 0)
+    int k;
+    if (n & 1)
     {
-        return (T) 0;
+        zeros.resize((n-1)/2 + 1, std::numeric_limits<T>::quiet_NaN());
+        zeros[0] = 0;
+        k = 1;
     }
-
-    if (n_in == 2 && k_in == 0)
+    else
     {
-        return (T) 1/sqrt(3);
+        zeros.resize(n/2, std::numeric_limits<T>::quiet_NaN());
+        k = 0;
     }
-
-    T n = n_in;
-    T k = k_in;
     T half_n = ceil(n*half<T>());
-    if (k > half_n - 1)
+
+    while (k < zeros.size())
     {
-        return policies::raise_domain_error<T>(function,
-         "k must be in range {0, 1, ..., ceil(n/2) - 1},"
-         " requested root %1% of a Legendre polynomial.\n",
-         k, pol);
+        // Bracket the root: Szego:
+        // Gabriel Szego, Inequalities for the Zeros of Legendre Polynomials and Related Functions, Transactions of the American Mathematical Society, Vol. 39, No. 1 (1936)
+        T theta_nk =  ((half_n - half<T>()*half<T>() - static_cast<T>(k))*pi<T>())/(static_cast<T>(n)+half<T>());
+        T lower_bound = cos( (half_n - static_cast<T>(k))*pi<T>()/static_cast<T>(n + 1));
+        T cos_nk = cos(theta_nk);
+        T upper_bound = cos_nk;
+        // First guess follows from:
+        //  F. G. Tricomi, Sugli zeri dei polinomi sferici ed ultrasferici, Ann. Mat. Pura Appl., 31 (1950), pp. 93–97;
+        T inv_n_sq = 1/static_cast<T>(n*n);
+        T sin_nk = sin(theta_nk);
+        T x_nk_guess = (1 - inv_n_sq/static_cast<T>(8) + inv_n_sq /static_cast<T>(8*n) - (inv_n_sq*inv_n_sq/384)*(39  - 28 / (sin_nk*sin_nk) ) )*cos_nk;
+
+        boost::uintmax_t number_of_iterations = policies::get_max_root_iterations<Policy>();
+
+        auto f = [&] (T x) { T Pn;
+                             T Pn_prime = detail::legendre_p_prime_imp(n, x, pol, &Pn);
+                             return std::pair<T, T>(Pn, Pn_prime); };
+
+        const T x_nk = newton_raphson_iterate(f, x_nk_guess,
+                                              lower_bound, upper_bound,
+                                              policies::digits<T, Policy>(),
+                                              number_of_iterations);
+
+        BOOST_ASSERT(lower_bound < x_nk);
+        BOOST_ASSERT(upper_bound > x_nk);
+        zeros[k] = x_nk;
+        ++k;
     }
-
-    // Bracket the root: Szego:
-    // Gabriel Szego, Inequalities for the Zeros of Legendre Polynomials and Related Functions, Transactions of the American Mathematical Society, Vol. 39, No. 1 (1936)
-    T theta_nk =  ((half_n - half<T>()*half<T>() - k)*pi<T>())/(n+half<T>());
-    T lower_bound = cos( (half_n - k)*pi<T>()/(n + 1));
-    T cos_nk = cos(theta_nk);
-    T upper_bound = cos_nk;
-    // First guess follows from:
-    //  F. G. Tricomi, Sugli zeri dei polinomi sferici ed ultrasferici, Ann. Mat. Pura Appl., 31 (1950), pp. 93–97;
-    T inv_n_sq = (T) 1/(n*n);
-    T sin_nk = sin(theta_nk);
-    T x_nk_guess = (1 - inv_n_sq/8 + inv_n_sq /(8*n) - (inv_n_sq*inv_n_sq/384)*(39  - 28 / (sin_nk*sin_nk) ) )*cos_nk;
-
-    boost::uintmax_t number_of_iterations = policies::get_max_root_iterations<Policy>();
-
-    auto f = [&] (T x) { T Pn;
-                         T Pn_prime = detail::legendre_p_prime_imp(n_in, x, pol, &Pn);
-                         return std::pair<T, T>(Pn, Pn_prime); };
-
-    const T x_nk = newton_raphson_iterate(f, x_nk_guess,
-                                          lower_bound, upper_bound,
-                                          policies::digits<T, Policy>(),
-                                          number_of_iterations);
-
-    if(number_of_iterations >= policies::get_max_root_iterations<Policy>())
-    {
-       return policies::raise_evaluation_error<T>(function, "Unable to locate root in a reasonable time:"
-          "  Current best guess is %1%", x_nk, Policy());
-    }
-    BOOST_ASSERT(lower_bound < x_nk);
-    BOOST_ASSERT(upper_bound > x_nk);
-    return x_nk;
+    return zeros;
 }
 
 } // namespace detail
@@ -240,19 +228,19 @@ inline typename tools::promote_args<T>::type
 }
 
 template <class T, class Policy>
-inline T legendre_p_zeros(int l, int k, const Policy& pol)
+inline std::vector<T> legendre_p_zeros(int l, const Policy& pol)
 {
     if(l < 0)
-        return detail::legendre_p_zeros_imp<T>(-l-1, k, pol);
+        return detail::legendre_p_zeros_imp<T>(-l-1, pol);
 
-    return detail::legendre_p_zeros_imp<T>(l, k, pol);
+    return detail::legendre_p_zeros_imp<T>(l, pol);
 }
 
 
 template <class T>
-inline T legendre_p_zeros(int l, int k)
+inline std::vector<T> legendre_p_zeros(int l)
 {
-   return boost::math::legendre_p_zeros<T>(l, k, policies::policy<>());
+   return boost::math::legendre_p_zeros<T>(l, policies::policy<>());
 }
 
 template <class T, class Policy>

--- a/include/boost/math/special_functions/legendre_stieltjes.hpp
+++ b/include/boost/math/special_functions/legendre_stieltjes.hpp
@@ -1,0 +1,229 @@
+#ifndef BOOST_MATH_SPECIAL_LEGENDRE_STIELTJES_HPP
+#define BOOST_MATH_SPECIAL_LEGENDRE_STIELTJES_HPP
+
+/*
+ * Constructs the Legendre-Stieltjes polynomial of degree m.
+ * The Legendre-Stieltjes polynomials are used to create extensions for Gaussian quadratures,
+ * commonly called "Gauss-Konrod" quadratures.
+ *
+ * References:
+ * Patterson, TNL. "The optimum addition of points to quadrature formulae." Mathematics of Computation 22.104 (1968): 847-856.
+ */
+
+#include <iostream>
+#include <vector>
+#include <boost/math/tools/roots.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
+
+namespace boost{
+namespace math{
+
+template<class Real>
+class legendre_stieltjes
+{
+public:
+    legendre_stieltjes(size_t m)
+    {
+        if (m == 0)
+        {
+           throw std::domain_error("The Legendre-Stieltjes polynomial is defined for order m > 0.\n");
+        }
+        m_m = m;
+        int64_t n = m - 1;
+        int64_t q;
+        int64_t r;
+        bool odd = n & 1;
+        if (odd)
+        {
+           q = 1;
+           r = (n-1)/2 + 2;
+        }
+        else
+        {
+           q = 0;
+           r = n/2 + 1;
+        }
+        m_a.resize(r + 1);
+        // We'll keep the ones-based indexing at the cost of storing a superfluous element
+        // so that we can follow Patterson's notation exactly.
+        m_a[r] = static_cast<Real>(1);
+        // Make sure using the zero index is a bug:
+        m_a[0] = std::numeric_limits<Real>::quiet_NaN();
+
+        for (int64_t k = 1; k < r; ++k)
+        {
+            Real ratio = 1;
+            m_a[r - k] = 0;
+            for (int64_t i = r + 1 - k; i <= r; ++i)
+            {
+                // See Patterson, equation 12
+                int64_t num = (n - q + 2*(i + k - 1))*(n + q + 2*(k - i + 1))*(n-1-q+2*(i-k))*(2*(k+i-1) -1 -q -n);
+                int64_t den = (n - q + 2*(i - k))*(2*(k + i - 1) - q - n)*(n + 1 + q + 2*(k - i))*(n - 1 - q + 2*(i + k));
+                ratio *= static_cast<Real>(num)/static_cast<Real>(den);
+                m_a[r - k] -= ratio*m_a[i];
+            }
+        }
+    }
+
+
+    Real norm_sq() const
+    {
+        Real t = 0;
+        bool odd = m_m & 1;
+        for (size_t i = 1; i < m_a.size(); ++i)
+        {
+            if(odd)
+            {
+                t += 2*m_a[i]*m_a[i]/static_cast<Real>(4*i-1);
+            }
+            else
+            {
+                t += 2*m_a[i]*m_a[i]/static_cast<Real>(4*i-3);
+            }
+        }
+        return t;
+    }
+
+
+    Real operator()(Real x) const
+    {
+        // Trivial implementation:
+        // Em += m_a[i]*legendre_p(2*i - 1, x);  m odd
+        // Em += m_a[i]*legendre_p(2*i - 2, x);  m even
+        size_t r = m_a.size() - 1;
+        Real p0 = 1;
+        Real p1 = x;
+
+        Real Em;
+        bool odd = m_m & 1;
+        if (odd)
+        {
+            Em = m_a[1]*p1;
+        }
+        else
+        {
+            Em = m_a[1]*p0;
+        }
+
+        unsigned n = 1;
+        for (size_t i = 2; i <= r; ++i)
+        {
+            std::swap(p0, p1);
+            p1 = boost::math::legendre_next(n, x, p0, p1);
+            ++n;
+            if (!odd)
+            {
+               Em += m_a[i]*p1;
+            }
+            std::swap(p0, p1);
+            p1 = boost::math::legendre_next(n, x, p0, p1);
+            ++n;
+            if(odd)
+            {
+                Em += m_a[i]*p1;
+            }
+        }
+        return Em;
+    }
+
+
+    Real prime(Real x) const
+    {
+        Real Em_prime = 0;
+
+        for (size_t i = 1; i < m_a.size(); ++i)
+        {
+            if(m_m & 1)
+            {
+                Em_prime += m_a[i]*detail::legendre_p_prime_imp(2*i - 1, x, policies::policy<>());
+            }
+            else
+            {
+                Em_prime += m_a[i]*detail::legendre_p_prime_imp(2*i - 2, x, policies::policy<>());
+            }
+        }
+        return Em_prime;
+    }
+
+    std::vector<Real> zeros() const
+    {
+        using boost::math::constants::half;
+
+        std::vector<Real> stieltjes_zeros;
+        std::vector<Real> legendre_zeros = legendre_p_zeros<Real>(m_m - 1);
+        int k;
+        if (m_m & 1)
+        {
+            stieltjes_zeros.resize(legendre_zeros.size() + 1, std::numeric_limits<Real>::quiet_NaN());
+            stieltjes_zeros[0] = 0;
+            k = 1;
+        }
+        else
+        {
+            stieltjes_zeros.resize(legendre_zeros.size(), std::numeric_limits<Real>::quiet_NaN());
+            k = 0;
+        }
+
+        while (k < stieltjes_zeros.size())
+        {
+            Real lower_bound;
+            Real upper_bound;
+            if (m_m & 1)
+            {
+                lower_bound = legendre_zeros[k - 1];
+                if (k == legendre_zeros.size())
+                {
+                    upper_bound = 1;
+                }
+                else
+                {
+                    upper_bound = legendre_zeros[k];
+                }
+            }
+            else
+            {
+                lower_bound = legendre_zeros[k];
+                if (k == legendre_zeros.size() - 1)
+                {
+                    upper_bound = 1;
+                }
+                else
+                {
+                    upper_bound = legendre_zeros[k+1];
+                }
+            }
+
+            // The root bracketing is not very tight; to keep weird stuff from happening
+            // in the Newton's method, let's tighten up the tolerance using a few bisections.
+            boost::math::tools::eps_tolerance<Real> tol(6);
+            auto g = [&](Real t) { return this->operator()(t); };
+            auto p = boost::math::tools::bisect(g, lower_bound, upper_bound, tol);
+
+            Real x_nk_guess = p.first + (p.second - p.first)*half<Real>();
+            boost::uintmax_t number_of_iterations = 500;
+
+            auto f = [&] (Real x) { Real Pn = this->operator()(x);
+                                    Real Pn_prime = this->prime(x);
+                                    return std::pair<Real, Real>(Pn, Pn_prime); };
+
+            const Real x_nk = boost::math::tools::newton_raphson_iterate(f, x_nk_guess,
+                                                  p.first, p.second,
+                                                  2*std::numeric_limits<Real>::digits10,
+                                                  number_of_iterations);
+
+            BOOST_ASSERT(p.first < x_nk);
+            BOOST_ASSERT(x_nk < p.second);
+            stieltjes_zeros[k] = x_nk;
+            ++k;
+        }
+        return stieltjes_zeros;
+    }
+
+private:
+    // Coefficients of Legendre expansion
+    std::vector<Real> m_a;
+    int m_m;
+};
+
+}}
+#endif

--- a/include/boost/math/special_functions/legendre_stieltjes.hpp
+++ b/include/boost/math/special_functions/legendre_stieltjes.hpp
@@ -1,3 +1,9 @@
+// Copyright Nick Thompson 2017.
+// Use, modification and distribution are subject to the
+// Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #ifndef BOOST_MATH_SPECIAL_LEGENDRE_STIELTJES_HPP
 #define BOOST_MATH_SPECIAL_LEGENDRE_STIELTJES_HPP
 

--- a/include/boost/math/special_functions/math_fwd.hpp
+++ b/include/boost/math/special_functions/math_fwd.hpp
@@ -185,6 +185,13 @@ namespace boost
    typename tools::promote_args<T>::type
           legendre_p_prime(int l, T x);
 
+
+   template <class T, class Policy>
+   inline T legendre_p_zeros(int l, int k, const Policy& pol);
+
+   template <class T>
+   inline T legendre_p_zeros(int l, int k);
+
 #if !BOOST_WORKAROUND(BOOST_MSVC, <= 1310)
    template <class T, class Policy>
    typename boost::enable_if_c<policies::is_policy<Policy>::value, typename tools::promote_args<T>::type>::type

--- a/include/boost/math/special_functions/math_fwd.hpp
+++ b/include/boost/math/special_functions/math_fwd.hpp
@@ -23,6 +23,7 @@
 #pragma once
 #endif
 
+#include <vector>
 #include <boost/math/special_functions/detail/round_fwd.hpp>
 #include <boost/math/tools/promotion.hpp> // for argument promotion.
 #include <boost/math/policies/policy.hpp>
@@ -187,10 +188,10 @@ namespace boost
 
 
    template <class T, class Policy>
-   inline T legendre_p_zeros(int l, int k, const Policy& pol);
+   inline std::vector<T> legendre_p_zeros(int l, const Policy& pol);
 
    template <class T>
-   inline T legendre_p_zeros(int l, int k);
+   inline std::vector<T> legendre_p_zeros(int l);
 
 #if !BOOST_WORKAROUND(BOOST_MSVC, <= 1310)
    template <class T, class Policy>

--- a/include/boost/math/special_functions/math_fwd.hpp
+++ b/include/boost/math/special_functions/math_fwd.hpp
@@ -181,6 +181,10 @@ namespace boost
    template <class T>
    typename tools::promote_args<T>::type
          legendre_p(int l, T x);
+   template <class T>
+   typename tools::promote_args<T>::type
+          legendre_p_prime(int l, T x);
+
 #if !BOOST_WORKAROUND(BOOST_MSVC, <= 1310)
    template <class T, class Policy>
    typename boost::enable_if_c<policies::is_policy<Policy>::value, typename tools::promote_args<T>::type>::type
@@ -1593,5 +1597,3 @@ template <class OutputIterator, class T>\
 
 
 #endif // BOOST_MATH_SPECIAL_MATH_FWD_HPP
-
-

--- a/test/legendre_stieltjes_test.cpp
+++ b/test/legendre_stieltjes_test.cpp
@@ -1,0 +1,135 @@
+#define BOOST_TEST_MODULE LegendreStieltjesTest
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <boost/math/special_functions/legendre.hpp>
+#include <boost/math/special_functions/legendre_stieltjes.hpp>
+#include <boost/math/constants/constants.hpp>
+#include <boost/multiprecision/cpp_bin_float.hpp>
+
+
+using boost::math::legendre_stieltjes;
+using boost::math::legendre_p;
+using boost::multiprecision::cpp_bin_float_quad;
+
+
+template<class Real>
+void test_legendre_stieltjes()
+{
+    std::cout << std::setprecision(std::numeric_limits<Real>::digits10);
+    using std::sqrt;
+    using std::abs;
+    using boost::math::constants::third;
+    using boost::math::constants::half;
+
+    Real tol = std::numeric_limits<Real>::epsilon();
+    legendre_stieltjes<Real> ls1(1);
+    legendre_stieltjes<Real> ls2(2);
+    legendre_stieltjes<Real> ls3(3);
+    legendre_stieltjes<Real> ls4(4);
+    legendre_stieltjes<Real> ls5(5);
+    legendre_stieltjes<Real> ls8(8);
+    Real x = -1;
+    while(x <= 1)
+    {
+        BOOST_CHECK_CLOSE_FRACTION(ls1(x), x, tol);
+        BOOST_CHECK_CLOSE_FRACTION(ls1.prime(x), 1, tol);
+
+        Real p2 = legendre_p(2, x);
+        BOOST_CHECK_CLOSE_FRACTION(ls2(x), p2 - 2/static_cast<Real>(5), tol);
+        BOOST_CHECK_CLOSE_FRACTION(ls2.prime(x), 3*x, tol);
+
+        Real p3 = legendre_p(3, x);
+        BOOST_CHECK_CLOSE_FRACTION(ls3(x), p3 - 9*x/static_cast<Real>(14), 100*tol);
+        BOOST_CHECK_CLOSE_FRACTION(ls3.prime(x), 15*x*x*half<Real>() -3*half<Real>()-9/static_cast<Real>(14), 100*tol);
+
+        Real p4 = legendre_p(4, x);
+        //-20P_2(x)/27 + 14P_0(x)/891
+        Real E4 = p4 - 20*p2/static_cast<Real>(27) + 14/static_cast<Real>(891);
+        BOOST_CHECK_CLOSE_FRACTION(ls4(x), E4, 250*tol);
+        BOOST_CHECK_CLOSE_FRACTION(ls4.prime(x), 35*x*(9*x*x -5)/static_cast<Real>(18), 250*tol);
+
+        Real p5 = legendre_p(5, x);
+        Real E5 = p5 - 35*p3/static_cast<Real>(44) + 135*x/static_cast<Real>(12584);
+        BOOST_CHECK_CLOSE_FRACTION(ls5(x), E5, 29000*tol);
+        Real E5prime = (315*(123 + 143*x*x*(11*x*x-9)))/static_cast<Real>(12584);
+        BOOST_CHECK_CLOSE_FRACTION(ls5.prime(x), E5prime, 29000*tol);
+        x += 1/static_cast<Real>(1 << 9);
+    }
+
+    // Test norm:
+    // E_1 = x
+    Real expected_norm_sq = 2*third<Real>();
+    BOOST_CHECK_CLOSE_FRACTION(expected_norm_sq, ls1.norm_sq(), tol);
+
+    // E_2 = P[sub 2](x) - 2P[sup 0](x)/5
+    expected_norm_sq = 2/static_cast<Real>(5) + 8/static_cast<Real>(25);
+    BOOST_CHECK_CLOSE_FRACTION(expected_norm_sq, ls2.norm_sq(), tol);
+
+    // E_3 = P[sub 3](x) - 9P[sub 1]/14
+    expected_norm_sq = 2/static_cast<Real>(7) + 9*9*2*third<Real>()/static_cast<Real>(14*14);
+    BOOST_CHECK_CLOSE_FRACTION(expected_norm_sq, ls3.norm_sq(), tol);
+
+    // E_4 = P[sub 4](x) -20P[sub 2](x)/27 + 14P[sub 0](x)/891
+    expected_norm_sq = static_cast<Real>(2)/static_cast<Real>(9) + static_cast<Real>(20*20*2)/static_cast<Real>(27*27*5) + 14*14*2/static_cast<Real>(891*891);
+    BOOST_CHECK_CLOSE_FRACTION(expected_norm_sq, ls4.norm_sq(), tol);
+
+    // E_5 = P[sub 5](x) - 35P[sub 3](x)/44 + 135P[sub 1](x)/12584
+    expected_norm_sq = 2/static_cast<Real>(11) + (35*35/static_cast<Real>(44*44))*(2/static_cast<Real>(7)) + (135*135/static_cast<Real>(12584*12584))*2*third<Real>();
+    BOOST_CHECK_CLOSE_FRACTION(expected_norm_sq, ls5.norm_sq(), tol);
+
+    // Only zero of E1 is 0:
+    std::vector<Real> zeros = ls1.zeros();
+    BOOST_CHECK(zeros.size() == 1);
+    BOOST_CHECK_SMALL(zeros[0], tol);
+    BOOST_CHECK_SMALL(ls1(zeros[0]), tol);
+
+    zeros = ls2.zeros();
+    BOOST_CHECK(zeros.size() == 1);
+    BOOST_CHECK_CLOSE_FRACTION(zeros[0], sqrt(3/static_cast<Real>(5)), tol);
+    BOOST_CHECK_SMALL(ls2(zeros[0]), tol);
+
+    zeros = ls3.zeros();
+    BOOST_CHECK(zeros.size() == 2);
+    BOOST_CHECK_SMALL(zeros[0], tol);
+    BOOST_CHECK_CLOSE_FRACTION(zeros[1], sqrt(6/static_cast<Real>(7)), tol);
+
+
+    zeros = ls4.zeros();
+    BOOST_CHECK(zeros.size() == 2);
+    Real expected = sqrt( (55 - 2*sqrt(static_cast<Real>(330)))/static_cast<Real>(11) )/static_cast<Real>(3);
+    BOOST_CHECK_CLOSE_FRACTION(zeros[0], expected, tol);
+
+    expected = sqrt( (55 + 2*sqrt(static_cast<Real>(330)))/static_cast<Real>(11) )/static_cast<Real>(3);
+    BOOST_CHECK_CLOSE_FRACTION(zeros[1], expected, 10*tol);
+
+
+    zeros = ls5.zeros();
+    BOOST_CHECK(zeros.size() == 3);
+    BOOST_CHECK_SMALL(zeros[0], tol);
+
+    expected = sqrt( ( 195 - sqrt(static_cast<Real>(6045)) )/static_cast<Real>(286));
+    BOOST_CHECK_CLOSE_FRACTION(zeros[1], expected, tol);
+
+    expected = sqrt( ( 195 + sqrt(static_cast<Real>(6045)) )/static_cast<Real>(286));
+    BOOST_CHECK_CLOSE_FRACTION(zeros[2], expected, tol);
+
+
+    for (size_t i = 6; i < 50; ++i)
+    {
+        legendre_stieltjes<Real> En(i);
+        zeros = En.zeros();
+        for(auto const & zero : zeros)
+        {
+            BOOST_CHECK_SMALL(En(zero), 50*tol);
+        }
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(LegendreStieltjesZeros)
+{
+    test_legendre_stieltjes<double>();
+    test_legendre_stieltjes<long double>();
+    test_legendre_stieltjes<cpp_bin_float_quad>();
+    //test_legendre_stieltjes<boost::multiprecision::cpp_bin_float_100>();
+}

--- a/test/legendre_stieltjes_test.cpp
+++ b/test/legendre_stieltjes_test.cpp
@@ -1,3 +1,9 @@
+// Copyright Nick Thompson 2017.
+// Use, modification and distribution are subject to the
+// Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #define BOOST_TEST_MODULE LegendreStieltjesTest
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>

--- a/test/test_legendre.cpp
+++ b/test/test_legendre.cpp
@@ -223,11 +223,8 @@ BOOST_AUTO_TEST_CASE( test_main )
    test_legendre_p_prime<double>();
    test_legendre_p_prime<long double>();
 
-   int distance = test_legendre_p_zeros_double_ulp(1, 107);
-   BOOST_CHECK(distance <= 1);
-   // This test is very expensive; the total runtime grows cubically with n.
-   //distance = test_legendre_p_zeros_double_ulp(108, 350);
-   //BOOST_CHECK(distance <= 2);
+   int ulp_distance = test_legendre_p_zeros_double_ulp(1, 100);
+   BOOST_CHECK(ulp_distance <= 2);
    test_legendre_p_zeros<float>();
    test_legendre_p_zeros<double>();
    test_legendre_p_zeros<long double>();

--- a/test/test_legendre.cpp
+++ b/test/test_legendre.cpp
@@ -222,4 +222,13 @@ BOOST_AUTO_TEST_CASE( test_main )
    test_legendre_p_prime<float>();
    test_legendre_p_prime<double>();
    test_legendre_p_prime<long double>();
+
+   int distance = test_legendre_p_zeros_double_ulp(1, 107);
+   BOOST_CHECK(distance <= 1);
+   // This test is very expensive; the total runtime grows cubically with n.
+   //distance = test_legendre_p_zeros_double_ulp(108, 350);
+   //BOOST_CHECK(distance <= 2);
+   test_legendre_p_zeros<float>();
+   test_legendre_p_zeros<double>();
+   test_legendre_p_zeros<long double>();
 }

--- a/test/test_legendre.cpp
+++ b/test/test_legendre.cpp
@@ -192,6 +192,7 @@ void expected_results()
       << BOOST_STDLIB << ", " << BOOST_PLATFORM << std::endl;
 }
 
+
 BOOST_AUTO_TEST_CASE( test_main )
 {
    BOOST_MATH_CONTROL_FP;
@@ -217,8 +218,8 @@ BOOST_AUTO_TEST_CASE( test_main )
       "not available at all, or because they are too inaccurate for these tests "
       "to pass.</note>" << std::endl;
 #endif
-   
+
+   test_legendre_p_prime<float>();
+   test_legendre_p_prime<double>();
+   test_legendre_p_prime<long double>();
 }
-
-
-

--- a/test/test_legendre.hpp
+++ b/test/test_legendre.hpp
@@ -13,6 +13,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/floating_point_comparison.hpp>
 #include <boost/math/special_functions/math_fwd.hpp>
+#include <boost/math/special_functions/legendre.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/array.hpp>
 #include "functor.hpp"
@@ -182,3 +183,78 @@ void test_spots(T, const char* t)
    BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_q(40, static_cast<T>(0.5L)), static_cast<T>(0.1493671665503550095010454949479907886011L), tolerance);
 }
 
+template <class T>
+void test_legendre_p_prime()
+{
+    T tolerance = 100*boost::math::tools::epsilon<T>();
+    T x = -1;
+    while (x <= 1)
+    {
+        // P_0'(x) = 0
+        BOOST_CHECK_SMALL(::boost::math::legendre_p_prime<T>(0,  x), tolerance);
+        // Reflection formula for P_{-1}(x) = P_{0}(x):
+        BOOST_CHECK_SMALL(::boost::math::legendre_p_prime<T>(-1,  x), tolerance);
+
+        // P_1(x) = x, so P_1'(x) = 1:
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(1,  x), static_cast<T>(1), tolerance);
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(-2,  x), static_cast<T>(1), tolerance);
+
+        // P_2(x) = 3x^2/2 + k => P_2'(x) = 3x
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(2,  x), 3*x, tolerance);
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(-3,  x), 3*x, tolerance);
+
+        // P_3(x) = (5x^3 - 3x)/2 => P_3'(x) = (15x^2 - 3)/2:
+        T xsq = x*x;
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(3,  x), (15*xsq - 3)/2, tolerance);
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(-4,  x), (15*xsq -3)/2, tolerance);
+
+        // P_4(x) = (35x^4 - 30x^2 +3)/8 => P_4'(x) = (5x/2)*(7x^2 - 3)
+        T expected = 5*x*(7*xsq - 3)/2;
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(4,  x), expected, tolerance);
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(-5,  x), expected, tolerance);
+
+        // P_5(x) = (63x^5 - 70x^3 + 15x)/8 => P_5'(x) = (315*x^4 - 210*x^2 + 15)/8
+        T x4 = xsq*xsq;
+        expected = (315*x4 - 210*xsq + 15)/8;
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(5,  x), expected, tolerance);
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(-6,  x), expected, tolerance);
+
+        // P_6(x) = (231x^6 -315*x^4 +105x^2 -5)/16 => P_6'(x) = (6*231*x^5 - 4*315*x^3 + 105x)/16
+        expected = 21*x*(33*x4 - 30*xsq + 5)/8;
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(6,  x), expected, tolerance);
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(-7,  x), expected, tolerance);
+
+        // Mathematica: D[LegendreP[7, x],x]
+        T x6 = x4*xsq;
+        expected = 7*(429*x6 -495*x4 + 135*xsq - 5)/16;
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(7,  x), expected, tolerance);
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(-8,  x), expected, tolerance);
+
+        // Mathematica: D[LegendreP[8, x],x]
+        // The naive polynomial evaluation algorithm is going to get worse from here out, so this will be enough.
+        expected = 9*x*(715*x6 - 1001*x4 + 385*xsq - 35)/16;
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(8,  x), expected, tolerance);
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(-9,  x), expected, tolerance);
+
+        x += static_cast<T>(1)/static_cast<T>(pow(2, 4));
+    }
+
+    int n = 0;
+    while (n < 5000)
+    {
+        T expected = n*(n+1)*boost::math::constants::half<T>();
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(n, (T) 1), expected, tolerance);
+        BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(-n - 1,  (T) 1), expected, tolerance);
+        if (n & 1)
+        {
+            BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(n, (T) -1), expected, tolerance);
+            BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(-n - 1,  (T) -1), expected, tolerance);
+        }
+        else
+        {
+            BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(n, (T) -1), -expected, tolerance);
+            BOOST_CHECK_CLOSE_FRACTION(::boost::math::legendre_p_prime<T>(-n - 1,  (T) -1), -expected, tolerance);
+        }
+        ++n;
+    }
+}


### PR DESCRIPTION
Legendre-Stieltjes polynomials are orthogonal with respect to the oscillatory measure defined by the Legendre polynomials. This property allows generation of Konrod extensions to Gaussian quadrature rules, which in turn allows for error estimates with abscissa reuse.