### PR TITLE
Quasi-Monte Carlo integration.

### DIFF
--- a/doc/quadrature/quasi_monte_carlo.qbk
+++ b/doc/quadrature/quasi_monte_carlo.qbk
@@ -1,0 +1,38 @@
+[/
+Copyright (c) 2018 Nick Thompson
+Use, modification and distribution are subject to the
+Boost Software License, Version 1.0. (See accompanying file
+LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+]
+
+
+[section:quasi_monte_carlo Quasi Monte Carlo Quadrature]
+
+[heading Synopsis]
+
+    #include <boost/math/quadrature/quasi_monte_carlo.hpp>
+    namespace boost{ namespace math{
+
+    template<class F, class Real>
+    Real quasi_monte_carlo(F& f);
+    }} // namespaces
+
+[heading Description]
+
+The functional `quasi_monte_carlo` calculates the integral of a function /f/ using randomized quasi Monte-Carlo integration.
+Some explanation is needed to unpack the language of "randomized quasi-Monte Carlo integration".
+A traditional Monte Carlo integration uses a pseudo-random sequence of quadrature nodes to produce an estimate of the integral.
+Pseudo-random numbers (which, for our purposes can be thought of as truly random) seem to form "clumps"-small volumes which have a surprising number of quadrature nodes.
+Random sampling of the domain has many good properties, but so does uniform coverage.
+An attempt to merge the these two ideas leads us to the notion of low-discrepancy sequences.
+
+
+References:
+
+Kocis, Ladislav, and William J. Whiten., ['Computational investigations of low-discrepancy sequences.], ACM Transactions on Mathematical Software (TOMS) 23.2 (1997): 266-294.
+
+Owen, Art B., ['A randomized Halton algorithm in R], to appear (http://statweb.stanford.edu/~owen/reports/rhalton.pdf).
+
+Niederreiter, Harald. ['Random number generation and quasi-Monte Carlo methods], Society for Industrial and Applied Mathematics, 1992.
+
+[endsect]

--- a/include/boost/math/quadrature/quasi_monte_carlo.hpp
+++ b/include/boost/math/quadrature/quasi_monte_carlo.hpp
@@ -1,0 +1,189 @@
+/*
+ *  (C) Copyright Nick Thompson 2018.
+ *  Use, modification and distribution are subject to the
+ *  Boost Software License, Version 1.0. (See accompanying file
+ *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#ifndef BOOST_MATH_QUADRATURE_QUASI_MONTE_CARLO_HPP
+#define BOOST_MATH_QUADRATURE_QUASI_MONTE_CARLO_HPP
+#include <algorithm>
+#include <vector>
+#include <atomic>
+#include <functional>
+#include <future>
+#include <thread>
+#include <initializer_list>
+#include <utility>
+#include <random>
+#include <chrono>
+#include <map>
+
+namespace boost { namespace math { namespace quadrature {
+
+template<class Real, class F, class Policy = boost::math::policies::policy<>>
+class quasi_monte_carlo
+{
+public:
+    quasi_monte_carlo(const F& f,
+                      std::vector<std::pair<Real, Real>> const & bounds,
+                      Real error_goal,
+                      size_t threads = std::thread::hardware_concurrency()): m_f{f}, m_num_threads{threads}
+    {
+        using std::isfinite;
+        size_t n = bounds.size();
+        m_lbs.resize(n);
+        m_dxs.resize(n);
+        m_volume = 1;
+        static const char* function = "boost::math::quadrature::naive_monte_carlo<%1%>";
+        for (size_t i = 0; i < n; ++i)
+        {
+            if (!(isfinite(bounds[i].first) && isfinite(bounds[i].second)))
+            {
+                boost::math::policies::raise_domain_error(function, "The routine only support bounded domains. Rescaling infinite domains must be done by the user.\n", bounds[i].first, Policy());
+                return;
+            }
+            if (bounds[i].second <= bounds[i].first)
+            {
+                boost::math::policies::raise_domain_error(function, "The upper bound is <= the lower bound.\n", bounds[i].second, Policy());
+                return;
+            }
+            m_lbs[i] = bounds[i].first;
+            m_dxs[i] = bounds[i].second - m_lbs[i];
+            m_volume *= m_dxs[i];
+        }
+        m_error_goal = error_goal;
+        m_start = std::chrono::system_clock::now();
+        m_done = false;
+        m_total_calls = 0;
+        if (m_num_threads < 2)
+        {
+            m_num_threads = 2;
+        }
+        m_variance = std::numeric_limits<Real>::max();
+    }
+
+    std::future<Real> integrate()
+    {
+        // Set done to false in case we wish to restart:
+        m_done = false;
+        return std::async(std::launch::async,
+                          &naive_monte_carlo::m_integrate, this);
+    }
+
+    void cancel()
+    {
+        m_done = true;
+    }
+
+    void update_target_error(Real new_target_error)
+    {
+        m_error_goal = new_target_error;
+    }
+
+    Real current_estimate() const
+    {
+        return m_avg.load()*m_volume;
+    }
+
+    size_t calls() const
+    {
+        return m_total_calls.load();
+    }
+
+private:
+
+    Real m_integrate()
+    {
+        m_start = std::chrono::system_clock::now();
+        std::vector<std::thread> threads(m_num_threads);
+        for (size_t i = 0; i < threads.size(); ++i)
+        {
+            threads[i] = std::thread(&quasi_monte_carlo::m_thread_task, this, i);
+        }
+        do {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            // Allow cancellation:
+            if (m_done)
+            {
+                break;
+            }
+        } while (this->current_error_estimate() > m_error_goal);
+        // Error bound met; signal the threads:
+        m_done = true;
+        // Wait for each one to finish:
+        std::for_each(threads.begin(), threads.end(),
+                      std::mem_fn(&std::thread::join));
+        if (m_exception)
+        {
+            std::rethrow_exception(m_exception);
+        }
+        return m_avg.load()*m_volume;
+    }
+
+    void m_thread_task(size_t thread_index)
+    {
+        try
+        {
+            std::vector<Real> x(m_lbs.size());
+            std::random_device rd;
+            auto seed = rd();
+            std::mt19937_64 gen(seed);
+            Real inv_denom = (Real) 1/( (Real) gen.max() + (Real) 2);
+            Real M1 = m_thread_averages[thread_index];
+            Real S = m_thread_Ss[thread_index];
+            // Kahan summation is required. See the implementation discussion.
+            Real compensator = 0;
+            size_t k = m_thread_calls[thread_index];
+            while (!m_done)
+            {
+                int j = 0;
+                int magic_calls_before_update = 2048;
+                while (j++ < magic_calls_before_update)
+                {
+                    for (size_t i = 0; i < m_lbs.size(); ++i)
+                    {
+                        x[i] = m_lbs[i] + (gen()+1)*inv_denom*m_dxs[i];
+                    }
+                    Real f = m_f(x);
+                    ++k;
+                    Real term = (f - M1)/k;
+                    Real y1 = term - compensator;
+                    Real M2 = M1 + y1;
+                    compensator = (M2 - M1) - y1;
+                    S += (f - M1)*(f - M2);
+                    M1 = M2;
+                }
+                m_thread_averages[thread_index] = M1;
+                m_thread_Ss[thread_index] = S;
+                m_thread_calls[thread_index] = k;
+            }
+        }
+        catch (...)
+        {
+            // Signal the other threads that the computation is ruined:
+            m_done = true;
+            m_exception = std::current_exception();
+        }
+    }
+
+    const F& m_f;
+    size_t m_num_threads;
+    std::atomic<Real> m_error_goal;
+    std::atomic<bool> m_done;
+    std::vector<Real> m_lbs;
+    std::vector<Real> m_dxs;
+    Real m_volume;
+    std::atomic<size_t> m_total_calls;
+    // I wanted these to be vectors rather than maps,
+    // but you can't resize a vector of atomics.
+    std::map<size_t, std::atomic<size_t>> m_thread_calls;
+    std::atomic<Real> m_variance;
+    std::map<size_t, std::atomic<Real>> m_thread_Ss;
+    std::atomic<Real> m_avg;
+    std::map<size_t, std::atomic<Real>> m_thread_averages;
+    std::chrono::time_point<std::chrono::system_clock> m_start;
+    std::exception_ptr m_exception;
+};
+}}}
+#endif

--- a/include/boost/math/tools/floor_sqrt.hpp
+++ b/include/boost/math/tools/floor_sqrt.hpp
@@ -1,0 +1,55 @@
+/*
+ *  (C) Copyright Nick Thompson 2017.
+ *  Use, modification and distribution are subject to the
+ *  Boost Software License, Version 1.0. (See accompanying file
+ *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ *
+ *  The integer floor_sqrt doesn't lose precision like a cast does.
+ *  Based on Algorithm 5.9 of "The Joy of Factoring".
+ */
+
+
+#ifndef BOOST_MATH_TOOLS_FLOOR_SQRT_HPP
+#define BOOST_MATH_TOOLS_FLOOR_SQRT_HPP
+#include <limits>
+//#include <boost/integer/integer_log2.hpp>
+
+namespace boost { namespace math {
+
+template<class Z>
+Z floor_sqrt(Z N)
+{
+    using std::pow;
+    static_assert(std::numeric_limits<Z>::is_integer,
+                  "The floor_sqrt function is for taking square roots of integers.\n");
+
+
+     Z x = N;
+     Z y = x/2 + (x&1);
+     while (y < x) {
+        x = y;
+        y = (x + N / x)/2;
+     }
+     return x;
+
+    // Starting with x = 2^ceil(log_2(N)/2) gets rid of a few iterations. But it's delicate.
+    // We need a log2 that returns a real, but that's precisely the problem we're trying to avoid.
+    /*Z l = boost::integer_log2(N);
+    Z exponent = l/2;
+    if (pow(2, l) < N)
+    {
+        exponent += 1;
+    }
+    Z x = pow(2, exponent);
+    Z y = (x + N/x)/2;
+    while (y < x)
+    {
+        x = y;
+        y = (x + N/x)/2;
+    }
+    return x;*/
+}
+
+}}
+
+#endif

--- a/include/boost/math/tools/halton_sequence.hpp
+++ b/include/boost/math/tools/halton_sequence.hpp
@@ -1,0 +1,119 @@
+/*
+ *  (C) Copyright Nick Thompson 2018.
+ *  Use, modification and distribution are subject to the
+ *  Boost Software License, Version 1.0. (See accompanying file
+ *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ *
+ *  The Halton sequence for quasi-random number generation.
+ */
+
+
+#ifndef BOOST_MATH_TOOLS_HALTON_SEQUENCE_HPP
+#define BOOST_MATH_TOOLS_HALTON_SEQUENCE_HPP
+#include <algorithm>
+#include <limits>
+#include <cmath>
+#include <random>
+#include <boost/math/tools/sieve_of_eratosthenes.hpp>
+
+namespace boost { namespace math {
+
+template<class Real, class Z>
+Real van_der_corput(Z x, Z b)
+{
+    static_assert(std::numeric_limits<Z>::is_integer,
+                  "The van der Corput function takes integers as arguments and returns real values.\n");
+    Real r = 0;
+    Real v = 1;
+    Real inv_b = static_cast<Real>(1) / static_cast<Real>(b);
+
+    while (x > 0)
+    {
+        v *= inv_b;
+        r += v*static_cast<Real>(x % b);
+        x /= b;
+    }
+    return r;
+}
+
+
+template<class Real>
+class halton_sequence {
+public:
+    halton_sequence(size_t dimension, bool shuffle_coordinates = true, bool leaped = true) : m_dimension{dimension}
+    {
+        // We need to build a sieve that contains 'dimension' primes.
+        // Since the prime counting function pi(x) < 1.26x/log(x), then we need dimension < 1.26x/log(x).
+        // This inequality can be solved via the Lambert-W function, which is in progress.
+        // For now, we'll just make a slight overestimate of the required sieve size:
+        size_t l = log(dimension);
+        size_t sieve_size = 2*dimension*l;
+        sieve_of_eratosthenes<size_t> sieve(sieve_size);
+        while (sieve.prime_count() < dimension + 1)
+        {
+            sieve_size *= 2;
+            sieve = sieve_of_eratosthenes<size_t>(sieve_size);
+        }
+
+        m_primes.resize(dimension);
+        for (size_t i = 0; i < m_primes.size(); ++i)
+        {
+            m_primes[i] = sieve.prime(i);
+        }
+        std::random_device rd;
+        std::mt19937 eng(rd());
+        if (shuffle_coordinates)
+        {
+            std::shuffle(m_primes.begin(), m_primes.end(), eng);
+        }
+        if (leaped)
+        {
+            // Randomly selecting a leap from the prime bases is recommended by Kocis and Whiten.
+            // The leap must be prime,
+            size_t index = eng() % dimension;
+            m_leap = m_primes[index];
+            m_primes[index] = sieve.prime(dimension);
+        }
+        else
+        {
+            m_leap = 1;
+        }
+        // The first few iterations of the Halton sequence have very poor properties.
+        m_iteration = m_leap*m_primes.back();
+    }
+
+    // Raw pointers are easier to wrap into other languages.
+    void operator()(Real* v, size_t dimension)
+    {
+        assert(dimension == m_dimension);
+        size_t count = m_iteration.fetch_add(m_leap);
+        for (size_t i = 0; i < dimension; ++i)
+        {
+            v[i] = van_der_corput<Real, size_t>(count, m_primes[i]);
+        }
+    }
+
+    template<class ForwardIterator>
+    void operator()(ForwardIterator begin, ForwardIterator end)
+    {
+        size_t count = m_iteration.fetch_add(m_leap);
+        auto it = begin;
+        auto prime_it = m_primes.begin();
+        size_t i = 0;
+        while(it != end)
+        {
+            *it++ = van_der_corput<Real, size_t>(count, *prime_it++);
+            ++i;
+        }
+        assert(i == m_dimension);
+    }
+
+
+private:
+    std::atomic<size_t> m_iteration;
+    size_t m_dimension;
+    std::vector<size_t> m_primes;
+    size_t m_leap;
+};
+}}
+#endif

--- a/include/boost/math/tools/sieve_of_eratosthenes.hpp
+++ b/include/boost/math/tools/sieve_of_eratosthenes.hpp
@@ -1,0 +1,80 @@
+/*
+ *  (C) Copyright Nick Thompson 2018.
+ *  Use, modification and distribution are subject to the
+ *  Boost Software License, Version 1.0. (See accompanying file
+ *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#ifndef BOOST_MATH_TOOLS_SIEVE_OF_ERATOSTHENESE_HPP
+#define BOOST_MATH_TOOLS_SIEVE_OF_ERATOSTHENESE_HPP
+#include <boost/math/tools/floor_sqrt.hpp>
+
+namespace boost { namespace math {
+
+template<class Z>
+class sieve_of_eratosthenes {
+public:
+      sieve_of_eratosthenes(Z max_j) : m_max_j{max_j}
+      {
+          std::vector<bool> is_prime((size_t) max_j+1, true);
+          is_prime[0] = false;
+          is_prime[1] = false;
+          Z p = 2;
+          Z root_j = floor_sqrt(max_j);
+          while (p <= root_j)
+          {
+              Z i = p + p;
+              while (i <= max_j)
+              {
+                  is_prime[(size_t) i] = false;
+                  i += p;
+              }
+              i = p + 1;
+              while (i <= root_j && is_prime[(size_t) i] ==  false)
+              {
+                  ++i;
+              }
+              p = i;
+          }
+          // TODO: Tighten this up using the prime counting function.
+          m_prime_list.reserve((size_t)max_j);
+          for(size_t i = 0; i < is_prime.size(); ++i)
+          {
+              if(is_prime[i])
+              {
+                  m_prime_list.push_back(i);
+              }
+          }
+          m_prime_list.shrink_to_fit();
+      }
+
+      bool is_prime(Z i) const
+      {
+          if (std::binary_search(m_prime_list.begin(), m_prime_list.end(), i))
+          {
+              return true;
+          }
+          if (i > m_max_j)
+          {
+              throw std::domain_error("Cannot determine if a number bigger than the prime table is prime.\n");
+          }
+          return false;
+      }
+
+      size_t prime_count() const
+      {
+          return m_prime_list.size();
+      }
+
+      Z prime(size_t i) const
+      {
+          return m_prime_list[i];
+      }
+
+private:
+    std::vector<Z> m_prime_list;
+    Z m_max_j;
+};
+
+}}
+#endif

--- a/test/floor_sqrt_test.cpp
+++ b/test/floor_sqrt_test.cpp
@@ -1,0 +1,45 @@
+/*
+ *  (C) Copyright Nick Thompson 2017.
+ *  Use, modification and distribution are subject to the
+ *  Boost Software License, Version 1.0. (See accompanying file
+ *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+
+#define BOOST_TEST_MODULE floor_sqrt_test
+#include <boost/test/included/unit_test.hpp>
+#include <boost/math/tools/floor_sqrt.hpp>
+
+using boost::math::floor_sqrt;
+
+template<class Z>
+void test_floor_sqrt()
+{
+    Z max_i = 500000;
+    for (Z i = 1; i < max_i; ++i)
+    {
+        Z j = floor_sqrt(i*i);
+        BOOST_CHECK_EQUAL(j, i);
+    }
+
+    for (Z i = 1; i < max_i; ++i)
+    {
+        Z  j = floor_sqrt(i);
+        BOOST_CHECK_LE(j*j, i);
+    }
+
+    for (Z i = 2; i < 100; ++i)
+    {
+        for (Z k = (i-1)*(i-1)+1; k < i*i; ++k)
+        {
+            Z j = floor_sqrt(k);
+            BOOST_CHECK_GE(j, i-1);
+            BOOST_CHECK(j < i);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(floor_sqrt_test)
+{
+    test_floor_sqrt<unsigned long long>();
+}

--- a/test/halton_sequence_test.cpp
+++ b/test/halton_sequence_test.cpp
@@ -1,0 +1,39 @@
+/*
+ *  (C) Copyright Nick Thompson 2018.
+ *  Use, modification and distribution are subject to the
+ *  Boost Software License, Version 1.0. (See accompanying file
+ *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+
+#define BOOST_TEST_MODULE halton_sequence_test
+#include <iostream>
+#include <iomanip>
+#include <boost/test/included/unit_test.hpp>
+#include <boost/math/tools/halton_sequence.hpp>
+
+
+using boost::math::halton_sequence;
+template<class Real>
+void test_halton()
+{
+    halton_sequence<Real> hs(6, true);
+    int i = 0;
+    std::cout << std::fixed;
+    std::cout << std::setprecision(std::numeric_limits<Real>::digits10);
+    std::vector<Real> r(6);
+    while(i++ < 500)
+    {
+        hs(r.begin(), r.end());
+        for (size_t j = 0; j < r.size();++j)
+        {
+            std::cout << r[j] << "\t";
+        }
+        std::cout << std::endl;
+    }
+}
+
+BOOST_AUTO_TEST_CASE(halton_sequence_test)
+{
+    test_halton<double>();
+}

--- a/test/sieve_of_eratosthenes_test.cpp
+++ b/test/sieve_of_eratosthenes_test.cpp
@@ -1,0 +1,35 @@
+/*
+ *  (C) Copyright Nick Thompson 2017.
+ *  Use, modification and distribution are subject to the
+ *  Boost Software License, Version 1.0. (See accompanying file
+ *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+
+#define BOOST_TEST_MODULE sieve_of_eratosthenes_test
+#include <boost/test/included/unit_test.hpp>
+#include <boost/math/tools/sieve_of_eratosthenes.hpp>
+#include <boost/math/special_functions/prime.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
+
+
+using boost::multiprecision::uint256_t;
+using boost::math::sieve_of_eratosthenes;
+
+template<class Z>
+void test_sieve()
+{
+    sieve_of_eratosthenes<Z> sieve(boost::math::prime(boost::math::max_prime - 1));
+    for (unsigned i = 0; i < sieve.prime_count(); ++i)
+    {
+        BOOST_CHECK_EQUAL(sieve.prime(i), boost::math::prime((unsigned)i));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(sieve_of_eratosthenes_test)
+{
+    test_sieve<int>();
+    test_sieve<unsigned>();
+    test_sieve<unsigned long long>();
+    test_sieve<uint256_t>();
+}


### PR DESCRIPTION
This was getting a bit too large for me to keep track of, so I'm PR'ing now.

The quasi-Monte Carlo integration takes quite a few tools. You need a quasi-random sequence, and Kocis and Whiten show that the leaped Halton sequence is excellent. So this PR has a Halton sequence. But for a Halton sequence, you need a prime table. Boost.Math has a nice big prime table of 10,000 entries, but for QMC it's not clear that's sufficient. So the PR has a sieve of Eratosthenes. The sieve requires a bigint square root, so it has that too!

This won't be done until I figure out how to allow people to provide quasi-random sequences, or at least provide (say) a Niederreiter and a Sobol sequence. But the leaped Halton is a nice starting place. 