### PR TITLE
Remove deprecation warning from the BOOST_BIG_ENDIAN and BOOST_LITTLE…

### DIFF
--- a/include/boost/math/special_functions/detail/fp_traits.hpp
+++ b/include/boost/math/special_functions/detail/fp_traits.hpp
@@ -216,9 +216,9 @@ template<> struct fp_traits_non_native<double, double_precision>
 
 private:
 
-#if defined(BOOST_ENDIAN_BIG_BYTE)
+#if BOOST_ENDIAN_BIG_BYTE
     BOOST_STATIC_CONSTANT(int, offset_ = 0);
-#elif defined(BOOST_ENDIAN_LITTLE_BYTE)
+#elif BOOST_ENDIAN_LITTLE_BYTE
     BOOST_STATIC_CONSTANT(int, offset_ = 4);
 #else
     BOOST_STATIC_ASSERT(false);
@@ -276,9 +276,9 @@ template<> struct fp_traits_non_native<long double, double_precision>
 
 private:
 
-#if defined(BOOST_ENDIAN_BIG_BYTE)
+#if BOOST_ENDIAN_BIG_BYTE
     BOOST_STATIC_CONSTANT(int, offset_ = 0);
-#elif defined(BOOST_ENDIAN_LITTLE_BYTE)
+#elif BOOST_ENDIAN_LITTLE_BYTE
     BOOST_STATIC_CONSTANT(int, offset_ = 4);
 #else
     BOOST_STATIC_ASSERT(false);
@@ -390,9 +390,9 @@ struct fp_traits_non_native<long double, extended_double_precision>
 
 private:
 
-#if defined(BOOST_ENDIAN_BIG_BYTE)
+#if BOOST_ENDIAN_BIG_BYTE
     BOOST_STATIC_CONSTANT(int, offset_ = 0);
-#elif defined(BOOST_ENDIAN_LITTLE_BYTE)
+#elif BOOST_ENDIAN_LITTLE_BYTE
     BOOST_STATIC_CONSTANT(int, offset_ = 12);
 #else
     BOOST_STATIC_ASSERT(false);
@@ -471,9 +471,9 @@ struct fp_traits_non_native<long double, extended_double_precision>
 
 private:
 
-#if defined(BOOST_ENDIAN_BIG_BYTE)
+#if BOOST_ENDIAN_BIG_BYTE
     BOOST_STATIC_CONSTANT(int, offset_ = 0);
-#elif defined(BOOST_ENDIAN_LITTLE_BYTE)
+#elif BOOST_ENDIAN_LITTLE_BYTE
     BOOST_STATIC_CONSTANT(int, offset_ = 12);
 #else
     BOOST_STATIC_ASSERT(false);

--- a/include/boost/math/special_functions/detail/fp_traits.hpp
+++ b/include/boost/math/special_functions/detail/fp_traits.hpp
@@ -24,7 +24,7 @@ With these techniques, the code could be simplified.
 
 #include <boost/assert.hpp>
 #include <boost/cstdint.hpp>
-#include <boost/detail/endian.hpp>
+#include <boost/predef/other/endian.h>
 #include <boost/static_assert.hpp>
 #include <boost/type_traits/is_floating_point.hpp>
 
@@ -51,9 +51,9 @@ With these techniques, the code could be simplified.
          && (_GLIBCXX_USE_C99_FP_MACROS_DYNAMIC != 0))
 #     ifdef _STLP_VENDOR_CSTD
 #        if _STLPORT_VERSION >= 0x520
-#           define BOOST_FPCLASSIFY_PREFIX ::__std_alias:: 
+#           define BOOST_FPCLASSIFY_PREFIX ::__std_alias::
 #        else
-#           define BOOST_FPCLASSIFY_PREFIX ::_STLP_VENDOR_CSTD:: 
+#           define BOOST_FPCLASSIFY_PREFIX ::_STLP_VENDOR_CSTD::
 #        endif
 #     else
 #        define BOOST_FPCLASSIFY_PREFIX ::std::
@@ -84,7 +84,7 @@ namespace detail {
 
 //------------------------------------------------------------------------------
 
-/* 
+/*
 The following classes are used to tag the different methods that are used
 for floating point classification
 */
@@ -216,9 +216,9 @@ template<> struct fp_traits_non_native<double, double_precision>
 
 private:
 
-#if defined(BOOST_BIG_ENDIAN)
+#if defined(BOOST_ENDIAN_BIG_BYTE)
     BOOST_STATIC_CONSTANT(int, offset_ = 0);
-#elif defined(BOOST_LITTLE_ENDIAN)
+#elif defined(BOOST_ENDIAN_LITTLE_BYTE)
     BOOST_STATIC_CONSTANT(int, offset_ = 4);
 #else
     BOOST_STATIC_ASSERT(false);
@@ -276,9 +276,9 @@ template<> struct fp_traits_non_native<long double, double_precision>
 
 private:
 
-#if defined(BOOST_BIG_ENDIAN)
+#if defined(BOOST_ENDIAN_BIG_BYTE)
     BOOST_STATIC_CONSTANT(int, offset_ = 0);
-#elif defined(BOOST_LITTLE_ENDIAN)
+#elif defined(BOOST_ENDIAN_LITTLE_BYTE)
     BOOST_STATIC_CONSTANT(int, offset_ = 4);
 #else
     BOOST_STATIC_ASSERT(false);
@@ -390,9 +390,9 @@ struct fp_traits_non_native<long double, extended_double_precision>
 
 private:
 
-#if defined(BOOST_BIG_ENDIAN)
+#if defined(BOOST_ENDIAN_BIG_BYTE)
     BOOST_STATIC_CONSTANT(int, offset_ = 0);
-#elif defined(BOOST_LITTLE_ENDIAN)
+#elif defined(BOOST_ENDIAN_LITTLE_BYTE)
     BOOST_STATIC_CONSTANT(int, offset_ = 12);
 #else
     BOOST_STATIC_ASSERT(false);
@@ -471,9 +471,9 @@ struct fp_traits_non_native<long double, extended_double_precision>
 
 private:
 
-#if defined(BOOST_BIG_ENDIAN)
+#if defined(BOOST_ENDIAN_BIG_BYTE)
     BOOST_STATIC_CONSTANT(int, offset_ = 0);
-#elif defined(BOOST_LITTLE_ENDIAN)
+#elif defined(BOOST_ENDIAN_LITTLE_BYTE)
     BOOST_STATIC_CONSTANT(int, offset_ = 12);
 #else
     BOOST_STATIC_ASSERT(false);
@@ -557,7 +557,7 @@ struct select_native<long double>
    && !defined(BOOST_MATH_DISABLE_STD_FPCLASSIFY)\
    && !defined(BOOST_INTEL)\
    && !defined(sun)\
-   && !defined(__VXWORKS__)   
+   && !defined(__VXWORKS__)
 #  define BOOST_MATH_USE_STD_FPCLASSIFY
 #endif
 


### PR DESCRIPTION
…_ENDIAN macros.