### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC and __CODEGEARC__ to BOOST_CODE…

### DIFF
--- a/doc/background/special_tut.qbk
+++ b/doc/background/special_tut.qbk
@@ -367,7 +367,7 @@ Now we just need to write the test driver program, at it's most basic it looks s
    #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
       test(0.1L, "long double");
    #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
-   #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+   #if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
       test(boost::math::concepts::real_concept(0.1), "real_concept");
    #endif
    #endif

--- a/example/nonfinite_signaling_NaN.cpp
+++ b/example/nonfinite_signaling_NaN.cpp
@@ -84,7 +84,7 @@ int main()
     cout << "quiet_NaN input was " << r << endl; // "1"
   }
 
-#if (!defined __BORLANDC__ && !defined __CODEGEARC__)
+#if (!defined BOOST_BORLANDC && !defined BOOST_CODEGEARC)
   // These compilers trap when trying to create a signaling_NaN!
   { // Try Signaling NaN
     stringstream ss; // Both input and output.

--- a/include/boost/math/complex/details.hpp
+++ b/include/boost/math/complex/details.hpp
@@ -56,7 +56,7 @@ inline long double safe_max(long double t)
    // insufficient internal precision:
    return std::sqrt((std::numeric_limits<double>::max)()) / t;
 }
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 // workaround for type deduction bug:
 inline float safe_max(float t)
 {
@@ -78,7 +78,7 @@ inline long double safe_min(long double t)
    // insufficient internal precision:
    return std::sqrt((std::numeric_limits<double>::min)()) * t;
 }
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 // type deduction workaround:
 inline double safe_min(double t)
 {

--- a/include/boost/math/distributions/non_central_beta.hpp
+++ b/include/boost/math/distributions/non_central_beta.hpp
@@ -653,7 +653,7 @@ namespace boost
 
             hypergeometric_2F2_sum<value_type> s(a1, a2, b1, b2, z);
             boost::uintmax_t max_iter = policies::get_max_series_iterations<Policy>();
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
             value_type zero = 0;
             value_type result = boost::math::tools::sum_series(s, boost::math::policies::get_epsilon<value_type, Policy>(), max_iter, zero);
 #else

--- a/include/boost/math/policies/policy.hpp
+++ b/include/boost/math/policies/policy.hpp
@@ -116,7 +116,7 @@ namespace policies{
 #define BOOST_MATH_MAX_ROOT_ITERATION_POLICY 200
 #endif
 
-#if !defined(__BORLANDC__)
+#if !defined(BOOST_BORLANDC)
 #define BOOST_MATH_META_INT(type, name, Default)\
    template <type N = Default> struct name : public boost::integral_constant<int, N>{};\
    namespace detail{\
@@ -266,7 +266,7 @@ struct precision
       digits2<((Digits10::value + 1) * 1000L) / 301L>
    >::type digits2_type;
 public:
-#ifdef __BORLANDC__
+#ifdef BOOST_BORLANDC
    typedef typename mpl::if_c<
       (Digits2::value > ::boost::math::policies::detail::precision<Digits10,Digits2>::digits2_type::value),
       Digits2, digits2_type>::type type;
@@ -796,7 +796,7 @@ template <class Real, class Policy>
 struct precision
 {
    BOOST_STATIC_ASSERT((::std::numeric_limits<Real>::radix == 2) || ((::std::numeric_limits<Real>::is_specialized == 0) || (::std::numeric_limits<Real>::digits == 0)));
-#ifndef __BORLANDC__
+#ifndef BOOST_BORLANDC
    typedef typename Policy::precision_type precision_type;
    typedef typename mpl::if_c<
       ((::std::numeric_limits<Real>::is_specialized == 0) || (::std::numeric_limits<Real>::digits == 0)),

--- a/include/boost/math/special_functions/bessel.hpp
+++ b/include/boost/math/special_functions/bessel.hpp
@@ -79,7 +79,7 @@ inline T sph_bessel_j_small_z_series(unsigned v, T x, const Policy& pol)
    BOOST_MATH_STD_USING // ADL of std names
    sph_bessel_j_small_z_series_term<T, Policy> s(v, x);
    boost::uintmax_t max_iter = policies::get_max_series_iterations<Policy>();
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    T zero = 0;
    T result = boost::math::tools::sum_series(s, boost::math::policies::get_epsilon<T, Policy>(), max_iter, zero);
 #else

--- a/include/boost/math/special_functions/detail/bessel_ik.hpp
+++ b/include/boost/math/special_functions/detail/bessel_ik.hpp
@@ -68,7 +68,7 @@ inline T bessel_i_small_z_series(T v, T x, const Policy& pol)
 
    cyl_bessel_i_small_z<T, Policy> s(v, x);
    boost::uintmax_t max_iter = policies::get_max_series_iterations<Policy>();
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    T zero = 0;
    T result = boost::math::tools::sum_series(s, boost::math::policies::get_epsilon<T, Policy>(), max_iter, zero);
 #else

--- a/include/boost/math/special_functions/detail/bessel_jy_derivatives_series.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jy_derivatives_series.hpp
@@ -67,7 +67,7 @@ inline T bessel_j_derivative_small_z_series(T v, T x, const Policy& pol)
 
    bessel_j_derivative_small_z_series_term<T, Policy> s(v, x);
    boost::uintmax_t max_iter = boost::math::policies::get_max_series_iterations<Policy>();
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    T zero = 0;
    T result = boost::math::tools::sum_series(s, boost::math::policies::get_epsilon<T, Policy>(), max_iter, zero);
 #else
@@ -181,7 +181,7 @@ inline T bessel_y_derivative_small_z_series(T v, T x, const Policy& pol)
    }
    bessel_y_derivative_small_z_series_term_a<T, Policy> s(v, x);
    boost::uintmax_t max_iter = boost::math::policies::get_max_series_iterations<Policy>();
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    T zero = 0;
    T result = boost::math::tools::sum_series(s, boost::math::policies::get_epsilon<T, Policy>(), max_iter, zero);
 #else
@@ -203,7 +203,7 @@ inline T bessel_y_derivative_small_z_series(T v, T x, const Policy& pol)
    }
    bessel_y_derivative_small_z_series_term_b<T, Policy> s2(v, x);
    max_iter = boost::math::policies::get_max_series_iterations<Policy>();
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    T b = boost::math::tools::sum_series(s2, boost::math::policies::get_epsilon<T, Policy>(), max_iter, zero);
 #else
    T b = boost::math::tools::sum_series(s2, boost::math::policies::get_epsilon<T, Policy>(), max_iter);

--- a/include/boost/math/special_functions/detail/bessel_jy_series.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jy_series.hpp
@@ -62,7 +62,7 @@ inline T bessel_j_small_z_series(T v, T x, const Policy& pol)
 
    bessel_j_small_z_series_term<T, Policy> s(v, x);
    boost::uintmax_t max_iter = policies::get_max_series_iterations<Policy>();
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    T zero = 0;
    T result = boost::math::tools::sum_series(s, boost::math::policies::get_epsilon<T, Policy>(), max_iter, zero);
 #else
@@ -179,7 +179,7 @@ inline T bessel_y_small_z_series(T v, T x, T* pscale, const Policy& pol)
    bessel_y_small_z_series_term_a<T, Policy> s(v, x);
    boost::uintmax_t max_iter = policies::get_max_series_iterations<Policy>();
    *pscale = scale;
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    T zero = 0;
    T result = boost::math::tools::sum_series(s, boost::math::policies::get_epsilon<T, Policy>(), max_iter, zero);
 #else
@@ -200,7 +200,7 @@ inline T bessel_y_small_z_series(T v, T x, T* pscale, const Policy& pol)
    }
    bessel_y_small_z_series_term_b<T, Policy> s2(v, x);
    max_iter = policies::get_max_series_iterations<Policy>();
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    T b = boost::math::tools::sum_series(s2, boost::math::policies::get_epsilon<T, Policy>(), max_iter, zero);
 #else
    T b = boost::math::tools::sum_series(s2, boost::math::policies::get_epsilon<T, Policy>(), max_iter);

--- a/include/boost/math/special_functions/detail/fp_traits.hpp
+++ b/include/boost/math/special_functions/detail/fp_traits.hpp
@@ -191,7 +191,7 @@ template<> struct fp_traits_non_native<float, single_precision>
 // ieee_tag version, double (64 bits) ----------------------------------------------
 
 #if defined(BOOST_NO_INT64_T) || defined(BOOST_NO_INCLASS_MEMBER_INITIALIZATION) \
-   || defined(__BORLANDC__) || defined(__CODEGEAR__)
+   || defined(BOOST_BORLANDC) || defined(__CODEGEAR__)
 
 template<> struct fp_traits_non_native<double, double_precision>
 {
@@ -251,7 +251,7 @@ template<> struct fp_traits_non_native<double, double_precision>
 // long double (64 bits) -------------------------------------------------------
 
 #if defined(BOOST_NO_INT64_T) || defined(BOOST_NO_INCLASS_MEMBER_INITIALIZATION)\
-   || defined(__BORLANDC__) || defined(__CODEGEAR__)
+   || defined(BOOST_BORLANDC) || defined(__CODEGEAR__)
 
 template<> struct fp_traits_non_native<long double, double_precision>
 {

--- a/include/boost/math/special_functions/detail/hypergeometric_series.hpp
+++ b/include/boost/math/special_functions/detail/hypergeometric_series.hpp
@@ -185,7 +185,7 @@
   {
     BOOST_MATH_STD_USING
     boost::uintmax_t max_iter = policies::get_max_series_iterations<Policy>();
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
     const T zero = 0;
     const T result = boost::math::tools::sum_series(term, boost::math::policies::get_epsilon<T, Policy>(), max_iter, zero);
 #else

--- a/include/boost/math/special_functions/expm1.hpp
+++ b/include/boost/math/special_functions/expm1.hpp
@@ -135,7 +135,7 @@ T expm1_imp(T x, const boost::integral_constant<int, 0>&, const Policy& pol)
       return x;
    detail::expm1_series<T> s(x);
    boost::uintmax_t max_iter = policies::get_max_series_iterations<Policy>();
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582)) && !BOOST_WORKAROUND(__EDG_VERSION__, <= 245)
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582)) && !BOOST_WORKAROUND(__EDG_VERSION__, <= 245)
    T result = tools::sum_series(s, policies::get_epsilon<T, Policy>(), max_iter);
 #else
    T zero = 0;
