### PR TITLE
autodiff: replace decay_t<T> with typename std::decay<T>::type.

### DIFF
--- a/include/boost/math/differentiation/autodiff.hpp
+++ b/include/boost/math/differentiation/autodiff.hpp
@@ -56,7 +56,7 @@ template <typename RealType, size_t Order>
 struct is_fvar_impl<fvar<RealType, Order>> : std::true_type {};
 
 template <typename T>
-using is_fvar = is_fvar_impl<decay_t<T>>;
+using is_fvar = is_fvar_impl<typename std::decay<T>::type>;
 
 template <typename RealType, size_t Order, size_t... Orders>
 struct nest_fvar {
@@ -76,7 +76,7 @@ struct get_depth_impl<fvar<RealType, Order>>
     : std::integral_constant<size_t, get_depth_impl<RealType>::value + 1> {};
 
 template <typename T>
-using get_depth = get_depth_impl<decay_t<T>>;
+using get_depth = get_depth_impl<typename std::decay<T>::type>;
 
 template <typename>
 struct get_order_sum_t : std::integral_constant<size_t, 0> {};
@@ -86,7 +86,7 @@ struct get_order_sum_t<fvar<RealType, Order>>
     : std::integral_constant<size_t, get_order_sum_t<RealType>::value + Order> {};
 
 template <typename T>
-using get_order_sum = get_order_sum_t<decay_t<T>>;
+using get_order_sum = get_order_sum_t<typename std::decay<T>::type>;
 
 template <typename RealType>
 struct get_root_type {
@@ -316,7 +316,8 @@ class fvar {
 
   explicit operator root_type() const;  // Must be explicit, otherwise overloaded operators are ambiguous.
 
-  template <typename T, typename = typename boost::enable_if<boost::is_arithmetic<decay_t<T>>>::type>
+  template <typename T,
+            typename = typename boost::enable_if<boost::is_arithmetic<typename std::decay<T>::type>>::type>
   explicit operator T() const;  // Must be explicit; multiprecision has trouble without the std::enable_if
 
   fvar& set_root(root_type const&);


### PR DESCRIPTION
This is a fix for an issue brought up in #311. For compatibility with C++11, we will use the more verbose `typename std::decay<T>::type` rather than the more succinct C++14 version `std::decay_t<T>`.