### PR TITLE
Add missing header

### DIFF
--- a/include/boost/math/special_functions/detail/fp_traits.hpp
+++ b/include/boost/math/special_functions/detail/fp_traits.hpp
@@ -21,6 +21,7 @@ With these techniques, the code could be simplified.
 #endif
 
 #include <cstring>
+#include <limits>
 
 #include <boost/assert.hpp>
 #include <boost/cstdint.hpp>


### PR DESCRIPTION
This patch allows the header to be built standalone, as part of clang C++ modules builds.