@@ -319,7 +319,7 @@ inline typename tools::promote_args<T>::type expm1(T x)
    return expm1(x, policies::policy<>());
 }
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 inline float expm1(float z)
 {
    return expm1<float>(z);

--- a/include/boost/math/special_functions/fpclassify.hpp
+++ b/include/boost/math/special_functions/fpclassify.hpp
@@ -77,7 +77,7 @@ is used.
 
 */
 
-#if defined(_MSC_VER) || defined(__BORLANDC__)
+#if defined(_MSC_VER) || defined(BOOST_BORLANDC)
 #include <float.h>
 #endif
 #ifdef BOOST_MATH_USE_FLOAT128
@@ -168,7 +168,7 @@ inline int fpclassify_imp BOOST_NO_MACRO_EXPAND(T t, const generic_tag<true>&)
 #elif defined(isnan)
    if(boost::math_detail::is_nan_helper(t, ::boost::is_floating_point<T>()))
       return FP_NAN;
-#elif defined(_MSC_VER) || defined(__BORLANDC__)
+#elif defined(_MSC_VER) || defined(BOOST_BORLANDC)
    if(::_isnan(boost::math::tools::real_cast<double>(t)))
       return FP_NAN;
 #endif

--- a/include/boost/math/special_functions/log1p.hpp
+++ b/include/boost/math/special_functions/log1p.hpp
@@ -106,7 +106,7 @@ T log1p_imp(T const & x, const Policy& pol, const boost::integral_constant<int, 
       return x;
    detail::log1p_series<result_type> s(x);
    boost::uintmax_t max_iter = policies::get_max_series_iterations<Policy>();
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582)) && !BOOST_WORKAROUND(__EDG_VERSION__, <= 245)
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582)) && !BOOST_WORKAROUND(__EDG_VERSION__, <= 245)
    result_type result = tools::sum_series(s, policies::get_epsilon<result_type, Policy>(), max_iter);
 #else
    result_type zero = 0;
