### PR TITLE
boost::math::pow is not constexpr #354

### DIFF
--- a/include/boost/math/special_functions/math_fwd.hpp
+++ b/include/boost/math/special_functions/math_fwd.hpp
@@ -1019,10 +1019,10 @@ namespace boost
 
    // pow:
    template <int N, typename T, class Policy>
-   typename tools::promote_args<T>::type pow(T base, const Policy& policy);
+   constexpr typename tools::promote_args<T>::type pow(T base, const Policy& policy);
 
    template <int N, typename T>
-   typename tools::promote_args<T>::type pow(T base);
+   constexpr typename tools::promote_args<T>::type pow(T base);
 
    // next:
    template <class T, class U, class Policy>

--- a/include/boost/math/special_functions/math_fwd.hpp
+++ b/include/boost/math/special_functions/math_fwd.hpp
@@ -1019,10 +1019,10 @@ namespace boost
 
    // pow:
    template <int N, typename T, class Policy>
-   constexpr typename tools::promote_args<T>::type pow(T base, const Policy& policy);
+   BOOST_CXX14_CONSTEXPR typename tools::promote_args<T>::type pow(T base, const Policy& policy);
 
    template <int N, typename T>
-   constexpr typename tools::promote_args<T>::type pow(T base);
+   BOOST_CXX14_CONSTEXPR typename tools::promote_args<T>::type pow(T base);
 
    // next:
    template <class T, class U, class Policy>

