### PR TITLE
Quantile-quantile plots

### DIFF
--- a/doc/statistics/qq_plot.qbk
+++ b/doc/statistics/qq_plot.qbk
@@ -1,0 +1,34 @@
+[/
+Copyright (c) 2019 Nick Thompson
+Use, modification and distribution are subject to the
+Boost Software License, Version 1.0. (See accompanying file
+LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+]
+
+[section:qq_plot Quantile-quantile plots]
+
+[heading Synopsis]
+
+```
+#include <boost/math/statistics/qq_plot.hpp>
+
+namespace boost::math::statistics {
+
+template<typename RandomAccessContainer>
+class qq_plot {
+public:
+    qq_plot(RandomAccessContainer&& x, RandomAccessContainer&& y);
+
+    template<typename Real>
+    qq_plot(RandomAccessContainer&& x, boost::math::distribution<Real>const & dist);
+
+}
+}
+```
+
+[heading Background]
+
+A quantile-quantile plot graphically gives evidence as to whether two datasets are samples of the same distribution, or if a dataset is drawn from a given distribution.
+
+[endsect]
+[/section:qq_plot]

--- a/include/boost/math/distributions/gauss_kuzmin.hpp
+++ b/include/boost/math/distributions/gauss_kuzmin.hpp
@@ -1,0 +1,59 @@
+//  Copyright Nick Thompson, 2020.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_DISTRIBUTIONS_GAUSS_KUZMIN_HPP
+#define BOOST_MATH_DISTRIBUTIONS_GAUSS_KUZMIN_HPP
+
+#include <cmath>
+
+namespace boost{ namespace math{
+
+template <typename Real, typename Z = uint64_t>
+class gauss_kuzmin
+{
+public:
+    gauss_kuzmin() {}
+
+    Real pdf(Z k) const {
+       using log1p;
+       using log2;
+       Real x = -Real(1)/Real( (k+1)*(k+1) );
+       return -log1p(x)/log2(e);
+    }
+
+    Real cdf(Z k) const {
+       using log2;
+       Real arg = Real(k+1)/Real(k+2);
+       return 1 + log2(arg);
+    }
+
+    Real mean() const {
+       return std::numeric_limits<Real>::infinity();
+    }
+
+    Z median() const { return 2; }
+
+    Z mode() const { return 1; }
+
+    Real variance() const {
+       return std::numeric_limits<Real>::infinity();
+    }
+
+    Real skewness() const {
+       return std::numeric_limits<Real>::quiet_NaN();
+    }
+
+    Real kurtosis() const {
+       return std::numeric_limits<Real>::quiet_NaN();
+    }
+
+    Real entropy() const {
+        // TODO: Fix this! Also, should it be in nats or bits?
+        // See: https://scicomp.stackexchange.com/questions/35444/accurate-computation-of-gauss-kuzmin-entropy
+        return 3.4325275147757390994337806344778410601013532228057895;
+    }
+};
+
+#endif


### PR DESCRIPTION
Produce quantile-quantile plots. Will be similar in style to the ULPs plot. See [qqnorm](https://stat.ethz.ch/R-manual/R-devel/library/stats/html/qqnorm.html) of R or Mathematica's [QuantilePlot](https://reference.wolfram.com/language/StatisticalPlots/ref/QuantilePlot.html).