@@ -325,7 +325,7 @@ inline typename tools::promote_args<T>::type log1p(T x, const Policy&)
       detail::log1p_imp(static_cast<value_type>(x), forwarding_policy(), tag_type()), "boost::math::log1p<%1%>(%1%)");
 }
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 // These overloads work around a type deduction bug:
 inline float log1p(float z)
 {
@@ -482,7 +482,7 @@ inline typename tools::promote_args<T>::type
    boost::math::detail::log1p_series<T> s(x);
    s();
    boost::uintmax_t max_iter = policies::get_max_series_iterations<Policy>();
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    T zero = 0;
    T result = boost::math::tools::sum_series(s, policies::get_epsilon<T, Policy>(), max_iter, zero);
 #else

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -33,7 +33,7 @@
    && !defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS)
 #  define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
 #endif
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 //
 // Borland post 5.8.2 uses Dinkumware's std C lib which
 // doesn't have true long double precision.  Earlier

--- a/include/boost/math/tools/tuple.hpp
+++ b/include/boost/math/tools/tuple.hpp
@@ -29,7 +29,7 @@ using ::std::tuple_element;
 
 }}
 
-#elif (defined(__BORLANDC__) && (__BORLANDC__ <= 0x600)) || defined(__IBMCPP__)
+#elif (defined(BOOST_BORLANDC) && (BOOST_BORLANDC <= 0x600)) || defined(__IBMCPP__)
 
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
@@ -57,7 +57,7 @@ struct tuple_element
    typedef typename boost::tuples::element<I,T>::type type;
 };
 
