### PR TITLE
Add missing include

### DIFF
--- a/include/boost/math/differentiation/autodiff.hpp
+++ b/include/boost/math/differentiation/autodiff.hpp
@@ -19,6 +19,7 @@
 #include <boost/math/special_functions/lambert_w.hpp>
 #include <boost/math/tools/config.hpp>
 #include <boost/math/tools/promotion.hpp>
+#include <boost/type_traits/decay.hpp>
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
This patch makes the header able to be built standalone, making possible C++ clang modules builds.