### PR TITLE
Add missing include

### DIFF
--- a/include/boost/math/special_functions/detail/bernoulli_details.hpp
+++ b/include/boost/math/special_functions/detail/bernoulli_details.hpp
@@ -13,6 +13,7 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/math/tools/toms748_solve.hpp>
 #include <boost/math/tools/cxx03_warn.hpp>
+#include <atomic>
 #include <vector>
 
 namespace boost{ namespace math{ namespace detail{


### PR DESCRIPTION
This patch makes the header able to be built standalone, making possible C++ clang modules builds.@vgvassilev