-#if !BOOST_WORKAROUND(__BORLANDC__, < 0x0582)
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, < 0x0582)
 // [6.1.3.4] Element access
 using ::boost::get;
 #endif

--- a/test/complex_test.cpp
+++ b/test/complex_test.cpp
@@ -279,7 +279,7 @@ void check_spots(const T&)
    bool test_infinity = std::numeric_limits<T>::has_infinity;
    T nan = 0;
    bool test_nan = false;
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
    // numeric_limits reports that a quiet NaN is present
    // but an attempt to access it will terminate the program!!!!
    if(std::numeric_limits<T>::has_quiet_NaN)

--- a/test/log1p_expm1_test.hpp
+++ b/test/log1p_expm1_test.hpp
@@ -78,7 +78,7 @@ void test(T, const char* type_name)
       BOOST_CHECK_EQUAL(boost::math::log1p(m_one), -std::numeric_limits<T>::infinity());
       BOOST_CHECK_EQUAL(boost::math::expm1(T(-std::numeric_limits<T>::infinity())), m_one);
       BOOST_CHECK_EQUAL(boost::math::expm1(std::numeric_limits<T>::infinity()), std::numeric_limits<T>::infinity());
-#ifndef __BORLANDC__
+#ifndef BOOST_BORLANDC
 #ifndef BOOST_NO_EXCEPTIONS
       // When building with Borland's compiler, simply the *presence*
       // of these tests cause other unrelated tests to fail!!! :-(

--- a/test/test_arcsine.cpp
+++ b/test/test_arcsine.cpp
@@ -555,7 +555,7 @@ void test_spots(RealType)
     test_spots(0.0); // Test double.
     #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
       test_spots(0.0L); // Test long double.
-      #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+      #if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
         test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
       #endif
     #endif

