### PR TITLE
make move constructor and operator= noexcept

### DIFF
--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -318,7 +318,7 @@ public:
 
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
    // move:
-   polynomial(polynomial&& p)
+   polynomial(polynomial&& p) BOOST_NOEXCEPT
       : m_data(std::move(p.m_data)) { }
 #endif
 
@@ -387,7 +387,7 @@ public:
 
    // operators:
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   polynomial& operator =(polynomial&& p)
+   polynomial& operator =(polynomial&& p) BOOST_NOEXCEPT
    {
        m_data = std::move(p.m_data);
        return *this;


### PR DESCRIPTION
This change helps the polynomial class play well with STL
containers.

> If the move constructor for an element type in a container
> is not noexcept then the container will use the copy constructor rather
> than the move constructor -- HIC++ Version 4.0

Benchmarking shows that the number of calls to copy constructor
are reduced.

Here is the benchmarking code I used:

```cpp
#include "benchmark/benchmark.h"
#include "boost/math/tools/polynomial.hpp"
#include <vector>

using namespace boost::math::tools;

auto get_polynomial(size_t len, double val) {
	std::vector<double> data(len, val);
	return polynomial<double>(data.begin(), data.end());
}

static void stlContainers(benchmark::State& state) {
  int N = state.range(0);
  while (state.KeepRunning()) {
    std::vector<polynomial<double> > vec;
    for (int i=0; i<10000; ++i)
      vec.push_back(get_polynomial(N, 1.2));
  }
}
BENCHMARK(stlContainers)
  ->RangeMultiplier(8)
  ->Range(1, 4096);

BENCHMARK_MAIN();
```