### PR TITLE
Remove 'print_coefficients()' as 'coefficients()' is implem…

### DIFF
--- a/include/boost/math/special_functions/chebyshev_transform.hpp
+++ b/include/boost/math/special_functions/chebyshev_transform.hpp
@@ -227,16 +227,6 @@ public:
         return dzdx*(z*d1 - d2 + b1);
     }
 
-    void print_coefficients() const
-    {
-        std::cout << "{";
-        for(auto const & coeff : m_coeffs) {
-          std::cout << coeff << ", ";
-        }
-        std::cout << "}\n";
-    }
-
-
 private:
     std::vector<Real> m_coeffs;
     Real m_a;


### PR DESCRIPTION
…ented and 'print_coefficients()' requires including <iostream> which was previously not included in chebyshev_transform.hpp.