### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Utility functions for dealing with floating point arithmetic, includes functions
 
 ### Specific Width Floating Point Types
 
-A set of typedefs similar to those provided by <cstdint> but for floating point types.
+A set of typedefs similar to those provided by `<cstdint>` but for floating point types.
 
 ### Mathematical Constants
 


### PR DESCRIPTION
Here are the snapshots:

Before:
![before](https://user-images.githubusercontent.com/66873825/93472494-593b2f80-f912-11ea-9a03-ce48d333158f.jpg)

After:
![after](https://user-images.githubusercontent.com/66873825/93472548-6d7f2c80-f912-11ea-8a73-6febd5a67153.jpg)
