### PR TITLE
Autodiff: minimise #includes and change type_traits usage to the std …

### DIFF
--- a/include/boost/math/differentiation/autodiff.hpp
+++ b/include/boost/math/differentiation/autodiff.hpp
@@ -8,7 +8,15 @@
 
 #include <boost/cstdfloat.hpp>
 #include <boost/math/constants/constants.hpp>
-#include <boost/math/special_functions.hpp>
+#include <boost/math/special_functions/trunc.hpp>
+#include <boost/math/special_functions/round.hpp>
+#include <boost/math/special_functions/acosh.hpp>
+#include <boost/math/special_functions/asinh.hpp>
+#include <boost/math/special_functions/atanh.hpp>
+#include <boost/math/special_functions/digamma.hpp>
+#include <boost/math/special_functions/polygamma.hpp>
+#include <boost/math/special_functions/erf.hpp>
+#include <boost/math/special_functions/lambert_w.hpp>
 #include <boost/math/tools/config.hpp>
 #include <boost/math/tools/promotion.hpp>
 
@@ -56,7 +64,7 @@ template <typename RealType, size_t Order>
 struct is_fvar_impl<fvar<RealType, Order>> : std::true_type {};
 
 template <typename T>
-using is_fvar = is_fvar_impl<decay_t<T>>;
+using is_fvar = is_fvar_impl<std::decay_t<T>>;
 
 template <typename RealType, size_t Order, size_t... Orders>
 struct nest_fvar {
@@ -76,7 +84,7 @@ struct get_depth_impl<fvar<RealType, Order>>
     : std::integral_constant<size_t, get_depth_impl<RealType>::value + 1> {};
 
 template <typename T>
-using get_depth = get_depth_impl<decay_t<T>>;
+using get_depth = get_depth_impl<std::decay_t<T>>;
 
 template <typename>
 struct get_order_sum_t : std::integral_constant<size_t, 0> {};
@@ -86,7 +94,7 @@ struct get_order_sum_t<fvar<RealType, Order>>
     : std::integral_constant<size_t, get_order_sum_t<RealType>::value + Order> {};
 
 template <typename T>
-using get_order_sum = get_order_sum_t<decay_t<T>>;
+using get_order_sum = get_order_sum_t<std::decay_t<T>>;
 
 template <typename RealType>
 struct get_root_type {
@@ -316,7 +324,7 @@ class fvar {
 
   explicit operator root_type() const;  // Must be explicit, otherwise overloaded operators are ambiguous.
 
-  template <typename T, typename = typename boost::enable_if<boost::is_arithmetic<decay_t<T>>>::type>
+  template <typename T, typename = typename std::enable_if<std::is_arithmetic<std::decay_t<T>>::value>>
   explicit operator T() const;  // Must be explicit; multiprecision has trouble without the std::enable_if
 
   fvar& set_root(root_type const&);

--- a/include/boost/math/differentiation/autodiff.hpp
+++ b/include/boost/math/differentiation/autodiff.hpp
@@ -64,7 +64,7 @@ template <typename RealType, size_t Order>
 struct is_fvar_impl<fvar<RealType, Order>> : std::true_type {};
 
 template <typename T>
-using is_fvar = is_fvar_impl<std::decay_t<T>>;
+using is_fvar = is_fvar_impl<typename std::decay<T>::type>;
 
 template <typename RealType, size_t Order, size_t... Orders>
 struct nest_fvar {
@@ -84,7 +84,7 @@ struct get_depth_impl<fvar<RealType, Order>>
     : std::integral_constant<size_t, get_depth_impl<RealType>::value + 1> {};
 
 template <typename T>
-using get_depth = get_depth_impl<std::decay_t<T>>;
+using get_depth = get_depth_impl<typename std::decay<T>::type>;
 
 template <typename>
 struct get_order_sum_t : std::integral_constant<size_t, 0> {};
@@ -94,7 +94,7 @@ struct get_order_sum_t<fvar<RealType, Order>>
     : std::integral_constant<size_t, get_order_sum_t<RealType>::value + Order> {};
 
 template <typename T>
-using get_order_sum = get_order_sum_t<std::decay_t<T>>;
+using get_order_sum = get_order_sum_t<typename std::decay<T>::type>;
 
 template <typename RealType>
 struct get_root_type {
@@ -324,7 +324,7 @@ class fvar {
 
   explicit operator root_type() const;  // Must be explicit, otherwise overloaded operators are ambiguous.
 
-  template <typename T, typename = typename std::enable_if<std::is_arithmetic<std::decay_t<T>>::value>>
+  template <typename T, typename = typename std::enable_if<std::is_arithmetic<typename std::decay<T>::type>::value>>
   explicit operator T() const;  // Must be explicit; multiprecision has trouble without the std::enable_if
 
   fvar& set_root(root_type const&);

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1313,6 +1313,7 @@ test-suite quadrature :
    [ run test_autodiff_6.cpp ../../test/build//boost_unit_test_framework : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj release [ check-target-builds ../config//has_float128 "GCC libquadmath and __float128 support" : <linkflags>-lquadmath ] [ requires cxx11_inline_namespaces ] ]
    [ run test_autodiff_7.cpp ../../test/build//boost_unit_test_framework : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj release [ check-target-builds ../config//has_float128 "GCC libquadmath and __float128 support" : <linkflags>-lquadmath ] [ requires cxx11_inline_namespaces ] ]
    [ run test_autodiff_8.cpp ../../test/build//boost_unit_test_framework : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj release [ check-target-builds ../config//has_float128 "GCC libquadmath and __float128 support" : <linkflags>-lquadmath ] [ requires cxx11_inline_namespaces ] ]
+   [ compile compile_test/autodiff_incl_test.cpp : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj release [ check-target-builds ../config//has_float128 "GCC libquadmath and __float128 support" : <linkflags>-lquadmath ] [ requires cxx11_inline_namespaces ] ]
 ;
 
 #

--- a/test/compile_test/autodiff_incl_test.cpp
+++ b/test/compile_test/autodiff_incl_test.cpp
@@ -1,0 +1,30 @@
+//  Copyright Nick Thompson 2017.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Basic sanity check that header <boost/math/special_functions/gamma.hpp>
+// #includes all the files that it needs to.
+//
+#include <boost/math/differentiation/autodiff.hpp>
+//
+// Note this header includes no other headers, this is
+// important if this test is to be meaningful:
+//
+#include "test_compile_result.hpp"
+
+template <typename T>
+T fourth_power(T const& x) {
+   T x4 = x * x;  // retval in operator*() uses x4's memory via NRVO.
+   x4 *= x4;      // No copies of x4 are made within operator*=() even when squaring.
+   return x4;     // x4 uses y's memory in main() via NRVO.
+}
+
+void compile_and_link_test()
+{
+   using namespace boost::math::differentiation;
+   auto const x = make_fvar<double, 5>(2.0);  // Find derivatives at x=2.
+   auto const y = fourth_power(x);
+   
+   check_result<double>(y.derivative(1));
+}

--- a/test/test_autodiff_5.cpp
+++ b/test/test_autodiff_5.cpp
@@ -4,6 +4,7 @@
 //           https://www.boost.org/LICENSE_1_0.txt)
 
 #include "test_autodiff.hpp"
+#include <boost/math/special_functions.hpp>
 
 BOOST_AUTO_TEST_SUITE(test_autodiff_5)
 

--- a/test/test_autodiff_6.cpp
+++ b/test/test_autodiff_6.cpp
@@ -4,6 +4,7 @@
 //           https://www.boost.org/LICENSE_1_0.txt)
 
 #include "test_autodiff.hpp"
+#include <boost/math/special_functions.hpp>
 
 BOOST_AUTO_TEST_SUITE(test_autodiff_6)
 

--- a/test/test_autodiff_8.cpp
+++ b/test/test_autodiff_8.cpp
@@ -4,6 +4,7 @@
 //           https://www.boost.org/LICENSE_1_0.txt)
 
 #include "test_autodiff.hpp"
+#include <boost/math/special_functions.hpp>
 
 BOOST_AUTO_TEST_SUITE(test_autodiff_8)
 


### PR DESCRIPTION
…versions.

Update tests to match.