### PR TITLE
Cubic B-spline second derivatives

### DIFF
--- a/doc/interpolators/cubic_b_spline.qbk
+++ b/doc/interpolators/cubic_b_spline.qbk
@@ -30,6 +30,8 @@ LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
         Real operator()(Real x) const;
 
         Real prime(Real x) const;
+
+        Real double_prime(Real x) const;
     };
 
   }} // namespaces
@@ -37,7 +39,7 @@ LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 [heading Cubic B-Spline Interpolation]
 
-The cubic B-spline class provided by boost allows fast and accurate interpolation of a function which is known at equally spaced points.
+The cubic B-spline class provided by Boost allows fast and accurate interpolation of a function which is known at equally spaced points.
 The cubic B-spline interpolation is numerically stable as it uses compactly supported basis functions constructed via iterative convolution.
 This is to be contrasted to traditional cubic spline interpolation which is ill-conditioned as the global support of cubic polynomials causes small changes far from the evaluation point to exert a large influence on the calculated value.
 
@@ -78,6 +80,15 @@ and to evaluate the derivative of the interpolant we use
     double yp = spline.prime(x);
 
 Be aware that the accuracy guarantees on the derivative of the spline are an order lower than the guarantees on the original function, see [@http://www.springer.com/us/book/9780387984087 Numerical Analysis, Graduate Texts in Mathematics, 181, Rainer Kress] for details.
+
+The last interesting member is the second derivative, evaluated via
+
+    double ypp = spline.double_prime(x);
+
+The basis functions of the spline are cubic polynomials, so the second derivative is simply linear interpolation.
+But the interpolation is not constrained by data (you don't pass in the second derivatives), and hence is less accurate than would be expected from assuming it is a linear interpolation.
+The problem is especially pronounced at the boundaries, where the second derivative is totally unconstrained.
+Use the second derivative of the cubic B-spline interpolator only in desperation.
 
 Finally, note that this is an interpolator, not an extrapolator.
 Therefore, you should strenuously avoid evaluating the spline outside the endpoints.

--- a/include/boost/math/interpolators/cubic_b_spline.hpp
+++ b/include/boost/math/interpolators/cubic_b_spline.hpp
@@ -45,6 +45,8 @@ public:
 
     Real prime(Real x) const;
 
+    Real double_prime(Real x) const;
+
 private:
     std::shared_ptr<detail::cubic_b_spline_imp<Real>> m_imp;
 };
@@ -73,6 +75,13 @@ Real cubic_b_spline<Real>::prime(Real x) const
 {
     return m_imp->prime(x);
 }
+
+template<class Real>
+Real cubic_b_spline<Real>::double_prime(Real x) const
+{
+    return m_imp->double_prime(x);
+}
+
 
 }}
 #endif

--- a/include/boost/math/interpolators/detail/cubic_b_spline_detail.hpp
+++ b/include/boost/math/interpolators/detail/cubic_b_spline_detail.hpp
@@ -32,6 +32,8 @@ public:
 
     Real prime(Real x) const;
 
+    Real double_prime(Real x) const;
+
 private:
     std::vector<Real> m_beta;
     Real m_h_inv;
@@ -75,6 +77,25 @@ Real b3_spline_prime(Real x)
     if (x < 2)
     {
         return -boost::math::constants::half<Real>()*(2 - x)*(2 - x);
+    }
+    return (Real) 0;
+}
+
+template<class Real>
+Real b3_spline_double_prime(Real x)
+{
+    if (x < 0)
+    {
+        return b3_spline_double_prime(-x);
+    }
+
+    if (x < 1)
+    {
+        return (3*boost::math::constants::half<Real>()*x - 2) + x*(3*boost::math::constants::half<Real>());
+    }
+    if (x < 2)
+    {
+        return (2 - x);
     }
     return (Real) 0;
 }
@@ -282,6 +303,28 @@ Real cubic_b_spline_imp<Real>::prime(Real x) const
     }
     return z*m_h_inv;
 }
+
+template<class Real>
+Real cubic_b_spline_imp<Real>::double_prime(Real x) const
+{
+    Real z = 0;
+    Real t = m_h_inv*(x - m_a) + 1;
+
+    using std::max;
+    using std::min;
+    using std::ceil;
+    using std::floor;
+
+    size_t k_min = (size_t) (max)(static_cast<long>(0), boost::math::ltrunc(ceil(t - 2)));
+    size_t k_max = (size_t) (min)(static_cast<long>(m_beta.size() - 1), boost::math::ltrunc(floor(t + 2)));
+
+    for (size_t k = k_min; k <= k_max; ++k)
+    {
+        z += m_beta[k]*b3_spline_double_prime(t - k);
+    }
+    return z*m_h_inv*m_h_inv;
+}
+
 
 }}}
 #endif

--- a/test/test_cubic_b_spline.cpp
+++ b/test/test_cubic_b_spline.cpp
@@ -30,6 +30,9 @@ void test_b3_spline()
     BOOST_CHECK_SMALL(boost::math::detail::b3_spline<Real>(-2.5), (Real) 0);
     BOOST_CHECK_SMALL(boost::math::detail::b3_spline_prime<Real>(2.5), (Real) 0);
     BOOST_CHECK_SMALL(boost::math::detail::b3_spline_prime<Real>(-2.5), (Real) 0);
+    BOOST_CHECK_SMALL(boost::math::detail::b3_spline_double_prime<Real>(2.5), (Real) 0);
+    BOOST_CHECK_SMALL(boost::math::detail::b3_spline_double_prime<Real>(-2.5), (Real) 0);
+
 
     // On the boundary of support:
     BOOST_CHECK_SMALL(boost::math::detail::b3_spline<Real>(2), (Real) 0);
@@ -52,6 +55,7 @@ void test_b3_spline()
         Real arg = i*0.01;
         BOOST_CHECK_CLOSE(boost::math::detail::b3_spline<Real>(arg), boost::math::detail::b3_spline<Real>(arg), eps);
         BOOST_CHECK_CLOSE(boost::math::detail::b3_spline_prime<Real>(-arg), -boost::math::detail::b3_spline_prime<Real>(arg), eps);
+        BOOST_CHECK_CLOSE(boost::math::detail::b3_spline_double_prime<Real>(-arg), boost::math::detail::b3_spline_double_prime<Real>(arg), eps);
     }
 
 }
@@ -109,6 +113,9 @@ void test_constant_function()
         BOOST_CHECK_CLOSE(y, constant, 10*std::numeric_limits<Real>::epsilon());
         Real y_prime = spline.prime(i*step + a + 0.002);
         BOOST_CHECK_SMALL(y_prime, 5000*std::numeric_limits<Real>::epsilon());
+        Real y_double_prime = spline.double_prime(i*step + a + 0.002);
+        BOOST_CHECK_SMALL(y_double_prime, 5000*std::numeric_limits<Real>::epsilon());
+
     }
 
     // Test that correctly specified left and right-derivatives work properly:


### PR DESCRIPTION
Leave this undocumented because it does linear interpolation of the data at the second derivative and has very low accuracy.