### PR TITLE
Fix for issue #459

### DIFF
--- a/include/boost/math/distributions/beta.hpp
+++ b/include/boost/math/distributions/beta.hpp
@@ -382,6 +382,13 @@ namespace boost
         return result;
       }
       using boost::math::beta;
+
+      // Corner case: check_x ensures x element of [0, 1], but PDF is 0 for x = 0 and x = 1. PDF EQN:
+      // https://wikimedia.org/api/rest_v1/media/math/render/svg/125fdaa41844a8703d1a8610ac00fbf3edacc8e7
+      if(x == 0 || x == 1)
+      {
+        return RealType(0);
+      }
       return ibeta_derivative(a, b, x, Policy());
     } // pdf
 

--- a/test/test_beta_dist.cpp
+++ b/test/test_beta_dist.cpp
@@ -562,8 +562,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 
    // Check a few values using double.
    BOOST_CHECK_EQUAL(pdf(mybeta11, 1), 0);   // is uniform unity over (0, 1) 
-   BOOST_CHECK_EQUAL(pdf(mybeta11, 0.5), 1); // https://www.wolframalpha.com/input/?i=beta+distribution+pdf+alpha+%3D+1%2C+beta+%3D+1
-   BOOST_CHECK_EQUAL(pdf(mybeta11, 0), 0);
+   BOOST_CHECK_EQUAL(pdf(mybeta11, 0), 0);   // https://www.wolframalpha.com/input/?i=beta+distribution+pdf+alpha+%3D+1%2C+beta+%3D+1
    // Although these next three have an exact result, internally they're
    // *not* treated as special cases, and may be out by a couple of eps:
    BOOST_CHECK_CLOSE_FRACTION(pdf(mybeta11, 0.5), 1.0, 5*std::numeric_limits<double>::epsilon());

--- a/test/test_beta_dist.cpp
+++ b/test/test_beta_dist.cpp
@@ -197,11 +197,11 @@ void test_spots(RealType)
   BOOST_CHECK_EQUAL( // a = b = 1 is uniform distribution.
      pdf(beta_distribution<RealType>(static_cast<RealType>(1), static_cast<RealType>(1)),
      static_cast<RealType>(1)),  // x
-     static_cast<RealType>(1));
+     static_cast<RealType>(0));
   BOOST_CHECK_EQUAL(
      pdf(beta_distribution<RealType>(static_cast<RealType>(1), static_cast<RealType>(1)),
      static_cast<RealType>(0)),  // x
-     static_cast<RealType>(1));
+     static_cast<RealType>(0));
   BOOST_CHECK_CLOSE_FRACTION(
      pdf(beta_distribution<RealType>(static_cast<RealType>(1), static_cast<RealType>(1)),
      static_cast<RealType>(0.5)),  // x
@@ -561,8 +561,9 @@ BOOST_AUTO_TEST_CASE( test_main )
    beta_distribution<> mybetaH3(0.5, 3.); //
 
    // Check a few values using double.
-   BOOST_CHECK_EQUAL(pdf(mybeta11, 1), 1); // is uniform unity over 0 to 1,
-   BOOST_CHECK_EQUAL(pdf(mybeta11, 0), 1); // including zero and unity.
+   BOOST_CHECK_EQUAL(pdf(mybeta11, 1), 0);   // is uniform unity over (0, 1) 
+   BOOST_CHECK_EQUAL(pdf(mybeta11, 0.5), 1); // https://www.wolframalpha.com/input/?i=beta+distribution+pdf+alpha+%3D+1%2C+beta+%3D+1
+   BOOST_CHECK_EQUAL(pdf(mybeta11, 0), 0);
    // Although these next three have an exact result, internally they're
    // *not* treated as special cases, and may be out by a couple of eps:
    BOOST_CHECK_CLOSE_FRACTION(pdf(mybeta11, 0.5), 1.0, 5*std::numeric_limits<double>::epsilon());


### PR DESCRIPTION
Fixes issue #459: corner case where check_x is valid [0, 1], but PDF is 0 for x = 0 or x =1