### PR TITLE
Update to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ inspect.html
 test/cuda
 *.DS_Store
 /**/*.dSYM/
+**/.temps/*
+build/*
+.vscode/*


### PR DESCRIPTION
Some small updates to the .gitignore. `**/.temps/*` is for b2 build artifacts and `build/*` is for all others (e.g. gcc with -MMD flag). `.vscode` for VSCode config files.