### PR TITLE
Fix for issue #464

### DIFF
--- a/include/boost/math/quaternion.hpp
+++ b/include/boost/math/quaternion.hpp
@@ -458,16 +458,16 @@ operator + (const T1& a, const quaternion<T2>& b)
    return quaternion<T2>(static_cast<T2>(b.R_component_1() + a), b.R_component_2(), b.R_component_3(), b.R_component_4());
 }
 template <class T1, class T2>
-inline BOOST_CONSTEXPR typename boost::enable_if_c<boost::is_convertible<T2, T1>::value, quaternion<T1> >::type
+inline BOOST_CXX14_CONSTEXPR typename boost::enable_if_c<boost::is_convertible<T2, T1>::value, quaternion<T1> >::type
 operator + (const quaternion<T1>& a, const std::complex<T2>& b)
 {
    return quaternion<T1>(a.R_component_1() + std::real(b), a.R_component_2() + std::imag(b), a.R_component_3(), a.R_component_4());
 }
 template <class T1, class T2>
-inline BOOST_CONSTEXPR typename boost::enable_if_c<boost::is_convertible<T1, T2>::value, quaternion<T2> >::type
+inline BOOST_CXX14_CONSTEXPR typename boost::enable_if_c<boost::is_convertible<T1, T2>::value, quaternion<T2> >::type
 operator + (const std::complex<T1>& a, const quaternion<T2>& b)
 {
-   return quaternion<T1>(b.R_component_1() + real(a), b.R_component_2() + imag(a), b.R_component_3(), b.R_component_4());
+   return quaternion<T1>(b.R_component_1() + std::real(a), b.R_component_2() + std::imag(a), b.R_component_3(), b.R_component_4());
 }
 template <class T>
 inline BOOST_CONSTEXPR quaternion<T> operator + (const quaternion<T>& a, const quaternion<T>& b)
@@ -488,16 +488,16 @@ operator - (const T1& a, const quaternion<T2>& b)
    return quaternion<T2>(static_cast<T2>(a - b.R_component_1()), -b.R_component_2(), -b.R_component_3(), -b.R_component_4());
 }
 template <class T1, class T2>
-inline BOOST_CONSTEXPR typename boost::enable_if_c<boost::is_convertible<T2, T1>::value, quaternion<T1> >::type
+inline BOOST_CXX14_CONSTEXPR typename boost::enable_if_c<boost::is_convertible<T2, T1>::value, quaternion<T1> >::type
 operator - (const quaternion<T1>& a, const std::complex<T2>& b)
 {
    return quaternion<T1>(a.R_component_1() - std::real(b), a.R_component_2() - std::imag(b), a.R_component_3(), a.R_component_4());
 }
 template <class T1, class T2>
-inline BOOST_CONSTEXPR typename boost::enable_if_c<boost::is_convertible<T1, T2>::value, quaternion<T2> >::type
+inline BOOST_CXX14_CONSTEXPR typename boost::enable_if_c<boost::is_convertible<T1, T2>::value, quaternion<T2> >::type
 operator - (const std::complex<T1>& a, const quaternion<T2>& b)
 {
-   return quaternion<T1>(real(a) - b.R_component_1(), imag(a) - b.R_component_2(), -b.R_component_3(), -b.R_component_4());
+   return quaternion<T1>(std::real(a) - b.R_component_1(), std::imag(a) - b.R_component_2(), -b.R_component_3(), -b.R_component_4());
 }
 template <class T>
 inline BOOST_CONSTEXPR quaternion<T> operator - (const quaternion<T>& a, const quaternion<T>& b)

--- a/test/quaternion_constexpr_test.cpp
+++ b/test/quaternion_constexpr_test.cpp
@@ -91,14 +91,10 @@ int main()
 
    constexpr qt q10 = q1 + d1;
    constexpr qt q11 = d1 + q1;
-   constexpr qt q12 = c2 + q1;
-   constexpr qt q13 = q1 + c2;
    constexpr qt q14 = q1 + q2;
 
    constexpr qt q15 = q1 - d1;
    constexpr qt q16 = d1 - q1;
-   constexpr qt q17 = c2 - q1;
-   constexpr qt q18 = q1 - c2;
    constexpr qt q19 = q1 - q2;
 
    constexpr qt q20 = q1 * d1;
@@ -129,13 +125,9 @@ int main()
    (void)c3;
    (void)q10;
    (void)q11;
-   (void)q12;
-   (void)q13;
    (void)q14;
    (void)q15;
    (void)q16;
-   (void)q17;
-   (void)q18;
    (void)q19;
    (void)q20;
    (void)q21;
@@ -156,7 +148,18 @@ int main()
 
 #ifndef BOOST_NO_CXX14_CONSTEXPR
 
+   constexpr qt q12 = c2 + q1;
+   constexpr qt q13 = q1 + c2;
+   
+   constexpr qt q17 = c2 - q1;
+   constexpr qt q18 = q1 - c2;
+   
    constexpr qt q24 = full_constexpr_test(q5, q5 + 1, 3.2, q5.C_component_1());
+   
+   (void)q12;
+   (void)q13;
+   (void)q17;
+   (void)q18;
    (void)q24;
 
 #endif


### PR DESCRIPTION
Fix for issue #464. `std::real` and `std::imag` did not become constexpr until c++14. Change function signature from `BOOST_CONSTEXPR` to `BOOST_CXX14_CONSTEXPR`.