--- a/test/test_bernoulli.cpp
+++ b/test/test_bernoulli.cpp
@@ -303,7 +303,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0F); // Test float.
   test_spots(0.0); // Test double.
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 

--- a/test/test_beta.cpp
+++ b/test/test_beta.cpp
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE( test_main )
    test_spots(0.0);
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
    test_spots(0.0L);
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    test_spots(boost::math::concepts::real_concept(0.1));
 #endif
 #else
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
    test_beta(0.1L, "long double");
 #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    test_beta(boost::math::concepts::real_concept(0.1), "real_concept");
 #endif
 #endif

--- a/test/test_beta_dist.cpp
+++ b/test/test_beta_dist.cpp
@@ -627,7 +627,7 @@ BOOST_AUTO_TEST_CASE( test_main )
    test_spots(0.0); // Test double.
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
    test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #endif

--- a/test/test_cauchy.cpp
+++ b/test/test_cauchy.cpp
@@ -721,7 +721,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tolerance = 1e07 %
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #else

--- a/test/test_classify.cpp
+++ b/test/test_classify.cpp
@@ -177,7 +177,7 @@ void test_classify(T t, const char* type)
       BOOST_CHECK_EQUAL((::boost::math::isnan)(-t), false);
       BOOST_CHECK_EQUAL((::boost::math::isnormal)(t), false);
       BOOST_CHECK_EQUAL((::boost::math::isnormal)(-t), false);
-#if !defined(__BORLANDC__) && !(defined(__DECCXX) && !defined(_IEEE_FP))
+#if !defined(BOOST_BORLANDC) && !(defined(__DECCXX) && !defined(_IEEE_FP))
       // divide by zero on Borland triggers a C++ exception :-(
       // divide by zero on Compaq CXX triggers a C style signal :-(
       t = 2;
@@ -213,7 +213,7 @@ void test_classify(T t, const char* type)
    {
       std::cout << "Infinity not tested" << std::endl;
    }
-#ifndef __BORLANDC__
+#ifndef BOOST_BORLANDC
    // NaN's:
    // Note that Borland throws an exception if we even try to obtain a Nan
    // by calling std::numeric_limits<T>::quiet_NaN() !!!!!!!

--- a/test/test_constants.cpp
+++ b/test/test_constants.cpp
@@ -818,7 +818,7 @@ BOOST_AUTO_TEST_CASE( test_main )
    test_spots(0.0); // Test double.
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
    test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x0582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x0582))
    test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
    test_spots(boost::math::concepts::big_real_concept(0.)); // Test real concept.
 #endif

--- a/test/test_dist_overloads.cpp
+++ b/test/test_dist_overloads.cpp
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tolerance = 1e07 %
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #else

--- a/test/test_erf.cpp
+++ b/test/test_erf.cpp
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE( test_main )
    test_spots(0.0, "double");
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
    test_spots(0.0L, "long double");
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    test_spots(boost::math::concepts::real_concept(0.1), "real_concept");
 #endif
 #endif
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
    test_erf(0.1L, "long double");
 #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    test_erf(boost::math::concepts::real_concept(0.1), "real_concept");
 #endif
 #endif

--- a/test/test_exponential_dist.cpp
+++ b/test/test_exponential_dist.cpp
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tolerance = 1e07 %
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #else

--- a/test/test_extreme_value.cpp
+++ b/test/test_extreme_value.cpp
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tolerance = 1e07 %
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #else

--- a/test/test_find_location.cpp
+++ b/test/test_find_location.cpp
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double.
   #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
     test_spots(0.0L); // Test long double.
-  #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x0582))
+  #if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x0582))
     test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
   #endif
   #else

--- a/test/test_find_scale.cpp
+++ b/test/test_find_scale.cpp
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double.
   #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
     test_spots(0.0L); // Test long double.
-    #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x0582))
+    #if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x0582))
     test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
   #endif
   #else

--- a/test/test_fisher_f.cpp
+++ b/test/test_fisher_f.cpp
@@ -519,7 +519,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double.
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #endif

