### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/doc/html/math_toolkit/lambert_w.html
+++ b/doc/html/math_toolkit/lambert_w.html
@@ -1872,7 +1872,7 @@ if (f(w) / f'</span><span class="special">(</span><span class="identifier">w</sp
 <li class="listitem">
           T.C. Banwell and A. Jayakumar, Electronic Letter, Feb 2000, 36(4), pages
           291-2. Exact analytical solution for current flow through diode with series
-          resistance. <a href="http://dx.doi.org/10.1049/el:20000301" target="_top">http://dx.doi.org/10.1049/el:20000301</a>
+          resistance. <a href="https://doi.org/10.1049/el:20000301" target="_top">https://doi.org/10.1049/el:20000301</a>
         </li>
 <li class="listitem">
           Princeton Companion to Applied Mathematics, 'The Lambert-W function', Section

--- a/doc/sf/lambert_w.qbk
+++ b/doc/sf/lambert_w.qbk
@@ -797,7 +797,7 @@ Mathematics, 244 (2013) 77-89.
 
 # T.C. Banwell and A. Jayakumar, Electronic Letter, Feb 2000, 36(4), pages 291-2.
 Exact analytical solution for current flow through diode with series resistance.
-[@http://dx.doi.org/10.1049/el:20000301]
+[@https://doi.org/10.1049/el:20000301]
 
 # Princeton Companion to Applied Mathematics,
 'The Lambert-W function', Section 1.3: Series and Generating Functions.

--- a/example/lambert_w_diode.cpp
+++ b/example/lambert_w_diode.cpp
@@ -9,7 +9,7 @@
   \details T. C. Banwell and A. Jayakumar,
   Exact analytical solution of current flow through diode with series resistance,
   Electron Letters, 36(4):291-2 (2000)
-  DOI:  dx.doi.org/10.1049/el:20000301 
+  DOI:  doi.org/10.1049/el:20000301 
 
   The current through a diode connected NPN bipolar junction transistor (BJT) 
   type 2N2222 (See https://en.wikipedia.org/wiki/2N2222 and 

--- a/example/lambert_w_diode_graph.cpp
+++ b/example/lambert_w_diode_graph.cpp
@@ -11,7 +11,7 @@ through a diode-connected transistor with preset series resistance.
 \details T. C. Banwell and A. Jayakumar,
 Exact analytical solution of current flow through diode with series resistance,
 Electron Letters, 36(4):291-2 (2000).
-DOI:  dx.doi.org/10.1049/el:20000301
+DOI:  doi.org/10.1049/el:20000301
 
 The current through a diode connected NPN bipolar junction transistor (BJT)
 type 2N2222 (See https://en.wikipedia.org/wiki/2N2222 and


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!