### PR TITLE
Removed feature macro test __cpp_lib_nonmember_container_access

### DIFF
--- a/include/boost/math/interpolators/catmull_rom.hpp
+++ b/include/boost/math/interpolators/catmull_rom.hpp
@@ -18,7 +18,7 @@
 
 namespace std_workaround {
 
-#if defined(__cpp_lib_nonmember_container_access) || (defined(BOOST_MSVC) && (BOOST_MSVC >= 1900))
+#if __cplusplus >= 201703 || (defined(BOOST_MSVC) && (BOOST_MSVC >= 1900))
    using std::size;
 #else
    template <class C>


### PR DESCRIPTION
Removed feature macro test __cpp_lib_nonmember_container_access
since it is available from c++20.
Used __cplusplus version instead.