### PR TITLE
Add a fake boost_math target to boost-install

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -120,8 +120,7 @@ lib boost_math_c99l : ../src/tr1/$(C99_SOURCES)l.cpp pch
          [ check-target-builds ../config//has_long_double_support "long double support" : : <build>no ]
    ;
 
-boost-install boost_math_c99 boost_math_c99f boost_math_c99l boost_math_tr1 boost_math_tr1f boost_math_tr1l ;
+# Fake 'library' target for dependency resolution purposes
+alias boost_math ;
 
-
-
-
+boost-install boost_math_c99 boost_math_c99f boost_math_c99l boost_math_tr1 boost_math_tr1f boost_math_tr1l boost_math ;


### PR DESCRIPTION
This adds a target `boost_math` that does nothing to the `boost-install` line for dependency resolution purposes. Some libraries such as `random` depend on `math`, but there's no `math`, so the fake target helps with that.