--- a/test/test_gamma.cpp
+++ b/test/test_gamma.cpp
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
    test_gamma(0.1L, "long double");
 #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    test_gamma(boost::math::concepts::real_concept(0.1), "real_concept");
 #endif
 #endif

--- a/test/test_geometric.cpp
+++ b/test/test_geometric.cpp
@@ -780,7 +780,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 #ifdef TEST_LDOUBLE
   test_spots(0.0L); // Test long double.
 #endif
-  #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+  #if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 #ifdef TEST_REAL_CONCEPT
     test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif

--- a/test/test_ibeta.cpp
+++ b/test/test_ibeta.cpp
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 #ifdef TEST_LDOUBLE
    test_spots(0.0L);
 #endif
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 #ifdef TEST_REAL_CONCEPT
    test_spots(boost::math::concepts::real_concept(0.1));
 #endif

--- a/test/test_ibeta_derivative.cpp
+++ b/test/test_ibeta_derivative.cpp
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 #ifdef TEST_LDOUBLE
    test_spots(0.0L);
 #endif
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 #ifdef TEST_REAL_CONCEPT
    test_spots(boost::math::concepts::real_concept(0.1));
 #endif

--- a/test/test_igamma.cpp
+++ b/test/test_igamma.cpp
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
    test_gamma(0.1L, "long double");
 #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    test_gamma(boost::math::concepts::real_concept(0.1), "real_concept");
 #endif
 #endif

--- a/test/test_igamma_inv.cpp
+++ b/test/test_igamma_inv.cpp
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 #ifdef TEST_LDOUBLE
    test_spots(0.0L, "long double");
 #endif
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 #ifdef TEST_REAL_CONCEPT
    test_spots(boost::math::concepts::real_concept(0.1), "real_concept");
 #endif
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE( test_main )
    test_gamma(0.1L, "long double");
 #endif
 #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 #ifdef TEST_REAL_CONCEPT
    test_gamma(boost::math::concepts::real_concept(0.1), "real_concept");
 #endif

--- a/test/test_igamma_inva.cpp
+++ b/test/test_igamma_inva.cpp
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE( test_main )
    test_gamma(0.1L, "long double");
 #endif
 #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 #ifdef TEST_REAL_CONCEPT
    test_gamma(boost::math::concepts::real_concept(0.1), "real_concept");
 #endif

--- a/test/test_inverse_chi_squared_distribution.cpp
+++ b/test/test_inverse_chi_squared_distribution.cpp
@@ -499,7 +499,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tolerance = 1e07 %
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x0582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x0582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #else

--- a/test/test_logistic_dist.cpp
+++ b/test/test_logistic_dist.cpp
@@ -371,7 +371,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tolerance = 1e07 %
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #else

--- a/test/test_lognormal.cpp
+++ b/test/test_lognormal.cpp
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tolerance = 1e07 %
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x0582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x0582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #else

--- a/test/test_nc_beta.cpp
+++ b/test/test_nc_beta.cpp
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 #ifdef TEST_LDOUBLE
    test_spots(0.0L); // Test long double.
 #endif
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 #ifdef TEST_REAL_CONCEPT
    test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
@@ -289,7 +289,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 #ifdef TEST_LDOUBLE
    test_accuracy(0.0L, "long double"); // Test long double.
 #endif
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 #ifdef TEST_REAL_CONCEPT
    test_accuracy(boost::math::concepts::real_concept(0.), "real_concept"); // Test real concept.
 #endif

--- a/test/test_nc_f.cpp
+++ b/test/test_nc_f.cpp
@@ -305,7 +305,7 @@ BOOST_AUTO_TEST_CASE( test_main )
    test_spots(0.0); // Test double.
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
    test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #endif

--- a/test/test_normal.cpp
+++ b/test/test_normal.cpp
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tolerance = 1e07 %
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x0582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x0582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #else

