### PR TITLE
Attempt to fix travis failure with clang++-6: The following packages …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -568,11 +568,10 @@ matrix:
       addons:
         apt:
           packages:
-            - libjsoncpp-dev
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
+            - llvm-toolchain-xenial-6.0
 
     - os: linux
       compiler: clang++-6.0
@@ -580,11 +579,10 @@ matrix:
       addons:
         apt:
           packages:
-            - libjsoncpp-dev
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
+            - llvm-toolchain-xenial-6.0
 
     - os: linux
       compiler: clang++-6.0
@@ -592,11 +590,10 @@ matrix:
       addons:
         apt:
           packages:
-            - libjsoncpp-dev
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
+            - llvm-toolchain-xenial-6.0
 
     - os: linux
       compiler: clang++-6.0
@@ -604,11 +601,10 @@ matrix:
       addons:
         apt:
           packages:
-            - libjsoncpp-dev
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
+            - llvm-toolchain-xenial-6.0
 
     - os: linux
       compiler: clang++-6.0
@@ -616,11 +612,10 @@ matrix:
       addons:
         apt:
           packages:
-            - libjsoncpp-dev
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
+            - llvm-toolchain-xenial-6.0
 
     - os: osx
       env: TOOLSET=clang COMPILER=clang++ CXXSTD=c++14 TEST_SUITE=special_fun

--- a/.travis.yml
+++ b/.travis.yml
@@ -568,7 +568,7 @@ matrix:
       addons:
         apt:
           packages:
-            - libjsoncpp0
+            - libjsoncpp-dev
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test
@@ -580,7 +580,7 @@ matrix:
       addons:
         apt:
           packages:
-            - libjsoncpp0
+            - libjsoncpp-dev
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test
@@ -592,7 +592,7 @@ matrix:
       addons:
         apt:
           packages:
-            - libjsoncpp0
+            - libjsoncpp-dev
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test
@@ -604,7 +604,7 @@ matrix:
       addons:
         apt:
           packages:
-            - libjsoncpp0
+            - libjsoncpp-dev
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test
@@ -616,7 +616,7 @@ matrix:
       addons:
         apt:
           packages:
-            - libjsoncpp0
+            - libjsoncpp-dev
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -568,6 +568,7 @@ matrix:
       addons:
         apt:
           packages:
+            - libjsoncpp0
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test
@@ -579,6 +580,7 @@ matrix:
       addons:
         apt:
           packages:
+            - libjsoncpp0
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test
@@ -590,6 +592,7 @@ matrix:
       addons:
         apt:
           packages:
+            - libjsoncpp0
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test
@@ -601,6 +604,7 @@ matrix:
       addons:
         apt:
           packages:
+            - libjsoncpp0
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test
@@ -612,6 +616,7 @@ matrix:
       addons:
         apt:
           packages:
+            - libjsoncpp0
             - clang-6.0
           sources:
             - ubuntu-toolchain-r-test


### PR DESCRIPTION
…have unmet dependencies: clang-6.0 : Depends: libjsoncpp0 (>= 0.6.0~rc2) but it is not installable.