### PR TITLE
Don't use std::fpclassify() on VxWorks as well

### DIFF
--- a/include/boost/math/special_functions/detail/fp_traits.hpp
+++ b/include/boost/math/special_functions/detail/fp_traits.hpp
@@ -556,7 +556,8 @@ struct select_native<long double>
    && !defined(__FAST_MATH__)\
    && !defined(BOOST_MATH_DISABLE_STD_FPCLASSIFY)\
    && !defined(BOOST_INTEL)\
-   && !defined(sun)
+   && !defined(sun)\
+   && !defined(__VXWORKS__)   
 #  define BOOST_MATH_USE_STD_FPCLASSIFY
 #endif
 


### PR DESCRIPTION
It doesn't exist