### PR TITLE
Remove forward references to gcd/lcm types:

### DIFF
--- a/include/boost/math_fwd.hpp
+++ b/include/boost/math_fwd.hpp
@@ -44,52 +44,6 @@ template < >
 template < >
     class octonion< long double >;
 
-// Also has many function templates (including operators)
-
-
-//  From <boost/math/special_functions/acosh.hpp>  ---------------------------//
-
-// Only has function template
-
-
-//  From <boost/math/special_functions/asinh.hpp>  ---------------------------//
-
-// Only has function template
-
-
-//  From <boost/math/special_functions/atanh.hpp>  ---------------------------//
-
-// Only has function template
-
-
-//  From <boost/math/special_functions/sinc.hpp>  ----------------------------//
-
-// Only has function templates
-
-
-//  From <boost/math/special_functions/sinhc.hpp>  ---------------------------//
-
-// Only has function templates
-
-
-//  From <boost/math/common_factor.hpp>  -------------------------------------//
-
-// Only #includes other headers
-
-
-//  From <boost/math/common_factor_ct.hpp>  ----------------------------------//
-
-#ifdef BOOST_NO_INTEGRAL_INT64_T
-     typedef unsigned long static_gcd_type;
-#else
-     typedef boost::uintmax_t static_gcd_type;
-#endif
-
-template < static_gcd_type Value1, static_gcd_type Value2 >
-    struct static_gcd;
-template < static_gcd_type Value1, static_gcd_type Value2 >
-    struct static_lcm;
-
 }  // namespace math
 }  // namespace boost
 


### PR DESCRIPTION
These are no longer part of Boost.Math, but moved to Integer.