--- a/test/test_owens_t.cpp
+++ b/test/test_owens_t.cpp
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double.
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #endif
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   check_against_T7(0.0); // Test double.
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   check_against_T7(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
   check_against_T7(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #endif
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_owens_t(0.0, "double"); // Test double.
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_owens_t(0.0L, "long double"); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
   test_owens_t(boost::math::concepts::real_concept(0.), "real_concept"); // Test real concept.
 #endif
 #endif

--- a/test/test_pareto.cpp
+++ b/test/test_pareto.cpp
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tol5eps = 1e07 %
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x0582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x0582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #else

--- a/test/test_rational_instances/test_rational_real_concept1.cpp
+++ b/test/test_rational_instances/test_rational_real_concept1.cpp
@@ -5,7 +5,7 @@
 
 
 #include <boost/detail/workaround.hpp>
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 
 #include "test_rational.hpp"
 #include <boost/math/concepts/real_concept.hpp>

--- a/test/test_rational_instances/test_rational_real_concept2.cpp
+++ b/test/test_rational_instances/test_rational_real_concept2.cpp
@@ -5,7 +5,7 @@
 
 
 #include <boost/detail/workaround.hpp>
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 
 #include "test_rational.hpp"
 #include <boost/math/concepts/real_concept.hpp>

--- a/test/test_rational_instances/test_rational_real_concept3.cpp
+++ b/test/test_rational_instances/test_rational_real_concept3.cpp
@@ -5,7 +5,7 @@
 
 
 #include <boost/detail/workaround.hpp>
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 
 #include "test_rational.hpp"
 #include <boost/math/concepts/real_concept.hpp>

--- a/test/test_rational_instances/test_rational_real_concept4.cpp
+++ b/test/test_rational_instances/test_rational_real_concept4.cpp
@@ -5,7 +5,7 @@
 
 
 #include <boost/detail/workaround.hpp>
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 
 #include "test_rational.hpp"
 #include <boost/math/concepts/real_concept.hpp>

--- a/test/test_rational_instances/test_rational_real_concept5.cpp
+++ b/test/test_rational_instances/test_rational_real_concept5.cpp
@@ -5,7 +5,7 @@
 
 
 #include <boost/detail/workaround.hpp>
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 
 #include "test_rational.hpp"
 #include <boost/math/concepts/real_concept.hpp>

--- a/test/test_rayleigh.cpp
+++ b/test/test_rayleigh.cpp
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tolerance = 1e07 %
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #else

--- a/test/test_students_t.cpp
+++ b/test/test_students_t.cpp
@@ -748,7 +748,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tolerance = 1e07 %
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #else

--- a/test/test_tgamma_ratio.cpp
+++ b/test/test_tgamma_ratio.cpp
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
    test_tgamma_ratio(0.1L, "long double");
 #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    test_tgamma_ratio(boost::math::concepts::real_concept(0.1), "real_concept");
 #endif
 #endif
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
    test_spots(0.1L, "long double");
 #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    test_spots(boost::math::concepts::real_concept(0.1), "real_concept");
 #endif
 #endif

--- a/test/test_triangular.cpp
+++ b/test/test_triangular.cpp
@@ -725,7 +725,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tolerance = 1e07 %
   #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
     test_spots(0.0L); // Test long double.
-  #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x0582))
+  #if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x0582))
     test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
   #endif
   #else

--- a/test/test_trig.cpp
+++ b/test/test_trig.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
    test_trig(0.1L, "long double");
 #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
    test_trig(boost::math::concepts::real_concept(0.1), "real_concept");
 #endif
 #endif

--- a/test/test_uniform.cpp
+++ b/test/test_uniform.cpp
@@ -429,7 +429,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tolerance = 1e07 %
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x0582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x0582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #else

--- a/test/test_weibull.cpp
+++ b/test/test_weibull.cpp
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_spots(0.0); // Test double. OK at decdigits 7, tolerance = 1e07 %
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
   test_spots(0.0L); // Test long double.
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x0582))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x0582))
   test_spots(boost::math::concepts::real_concept(0.)); // Test real concept.
 #endif
 #else


### PR DESCRIPTION
…GEARC, which is defined in Boost config for the Embarcadero non-clang-based compilers.