### PR TITLE
Reduce unwanted double promotions

### DIFF
--- a/include/boost/math/special_functions/airy.hpp
+++ b/include/boost/math/special_functions/airy.hpp
@@ -175,7 +175,7 @@ T airy_ai_zero_imp(int m, const Policy& pol)
    }
 
    // Set up the initial guess for the upcoming root-finding.
-   const T guess_root = boost::math::detail::airy_zero::airy_ai_zero_detail::initial_guess<T>(m);
+   const T guess_root = boost::math::detail::airy_zero::airy_ai_zero_detail::initial_guess<T>(m, pol);
 
    // Select the maximum allowed iterations based on the number
    // of decimal digits in the numeric type T, being at least 12.
@@ -227,7 +227,7 @@ T airy_bi_zero_imp(int m, const Policy& pol)
         "The requested rank of the zero is %1%, but must be 1 or more !", static_cast<T>(m), pol);
    }
    // Set up the initial guess for the upcoming root-finding.
-   const T guess_root = boost::math::detail::airy_zero::airy_bi_zero_detail::initial_guess<T>(m);
+   const T guess_root = boost::math::detail::airy_zero::airy_bi_zero_detail::initial_guess<T>(m, pol);
 
    // Select the maximum allowed iterations based on the number
    // of decimal digits in the numeric type T, being at least 12.

