### PR TITLE
Fix reciprocal of min for mpfr/cpp_bin_float in continued fractions.

### DIFF
--- a/include/boost/math/tools/fraction.hpp
+++ b/include/boost/math/tools/fraction.hpp
@@ -73,7 +73,7 @@ namespace detail
    struct tiny_value
    {
       static T get() {
-         return tools::min_value<T>(); 
+         return 16*tools::min_value<T>();
       }
    };
    template <class T>
@@ -81,7 +81,7 @@ namespace detail
    {
       typedef typename T::value_type value_type;
       static T get() {
-         return tools::min_value<value_type>();
+         return 16*tools::min_value<value_type>();
       }
    };
 
@@ -128,7 +128,6 @@ inline typename detail::fraction_traits<Gen>::result_type continued_fraction_b(G
    D = 0;
 
    boost::uintmax_t counter(max_terms);
-
    do{
       v = g();
       D = traits::b(v) + traits::a(v) * D;

--- a/include/boost/math/tools/fraction.hpp
+++ b/include/boost/math/tools/fraction.hpp
@@ -72,6 +72,9 @@ namespace detail
    template <class T, bool = is_complex_type<T>::value>
    struct tiny_value
    {
+      // For float, double, and long double, 1/min_value<T>() is finite.
+      // But for mpfr_float and cpp_bin_float, 1/min_value<T>() is inf.
+      // Multiply the min by 16 so that the reciprocal doesn't overflow.
       static T get() {
          return 16*tools::min_value<T>();
       }
@@ -102,7 +105,7 @@ namespace detail
 // Note that the first a0 returned by generator Gen is discarded.
 //
 template <class Gen, class U>
-inline typename detail::fraction_traits<Gen>::result_type continued_fraction_b(Gen& g, const U& factor, boost::uintmax_t& max_terms) 
+inline typename detail::fraction_traits<Gen>::result_type continued_fraction_b(Gen& g, const U& factor, boost::uintmax_t& max_terms)
       BOOST_NOEXCEPT_IF(BOOST_MATH_IS_FLOAT(typename detail::fraction_traits<Gen>::result_type) && noexcept(std::declval<Gen>()()))
 {
    BOOST_MATH_STD_USING // ADL of std names
@@ -283,4 +286,3 @@ inline typename detail::fraction_traits<Gen>::result_type continued_fraction_a(G
 } // namespace boost
 
 #endif // BOOST_MATH_TOOLS_FRACTION_INCLUDED
-


### PR DESCRIPTION
The issue is identified [here](https://github.com/boostorg/multiprecision/issues/253).

The issue can be reproduced by calling `continued_fraction_b` with b0 = 0 and a mpfr result_type.