### PR TITLE
Bugfix/exp sinh quardature complex non standard range error

### DIFF
--- a/include/boost/math/quadrature/exp_sinh.hpp
+++ b/include/boost/math/quadrature/exp_sinh.hpp
@@ -62,13 +62,13 @@ auto exp_sinh<Real, Policy>::integrate(const F& f, Real a, Real b, Real toleranc
         {
             return m_imp->integrate(f, error, L1, function, tolerance, levels);
         }
-        const auto u = [&](Real t)->Real { return f(t + a); };
+        const auto u = [&](Real t)->K { return f(t + a); };
         return m_imp->integrate(u, error, L1, function, tolerance, levels);
     }
 
     if ((boost::math::isfinite)(b) && a <= -boost::math::tools::max_value<Real>())
     {
-        const auto u = [&](Real t)->Real { return f(b-t);};
+        const auto u = [&](Real t)->K { return f(b-t);};
         return m_imp->integrate(u, error, L1, function, tolerance, levels);
     }
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1167,6 +1167,9 @@ test-suite quadrature :
    [ run exp_sinh_quadrature_test.cpp ../../test/build//boost_unit_test_framework
      : : : release <define>TEST8 [ check-target-builds ../config//has_float128 "GCC libquadmath and __float128 support" : <linkflags>-lquadmath ]
      [ requires cxx11_auto_declarations cxx11_lambdas cxx11_smart_ptr cxx11_unified_initialization_syntax ] : exp_sinh_quadrature_test_8 ]
+   [ run exp_sinh_quadrature_test.cpp ../../test/build//boost_unit_test_framework
+     : : : release <define>TEST9 [ check-target-builds ../config//has_float128 "GCC libquadmath and __float128 support" : <linkflags>-lquadmath ]
+     [ requires cxx11_auto_declarations cxx11_lambdas cxx11_smart_ptr cxx11_unified_initialization_syntax ] : exp_sinh_quadrature_test_9 ]
 
    [ run  compile_test/exp_sinh_incl_test.cpp compile_test_main : : : [ requires cxx11_auto_declarations cxx11_lambdas cxx11_smart_ptr cxx11_unified_initialization_syntax ] ]
    [ run  compile_test/sinh_sinh_incl_test.cpp compile_test_main : : : [ requires cxx11_auto_declarations cxx11_lambdas cxx11_smart_ptr cxx11_unified_initialization_syntax ] ]

--- a/test/exp_sinh_quadrature_test.cpp
+++ b/test/exp_sinh_quadrature_test.cpp
@@ -52,7 +52,7 @@ using boost::math::constants::root_two_pi;
 using boost::math::constants::root_pi;
 using boost::math::quadrature::exp_sinh;
 
-#if !defined(TEST1) && !defined(TEST2) && !defined(TEST3) && !defined(TEST4) && !defined(TEST5) && !defined(TEST6) && !defined(TEST7) && !defined(TEST8)
+#if !defined(TEST1) && !defined(TEST2) && !defined(TEST3) && !defined(TEST4) && !defined(TEST5) && !defined(TEST6) && !defined(TEST7) && !defined(TEST8) && !defined(TEST9)
 #  define TEST1
 #  define TEST2
 #  define TEST3
@@ -61,6 +61,7 @@ using boost::math::quadrature::exp_sinh;
 #  define TEST6
 #  define TEST7
 #  define TEST8
+#  define TEST9
 #endif
 
 #ifdef BOOST_MSVC
@@ -515,6 +516,37 @@ void test_complex_modified_bessel()
     BOOST_CHECK_CLOSE_FRACTION(K0.imag(), K0_y_expected, tol);
 }
 
+template<typename Complex>
+void test_complex_exponential_integral_E1(){
+    std::cout << "Testing complex exponential integral on type " << boost::typeindex::type_id<Complex>().pretty_name() << "\n";
+    typedef typename Complex::value_type Real;
+    Real tol = 100 * boost::math::tools::epsilon<Real>();
+    Real error;
+    Real L1;
+    auto integrator = get_integrator<Real>();
+
+    Complex z{1.5,0.5};
+
+    // Integral representation of exponential integral E1, valid for Re z > 0
+    // https://en.wikipedia.org/wiki/Exponential_integral#Definitions
+    auto f = [&z](const Real& t)->Complex
+    {
+       using std::exp;
+       return exp(-z*t)/t;
+    };
+
+    Real inf = std::numeric_limits<Real>::has_infinity ? std::numeric_limits<Real>::infinity() : boost::math::tools::max_value<Real>();
+
+    Complex E1 = integrator.integrate(f,1,inf,get_convergence_tolerance<Real>(),&error,&L1);
+
+   // Mathematica code: N[ExpIntegral[1,1.5 + 0.5 I],140]
+    Real E1_real_expected = boost::lexical_cast<Real>("0.071702995463938694845949672113596046091766639758473558841839765788732549949008866887694451956003503764943496943262401868244277788066634858393");
+    Real E1_imag_expected = boost::lexical_cast<Real>("-0.065138628279238400564373880665751377423524428792583839078600260273866805818117625959446311737353882269129094759883720722150048944193926087208");
+    BOOST_CHECK_CLOSE_FRACTION(E1.real(), E1_real_expected, tol);
+    BOOST_CHECK_CLOSE_FRACTION(E1.imag(), E1_imag_expected, tol);
+
+}
+
 
 BOOST_AUTO_TEST_CASE(exp_sinh_quadrature_test)
 {
@@ -592,5 +624,14 @@ BOOST_AUTO_TEST_CASE(exp_sinh_quadrature_test)
         test_complex_modified_bessel<boost::multiprecision::complex128>();
     #endif
     test_complex_modified_bessel<boost::multiprecision::cpp_complex_quad>();
+#endif
+#ifdef TEST9
+    test_complex_exponential_integral_E1<std::complex<float>>();
+    test_complex_exponential_integral_E1<std::complex<double>>();
+    test_complex_exponential_integral_E1<std::complex<long double>>();
+      #ifdef BOOST_HAS_FLOAT128
+         test_complex_exponential_integral_E1<boost::multiprecision::complex128>();
+      #endif
+    test_complex_exponential_integral_E1<boost::multiprecision::cpp_complex_quad>();
 #endif
 }


### PR DESCRIPTION
I found a bug where the exp_sinh integrator failed to compile when used to integrate function returning a complex number over a non-native range (that is not from 0 to infinity).

This turned out to be due to the functions which mapped the integral back onto the native range requiring the function being integrated to return the same type that was used for the integration range, rather than the type inferred from the integrand. 

I have fixed the bug and added some tests to cover the case of a complex valued function being integrated over a non-native range. 