### PR TITLE
Fix some Clang and Clang-tidy warnings

### DIFF
--- a/include/boost/math/special_functions/detail/bessel_jy.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jy.hpp
@@ -154,7 +154,7 @@ namespace boost { namespace math {
 
             // modified Lentz's method, see
             // Lentz, Applied Optics, vol 15, 668 (1976)
-            tolerance = 2 * policies::get_epsilon<T, Policy>();;
+            tolerance = 2 * policies::get_epsilon<T, Policy>();
          tiny = sqrt(tools::min_value<T>());
          C = f = tiny;                           // b0 = 0, replace with tiny
          D = 0;
@@ -586,4 +586,3 @@ namespace boost { namespace math {
 }} // namespaces
 
 #endif // BOOST_MATH_BESSEL_JY_HPP
-

--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -1,4 +1,3 @@
-
 //  Copyright John Maddock 2006-7, 2013-14.
 //  Copyright Paul A. Bristow 2007, 2013-14.
 //  Copyright Nikhar Agrawal 2013-14
@@ -1200,7 +1199,7 @@ T gamma_incomplete_imp(T a, T x, bool normalised, bool invert,
       return exp(result);
    }
 
-   BOOST_ASSERT((p_derivative == 0) || (normalised == true));
+   BOOST_ASSERT((p_derivative == 0) || normalised);
 
    bool is_int, is_half_int;
    bool is_small_a = (a < 30) && (a <= x + 1) && (x < tools::log_max_value<T>());
@@ -1331,14 +1330,14 @@ T gamma_incomplete_imp(T a, T x, bool normalised, bool invert,
    case 0:
       {
          result = finite_gamma_q(a, x, pol, p_derivative);
-         if(normalised == false)
+         if(!normalised)
             result *= boost::math::tgamma(a, pol);
          break;
       }
    case 1:
       {
          result = finite_half_gamma_q(a, x, p_derivative, pol);
-         if(normalised == false)
+         if(!normalised)
             result *= boost::math::tgamma(a, pol);
          if(p_derivative && (*p_derivative == 0))
             *p_derivative = regularised_gamma_prefix(a, x, pol, lanczos_type());
@@ -2173,7 +2172,3 @@ inline typename tools::promote_args<T1, T2>::type
 #include <boost/math/special_functions/erf.hpp>
 
 #endif // BOOST_MATH_SF_GAMMA_HPP
-
-
-
-

--- a/include/boost/math/special_functions/jacobi_elliptic.hpp
+++ b/include/boost/math/special_functions/jacobi_elliptic.hpp
@@ -137,7 +137,7 @@ inline typename tools::promote_args<T, U, V>::type jacobi_elliptic(T k, U theta,
       *pcn = policies::checked_narrowing_cast<result_type, Policy>(cn, function);
    if(pdn)
       *pdn = policies::checked_narrowing_cast<result_type, Policy>(dn, function);
-   return policies::checked_narrowing_cast<result_type, Policy>(sn, function);;
+   return policies::checked_narrowing_cast<result_type, Policy>(sn, function);
 }
 
 template <class T, class U, class V>

--- a/include/boost/math/special_functions/legendre.hpp
+++ b/include/boost/math/special_functions/legendre.hpp
@@ -1,4 +1,3 @@
-
 //  (C) Copyright John Maddock 2006.
 //  Use, modification and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
@@ -149,7 +148,7 @@ struct legendre_p_zero_func
       T Pn;
       T Pn_prime = detail::legendre_p_prime_imp(n, x, pol, &Pn);
       return std::pair<T, T>(Pn, Pn_prime); 
-   };
+   }
 };
 
 template <class T, class Policy>

--- a/include/boost/math/special_functions/next.hpp
+++ b/include/boost/math/special_functions/next.hpp
@@ -90,7 +90,7 @@ inline T get_smallest_value(boost::true_type const&)
    //
    static const T m = std::numeric_limits<T>::denorm_min();
 #ifdef BOOST_MATH_CHECK_SSE2
-   return (_mm_getcsr() & (_MM_FLUSH_ZERO_ON | 0x40)) ? tools::min_value<T>() : m;;
+   return (_mm_getcsr() & (_MM_FLUSH_ZERO_ON | 0x40)) ? tools::min_value<T>() : m;
 #else
    return ((tools::min_value<T>() / 2) == 0) ? tools::min_value<T>() : m;
 #endif
@@ -883,4 +883,3 @@ inline typename tools::promote_args<T>::type float_advance(const T& val, int dis
 }} // boost math namespaces
 
 #endif // BOOST_MATH_SPECIAL_NEXT_HPP
-


### PR DESCRIPTION
Fix Clang -Wextra-semi-stmt and Clang-tidy readability-simplify-boolean-expr warnings.