--- a/include/boost/math/special_functions/beta.hpp
+++ b/include/boost/math/special_functions/beta.hpp
@@ -928,8 +928,8 @@ T beta_small_b_large_a_series(T a, T b, T x, T y, T s0, T mult, const Policy& po
 // For integer arguments we can relate the incomplete beta to the
 // complement of the binomial distribution cdf and use this finite sum.
 //
-template <class T>
-T binomial_ccdf(T n, T k, T x, T y)
+template <class T, class Policy>
+T binomial_ccdf(T n, T k, T x, T y, const Policy& pol)
 {
    BOOST_MATH_STD_USING // ADL of std names
 
@@ -951,14 +951,14 @@ T binomial_ccdf(T n, T k, T x, T y)
       int start = itrunc(n * x);
       if(start <= k + 1)
          start = itrunc(k + 2);
-      result = pow(x, start) * pow(y, n - start) * boost::math::binomial_coefficient<T>(itrunc(n), itrunc(start));
+      result = pow(x, start) * pow(y, n - start) * boost::math::binomial_coefficient<T>(itrunc(n), itrunc(start), pol);
       if(result == 0)
       {
          // OK, starting slightly above the mode didn't work,
          // we'll have to sum the terms the old fashioned way:
          for(unsigned i = start - 1; i > k; --i)
          {
-            result += pow(x, (int)i) * pow(y, n - i) * boost::math::binomial_coefficient<T>(itrunc(n), itrunc(i));
+            result += pow(x, (int)i) * pow(y, n - i) * boost::math::binomial_coefficient<T>(itrunc(n), itrunc(i), pol);
          }
       }
       else
@@ -1288,7 +1288,7 @@ T ibeta_imp(T a, T b, T x, const Policy& pol, bool inv, bool normalised, T* p_de
             // relate to the binomial distribution and use a finite sum:
             T k = a - 1;
             T n = b + k;
-            fract = binomial_ccdf(n, k, x, y);
+            fract = binomial_ccdf(n, k, x, y, pol);
             if(!normalised)
                fract *= boost::math::beta(a, b, pol);
             BOOST_MATH_INSTRUMENT_VARIABLE(fract);

--- a/include/boost/math/special_functions/binomial.hpp
+++ b/include/boost/math/special_functions/binomial.hpp
@@ -63,7 +63,13 @@ T binomial_coefficient(unsigned n, unsigned k, const Policy& pol)
 template <>
 inline float binomial_coefficient<float, policies::policy<> >(unsigned n, unsigned k, const policies::policy<>& pol)
 {
-   return policies::checked_narrowing_cast<float, policies::policy<> >(binomial_coefficient<double>(n, k, pol), "boost::math::binomial_coefficient<%1%>(unsigned,unsigned)");
+   typedef policies::normalise<
+       policies::policy<>,
+       policies::promote_float<true>,
+       policies::promote_double<false>,
+       policies::discrete_quantile<>,
+       policies::assert_undefined<> >::type forwarding_policy;
+   return policies::checked_narrowing_cast<float, forwarding_policy>(binomial_coefficient<double>(n, k, forwarding_policy()), "boost::math::binomial_coefficient<%1%>(unsigned,unsigned)");
 }
 
 template <class T>

--- a/include/boost/math/special_functions/detail/airy_ai_bi_zero.hpp
+++ b/include/boost/math/special_functions/detail/airy_ai_bi_zero.hpp
@@ -31,13 +31,13 @@
 
     namespace airy_zero
     {
-      template<class T>
-      T equation_as_10_4_105(const T& z)
+      template<class T, class Policy>
+      T equation_as_10_4_105(const T& z, const Policy& pol)
       {
         const T one_over_z        (T(1) / z);
         const T one_over_z_squared(one_over_z * one_over_z);
 
-        const T z_pow_third     (boost::math::cbrt(z));
+        const T z_pow_third     (boost::math::cbrt(z, pol));
         const T z_pow_two_thirds(z_pow_third * z_pow_third);
 
         // Implement the top line of Eq. 10.4.105.
@@ -53,8 +53,8 @@
 
       namespace airy_ai_zero_detail
       {
-        template<class T>
-        T initial_guess(const int m)
+        template<class T, class Policy>
+        T initial_guess(const int m, const Policy& pol)
         {
           T guess;
 
@@ -74,7 +74,7 @@
             default:
             {
               const T t(((boost::math::constants::pi<T>() * 3) * ((T(m) * 4) - 1)) / 8);
-              guess = -boost::math::detail::airy_zero::equation_as_10_4_105(t);
+              guess = -boost::math::detail::airy_zero::equation_as_10_4_105(t, pol);
               break;
             }
           }
@@ -104,8 +104,8 @@
 
       namespace airy_bi_zero_detail
       {
-        template<class T>
-        T initial_guess(const int m)
+        template<class T, class Policy>
+        T initial_guess(const int m, const Policy& pol)
         {
           T guess;
 
@@ -125,7 +125,7 @@
             default:
             {
               const T t(((boost::math::constants::pi<T>() * 3) * ((T(m) * 4) - 3)) / 8);
-              guess = -boost::math::detail::airy_zero::equation_as_10_4_105(t);
+              guess = -boost::math::detail::airy_zero::equation_as_10_4_105(t, pol);
               break;
             }
           }

--- a/include/boost/math/special_functions/detail/bessel_ik.hpp
+++ b/include/boost/math/special_functions/detail/bessel_ik.hpp
@@ -104,7 +104,7 @@ int temme_ik(T v, T x, T* K, T* K1, const Policy& pol)
     b = exp(v * a);
     sigma = -a * v;
     c = abs(v) < tools::epsilon<T>() ?
-       T(1) : T(boost::math::sin_pi(v) / (v * pi<T>()));
+       T(1) : T(boost::math::sin_pi(v, pol) / (v * pi<T>()));
     d = abs(sigma) < tools::epsilon<T>() ?
         T(1) : T(sinh(sigma) / sigma);
     gamma1 = abs(v) < tools::epsilon<T>() ?
@@ -424,7 +424,7 @@ int bessel_ik(T v, T x, T* I, T* K, int kind, const Policy& pol)
     if (reflect)
     {
         T z = (u + n % 2);
-        T fact = (2 / pi<T>()) * (boost::math::sin_pi(z) * Kv);
+        T fact = (2 / pi<T>()) * (boost::math::sin_pi(z, pol) * Kv);
         if(fact == 0)
            *I = Iv;
         else if(tools::max_value<T>() * scale < fact)

--- a/include/boost/math/special_functions/detail/bessel_jn.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jn.hpp
@@ -51,7 +51,7 @@ T bessel_jn(int n, T x, const Policy& pol)
     // Special cases:
     //
     if(asymptotic_bessel_large_x_limit(T(n), x))
-       return factor * asymptotic_bessel_j_large_x_2<T>(T(n), x);
+       return factor * asymptotic_bessel_j_large_x_2<T>(T(n), x, pol);
     if (n == 0)
     {
         return factor * bessel_j0(x);

--- a/include/boost/math/special_functions/detail/bessel_jy.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jy.hpp
@@ -376,13 +376,13 @@ namespace boost { namespace math {
          {
             if(kind&need_y)
             {
-               Yv = asymptotic_bessel_y_large_x_2(v, x);
+               Yv = asymptotic_bessel_y_large_x_2(v, x, pol);
             }
             else
                Yv = std::numeric_limits<T>::quiet_NaN(); // any value will do, we're not using it.
             if(kind&need_j)
             {
-               Jv = asymptotic_bessel_j_large_x_2(v, x);
+               Jv = asymptotic_bessel_j_large_x_2(v, x, pol);
             }
             else
                Jv = std::numeric_limits<T>::quiet_NaN(); // any value will do, we're not using it.
@@ -405,8 +405,8 @@ namespace boost { namespace math {
             T mod_v = fmod(T(v / 2 + 0.25f), T(2));
             T sx = sin(x);
             T cx = cos(x);
-            T sv = sin_pi(mod_v);
-            T cv = cos_pi(mod_v);
+            T sv = boost::math::sin_pi(mod_v, pol);
+            T cv = boost::math::cos_pi(mod_v, pol);
 
             T sc = sx * cv - sv * cx; // == sin(chi);
             T cc = cx * cv + sx * sv; // == cos(chi);

--- a/include/boost/math/special_functions/detail/bessel_jy_asym.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jy_asym.hpp
@@ -62,8 +62,8 @@ T asymptotic_bessel_phase_mx(T v, T x)
    return s;
 }
 
-template <class T>
-inline T asymptotic_bessel_y_large_x_2(T v, T x)
+template <class T, class Policy>
+inline T asymptotic_bessel_y_large_x_2(T v, T x, const Policy& pol)
 {
    // See A&S 9.2.19.
    BOOST_MATH_STD_USING
@@ -80,8 +80,8 @@ inline T asymptotic_bessel_y_large_x_2(T v, T x)
    //
    T cx = cos(x);
    T sx = sin(x);
-   T ci = cos_pi(v / 2 + 0.25f);
-   T si = sin_pi(v / 2 + 0.25f);
+   T ci = boost::math::cos_pi(v / 2 + 0.25f, pol);
+   T si = boost::math::sin_pi(v / 2 + 0.25f, pol);
    T sin_phase = sin(phase) * (cx * ci + sx * si) + cos(phase) * (sx * ci - cx * si);
    BOOST_MATH_INSTRUMENT_CODE(sin(phase));
    BOOST_MATH_INSTRUMENT_CODE(cos(x));
@@ -90,8 +90,8 @@ inline T asymptotic_bessel_y_large_x_2(T v, T x)
    return sin_phase * ampl;
 }
 
-template <class T>
-inline T asymptotic_bessel_j_large_x_2(T v, T x)
+template <class T, class Policy>
+inline T asymptotic_bessel_j_large_x_2(T v, T x, const Policy& pol)
 {
    // See A&S 9.2.19.
    BOOST_MATH_STD_USING
@@ -112,8 +112,8 @@ inline T asymptotic_bessel_j_large_x_2(T v, T x)
    BOOST_MATH_INSTRUMENT_CODE(sin(x));
    T cx = cos(x);
    T sx = sin(x);
-   T ci = cos_pi(v / 2 + 0.25f);
-   T si = sin_pi(v / 2 + 0.25f);
+   T ci = boost::math::cos_pi(v / 2 + 0.25f, pol);
+   T si = boost::math::sin_pi(v / 2 + 0.25f, pol);
    T sin_phase = cos(phase) * (cx * ci + sx * si) - sin(phase) * (sx * ci - cx * si);
    BOOST_MATH_INSTRUMENT_VARIABLE(sin_phase);
    return sin_phase * ampl;

--- a/include/boost/math/special_functions/detail/bessel_jy_derivatives_series.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jy_derivatives_series.hpp
@@ -193,7 +193,7 @@ inline T bessel_y_derivative_small_z_series(T v, T x, const Policy& pol)
    p = pow(x / 2, v - 1) / 2;
    if (!need_logs)
    {
-      prefix = boost::math::tgamma(-v, pol) * boost::math::cos_pi(v) * p / boost::math::constants::pi<T>();
+      prefix = boost::math::tgamma(-v, pol) * boost::math::cos_pi(v, pol) * p / boost::math::constants::pi<T>();
    }
    else
    {

--- a/include/boost/math/special_functions/detail/bessel_jy_series.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jy_series.hpp
@@ -190,7 +190,7 @@ inline T bessel_y_small_z_series(T v, T x, T* pscale, const Policy& pol)
 
    if(!need_logs)
    {
-      prefix = boost::math::tgamma(-v, pol) * boost::math::cos_pi(v) * p / constants::pi<T>();
+      prefix = boost::math::tgamma(-v, pol) * boost::math::cos_pi(v, pol) * p / constants::pi<T>();
    }
    else
    {
@@ -240,7 +240,7 @@ T bessel_yn_small_z(int n, T z, T* scale, const Policy& pol)
    else
    {
       T p = pow(z / 2, n);
-      T result = -((boost::math::factorial<T>(n - 1) / constants::pi<T>()));
+      T result = -((boost::math::factorial<T>(n - 1, pol) / constants::pi<T>()));
       if(p * tools::max_value<T>() < result)
       {
          T div = tools::max_value<T>() / 8;

--- a/include/boost/math/special_functions/detail/bessel_jy_zero.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jy_zero.hpp
@@ -83,8 +83,8 @@
         const T zeta;
       };
 
-      template<class T>
-      static T equation_as_9_5_26(const T& v, const T& ai_bi_root)
+      template<class T, class Policy>
+      static T equation_as_9_5_26(const T& v, const T& ai_bi_root, const Policy& pol)
       {
         BOOST_MATH_STD_USING // ADL of std names, needed for log, sqrt.
 
@@ -105,7 +105,7 @@
         // to refine the value of the estimate of the root of z
         // as a function of zeta.
 
-        const T v_pow_third(boost::math::cbrt(v));
+        const T v_pow_third(boost::math::cbrt(v, pol));
         const T v_pow_minus_two_thirds(T(1) / (v_pow_third * v_pow_third));
 
         // Obtain zeta using the order v combined with the m'th root of
@@ -165,10 +165,10 @@
 
       namespace cyl_bessel_j_zero_detail
       {
-        template<class T>
-        T equation_nist_10_21_40_a(const T& v)
+        template<class T, class Policy>
+        T equation_nist_10_21_40_a(const T& v, const Policy& pol)
         {
-          const T v_pow_third(boost::math::cbrt(v));
+          const T v_pow_third(boost::math::cbrt(v, pol));
           const T v_pow_minus_two_thirds(T(1) / (v_pow_third * v_pow_third));
 
           return v * (((((                         + T(0.043)
@@ -355,7 +355,7 @@
             else
             {
               // For larger v, use the first line of Eqs. 10.21.40 in the NIST Handbook.
-              guess = boost::math::detail::bessel_zero::cyl_bessel_j_zero_detail::equation_nist_10_21_40_a(v);
+              guess = boost::math::detail::bessel_zero::cyl_bessel_j_zero_detail::equation_nist_10_21_40_a(v, pol);
             }
           }
           else
@@ -370,10 +370,10 @@
             else
             {
               // Get an estimate of the m'th root of airy_ai.
-              const T airy_ai_root(boost::math::detail::airy_zero::airy_ai_zero_detail::initial_guess<T>(m));
+              const T airy_ai_root(boost::math::detail::airy_zero::airy_ai_zero_detail::initial_guess<T>(m, pol));
 
               // Use Eq. 9.5.26 in the A&S Handbook.
-              guess = boost::math::detail::bessel_zero::equation_as_9_5_26(v, airy_ai_root);
+              guess = boost::math::detail::bessel_zero::equation_as_9_5_26(v, airy_ai_root, pol);
             }
           }
 
@@ -383,10 +383,10 @@
 
       namespace cyl_neumann_zero_detail
       {
-        template<class T>
-        T equation_nist_10_21_40_b(const T& v)
+        template<class T, class Policy>
+        T equation_nist_10_21_40_b(const T& v, const Policy& pol)
         {
-          const T v_pow_third(boost::math::cbrt(v));
+          const T v_pow_third(boost::math::cbrt(v, pol));
           const T v_pow_minus_two_thirds(T(1) / (v_pow_third * v_pow_third));
 
           return v * (((((                         - T(0.001)
@@ -586,7 +586,7 @@
             else
             {
               // For larger v, use the second line of Eqs. 10.21.40 in the NIST Handbook.
-              guess = boost::math::detail::bessel_zero::cyl_neumann_zero_detail::equation_nist_10_21_40_b(v);
+              guess = boost::math::detail::bessel_zero::cyl_neumann_zero_detail::equation_nist_10_21_40_b(v, pol);
             }
           }
           else
@@ -601,10 +601,10 @@
             else
             {
               // Get an estimate of the m'th root of airy_bi.
-              const T airy_bi_root(boost::math::detail::airy_zero::airy_bi_zero_detail::initial_guess<T>(m));
+              const T airy_bi_root(boost::math::detail::airy_zero::airy_bi_zero_detail::initial_guess<T>(m, pol));
 
               // Use Eq. 9.5.26 in the A&S Handbook.
-              guess = boost::math::detail::bessel_zero::equation_as_9_5_26(v, airy_bi_root);
+              guess = boost::math::detail::bessel_zero::equation_as_9_5_26(v, airy_bi_root, pol);
             }
           }
 

--- a/include/boost/math/special_functions/detail/bessel_yn.hpp
+++ b/include/boost/math/special_functions/detail/bessel_yn.hpp
@@ -62,7 +62,7 @@ T bessel_yn(int n, T x, const Policy& pol)
     }
     else if(asymptotic_bessel_large_x_limit(n, x))
     {
-       value = factor * asymptotic_bessel_y_large_x_2(static_cast<T>(abs(n)), x);
+       value = factor * asymptotic_bessel_y_large_x_2(static_cast<T>(abs(n)), x, pol);
     }
     else if (n == 0)
     {

--- a/include/boost/math/special_functions/detail/hypergeometric_1F1_bessel.hpp
+++ b/include/boost/math/special_functions/detail/hypergeometric_1F1_bessel.hpp
@@ -578,7 +578,7 @@
         boost::uintmax_t max_iter = boost::math::policies::get_max_series_iterations<Policy>();
         T result = boost::math::tools::sum_series(s, boost::math::policies::get_epsilon<T, Policy>(), max_iter);
         boost::math::policies::check_series_iterations<T>("boost::math::hypergeometric_1F1_AS_13_3_6<%1%>(%1%,%1%,%1%)", max_iter, pol);
-        result *= boost::math::tgamma(b_minus_a - 0.5f) * pow(z / 4, -b_minus_a + 0.5f);
+        result *= boost::math::tgamma(b_minus_a - 0.5f, pol) * pow(z / 4, -b_minus_a + 0.5f);
         int scale = itrunc(z / 2);
         log_scaling += scale;
         log_scaling += s.scaling();

--- a/include/boost/math/special_functions/detail/polygamma.hpp
+++ b/include/boost/math/special_functions/detail/polygamma.hpp
@@ -459,7 +459,7 @@ namespace boost { namespace math { namespace detail{
      if(s == 0)
         return sum * boost::math::policies::raise_overflow_error<T>(function, 0, pol);
      power_terms -= log(fabs(s)) * (n + 1);
-     power_terms += boost::math::lgamma(T(n));
+     power_terms += boost::math::lgamma(T(n), pol);
      power_terms += log(fabs(sum));
 
      if(power_terms > boost::math::tools::log_max_value<T>())

--- a/include/boost/math/special_functions/detail/t_distribution_inv.hpp
+++ b/include/boost/math/special_functions/detail/t_distribution_inv.hpp
@@ -284,7 +284,7 @@ T inverse_students_t(T df, T u, T v, const Policy& pol, bool* pexact = 0)
             // supplement:
             //
             T a = 4 * (u - u * u);//1 - 4 * (u - 0.5f) * (u - 0.5f);
-            T b = boost::math::cbrt(a);
+            T b = boost::math::cbrt(a, pol);
             static const T c = static_cast<T>(0.85498797333834849467655443627193);
             T p = 6 * (1 + c * (1 / b - 1));
             T p0;

--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -576,7 +576,7 @@ inline T log_gamma_near_1(const T& z, Policy const& pol)
 
    do
    {
-      term = power_term * boost::math::polygamma(n - 1, T(1));
+      term = power_term * boost::math::polygamma(n - 1, T(1), pol);
       result += term;
       ++n;
       power_term *= z / n;


### PR DESCRIPTION
A small audit of the Bessel and beta functions revealed a number of places where primitive functions were being called without a `Policy` argument, thus introducing double- and float-promotion in violation of the user-provided policy. The primitive functions in question include `cbrt`, `cos_pi`, `sin_pi`, `lgamma`, `tgamma`, and `polygamma`.

This commit passes the `Policy` argument down the call chain in several locations. As part of this work, a number of internal functions have had a `Policy` argument added to them. These functions include:

* `airy_ai_zero_detail::initial_guess`
* `airy_bi_zero_detail::initial_guess`
* `airy_zero::equation_as_10_4_105`
* `binomial_ccdf` (in special_functions/beta.hpp)
* `bessel_zero::asymptotic_bessel_j_large_x_2`
* `bessel_zero::asymptotic_bessel_y_large_x_2`
* `bessel_zero::equation_as_9_5_26`
* `bessel_zero::cyl_neumann_zero_detail::equation_nist_10_21_40_a`
* `bessel_zero::cyl_neumann_zero_detail::equation_nist_10_21_40_b`

The above functions do not have any user-facing documentation, and so I did not preserve their non-policy function signatures.

I do not know of a good way to verify the absence of float-promotion deep down a call chain, and so I have not added any new tests. The existing tests in the `special_fun` and `distribution_tests` suites continue to pass (on my machine, at any rate).

See #398