### PR TITLE
roots: Use C versions of fma and copysign

### DIFF
--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -800,8 +800,8 @@ namespace detail
     inline T discriminant(T const & a, T const & b, T const & c)
     {
         T w = 4*a*c;
-        T e = std::fma(-c, 4*a, w);
-        T f = std::fma(b, b, -w);
+        T e = fma(-c, 4*a, w);
+        T f = fma(b, b, -w);
         return f + e;
     }
 }
@@ -809,7 +809,6 @@ namespace detail
 template<class T>
 auto quadratic_roots(T const& a, T const& b, T const& c)
 {
-    using std::copysign;
     using std::sqrt;
     if constexpr (std::is_integral<T>::value)
     {


### PR DESCRIPTION
fma and copysign are C++11 functions that do not get included in std::
by uClibc-ng. Switch to the C version.