--- a/include/boost/math/special_functions/pow.hpp
+++ b/include/boost/math/special_functions/pow.hpp
@@ -35,7 +35,7 @@ template <int N, int M = N%2>
 struct positive_power
 {
     template <typename T>
-    static constexpr T result(T base)
+    static BOOST_CXX14_CONSTEXPR T result(T base)
     {
         T power = positive_power<N/2>::result(base);
         return power * power;
@@ -46,7 +46,7 @@ template <int N>
 struct positive_power<N, 1>
 {
     template <typename T>
-    static constexpr T result(T base)
+    static BOOST_CXX14_CONSTEXPR T result(T base)
     {
         T power = positive_power<N/2>::result(base);
         return base * power * power;
@@ -57,7 +57,7 @@ template <>
 struct positive_power<1, 1>
 {
     template <typename T>
-    static constexpr T result(T base){ return base; }
+    static BOOST_CXX14_CONSTEXPR T result(T base){ return base; }
 };
 
 
@@ -65,7 +65,7 @@ template <int N, bool>
 struct power_if_positive
 {
     template <typename T, class Policy>
-    static constexpr T result(T base, const Policy&)
+    static BOOST_CXX14_CONSTEXPR T result(T base, const Policy&)
     { return positive_power<N>::result(base); }
 };
 
@@ -73,7 +73,7 @@ template <int N>
 struct power_if_positive<N, false>
 {
     template <typename T, class Policy>
-    static constexpr T result(T base, const Policy& policy)
+    static BOOST_CXX14_CONSTEXPR T result(T base, const Policy& policy)
     {
         if (base == 0)
         {
@@ -92,7 +92,7 @@ template <>
 struct power_if_positive<0, true>
 {
     template <typename T, class Policy>
-    static constexpr T result(T base, const Policy& policy)
+    static BOOST_CXX14_CONSTEXPR T result(T base, const Policy& policy)
     {
         if (base == 0)
         {
@@ -126,14 +126,14 @@ struct select_power_if_positive
 
 
 template <int N, typename T, class Policy>
-constexpr inline typename tools::promote_args<T>::type pow(T base, const Policy& policy)
+BOOST_CXX14_CONSTEXPR inline typename tools::promote_args<T>::type pow(T base, const Policy& policy)
 { 
    typedef typename tools::promote_args<T>::type result_type;
    return detail::select_power_if_positive<N>::type::result(static_cast<result_type>(base), policy); 
 }
 
 template <int N, typename T>
-constexpr inline typename tools::promote_args<T>::type pow(T base)
+BOOST_CXX14_CONSTEXPR inline typename tools::promote_args<T>::type pow(T base)
 { return pow<N>(base, policies::policy<>()); }
 
 #ifdef BOOST_MSVC

--- a/include/boost/math/special_functions/pow.hpp
+++ b/include/boost/math/special_functions/pow.hpp
@@ -35,7 +35,7 @@ template <int N, int M = N%2>
 struct positive_power
 {
     template <typename T>
-    static T result(T base)
+    static constexpr T result(T base)
     {
         T power = positive_power<N/2>::result(base);
         return power * power;
@@ -46,7 +46,7 @@ template <int N>
 struct positive_power<N, 1>
 {
     template <typename T>
-    static T result(T base)
+    static constexpr T result(T base)
     {
         T power = positive_power<N/2>::result(base);
         return base * power * power;
@@ -57,7 +57,7 @@ template <>
 struct positive_power<1, 1>
 {
     template <typename T>
-    static T result(T base){ return base; }
+    static constexpr T result(T base){ return base; }
 };
 
 
@@ -65,7 +65,7 @@ template <int N, bool>
 struct power_if_positive
 {
     template <typename T, class Policy>
-    static T result(T base, const Policy&)
+    static constexpr T result(T base, const Policy&)
     { return positive_power<N>::result(base); }
 };
 
@@ -73,7 +73,7 @@ template <int N>
 struct power_if_positive<N, false>
 {
     template <typename T, class Policy>
-    static T result(T base, const Policy& policy)
+    static constexpr T result(T base, const Policy& policy)
     {
         if (base == 0)
         {
@@ -92,7 +92,7 @@ template <>
 struct power_if_positive<0, true>
 {
     template <typename T, class Policy>
-    static T result(T base, const Policy& policy)
+    static constexpr T result(T base, const Policy& policy)
     {
         if (base == 0)
         {
@@ -126,15 +126,14 @@ struct select_power_if_positive
 
 
 template <int N, typename T, class Policy>
-inline typename tools::promote_args<T>::type pow(T base, const Policy& policy)
+constexpr inline typename tools::promote_args<T>::type pow(T base, const Policy& policy)
 { 
    typedef typename tools::promote_args<T>::type result_type;
    return detail::select_power_if_positive<N>::type::result(static_cast<result_type>(base), policy); 
 }
 
-
 template <int N, typename T>
-inline typename tools::promote_args<T>::type pow(T base)
+constexpr inline typename tools::promote_args<T>::type pow(T base)
 { return pow<N>(base, policies::policy<>()); }
 
 #ifdef BOOST_MSVC

--- a/test/pow_test.cpp
+++ b/test/pow_test.cpp
@@ -194,7 +194,9 @@ BOOST_AUTO_TEST_CASE( test_main )
     test_with_big_exponents<boost::math::concepts::real_concept, -1>();
 #endif
 
+    #ifndef BOOST_NO_CXX14_CONSTEXPR
     static_assert(boost::math::pow<8>(2)==256, "Pow is not constexpr");
+    #endif
 
     test_return_types();
 

--- a/test/pow_test.cpp
+++ b/test/pow_test.cpp
@@ -194,6 +194,8 @@ BOOST_AUTO_TEST_CASE( test_main )
     test_with_big_exponents<boost::math::concepts::real_concept, -1>();
 #endif
 
+    static_assert(boost::math::pow<8>(2)==256, "Pow is not constexpr");
+
     test_return_types();
 
     test_error_policy();


### PR DESCRIPTION
Made pow constexpr as requested in issue #354. Forward declaring constexpr functions requires the language standard to be at least C++14. The if statements were left as is due to making them constexpr as well would raise the language standard to 17. The only change that would have is determining which of the return statements would compile. If you compile with -std=c++11 you will receive 6 [-Wc++14-extension] warnings but the results will remain as expected. Please let me know if you have any questions. 