### PR TITLE
Fix for issue #430

### DIFF
--- a/include/boost/math/special_functions/round.hpp
+++ b/include/boost/math/special_functions/round.hpp
@@ -82,8 +82,9 @@ template <class T, class Policy>
 inline int iround(const T& v, const Policy& pol)
 {
    BOOST_MATH_STD_USING
+   typedef typename tools::promote_args<T>::type result_type;
    T r = boost::math::round(v, pol);
-   if((r > (std::numeric_limits<int>::max)()) || (r < (std::numeric_limits<int>::min)()))
+   if((r > static_cast<result_type>(std::numeric_limits<int>::max()) || (r < static_cast<result_type>(std::numeric_limits<int>::min()))))
       return static_cast<int>(policies::raise_rounding_error("boost::math::iround<%1%>(%1%)", 0, v, 0, pol));
    return static_cast<int>(r);
 }
@@ -97,8 +98,9 @@ template <class T, class Policy>
 inline long lround(const T& v, const Policy& pol)
 {
    BOOST_MATH_STD_USING
+   typedef typename tools::promote_args<T>::type result_type;
    T r = boost::math::round(v, pol);
-   if((r > (std::numeric_limits<long>::max)()) || (r < (std::numeric_limits<long>::min)()))
+   if((r > static_cast<result_type>(std::numeric_limits<long>::max()) || (r < static_cast<result_type>(std::numeric_limits<long>::min()))))
       return static_cast<long int>(policies::raise_rounding_error("boost::math::lround<%1%>(%1%)", 0, v, 0L, pol));
    return static_cast<long int>(r);
 }
@@ -114,9 +116,13 @@ template <class T, class Policy>
 inline boost::long_long_type llround(const T& v, const Policy& pol)
 {
    BOOST_MATH_STD_USING
+   typedef typename tools::promote_args<T>::type result_type;
    T r = boost::math::round(v, pol);
-   if((r > (std::numeric_limits<boost::long_long_type>::max)()) || (r < (std::numeric_limits<boost::long_long_type>::min)()))
+   if((r > static_cast<result_type>(std::numeric_limits<boost::long_long_type>::max()) || 
+      (r < static_cast<result_type>(std::numeric_limits<boost::long_long_type>::min()))))
+   {
       return static_cast<boost::long_long_type>(policies::raise_rounding_error("boost::math::llround<%1%>(%1%)", 0, v, static_cast<boost::long_long_type>(0), pol));
+   }
    return static_cast<boost::long_long_type>(r);
 }
 template <class T>

--- a/include/boost/math/special_functions/round.hpp
+++ b/include/boost/math/special_functions/round.hpp
@@ -78,13 +78,17 @@ inline typename tools::promote_args<T>::type round(const T& v)
 // namespace as the UDT: these will then be found via argument
 // dependent lookup.  See our concept archetypes for examples.
 //
+// Non-standard numeric limits syntax "(std::numeric_limits<int>::max)()" 
+// is to avoid macro substiution from MSVC
+// https://stackoverflow.com/questions/27442885/syntax-error-with-stdnumeric-limitsmax
+//
 template <class T, class Policy>
 inline int iround(const T& v, const Policy& pol)
 {
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    T r = boost::math::round(v, pol);
-   if(r > static_cast<result_type>(std::numeric_limits<int>::max()) || r < static_cast<result_type>(std::numeric_limits<int>::min()))
+   if(r > static_cast<result_type>((std::numeric_limits<int>::max)()) || r < static_cast<result_type>((std::numeric_limits<int>::min)()))
       return static_cast<int>(policies::raise_rounding_error("boost::math::iround<%1%>(%1%)", 0, v, 0, pol));
    return static_cast<int>(r);
 }
@@ -100,7 +104,7 @@ inline long lround(const T& v, const Policy& pol)
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    T r = boost::math::round(v, pol);
-   if(r > static_cast<result_type>(std::numeric_limits<long>::max()) || r < static_cast<result_type>(std::numeric_limits<long>::min()))
+   if(r > static_cast<result_type>((std::numeric_limits<long>::max)()) || r < static_cast<result_type>((std::numeric_limits<long>::min)()))
       return static_cast<long int>(policies::raise_rounding_error("boost::math::lround<%1%>(%1%)", 0, v, 0L, pol));
    return static_cast<long int>(r);
 }
@@ -118,8 +122,8 @@ inline boost::long_long_type llround(const T& v, const Policy& pol)
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    T r = boost::math::round(v, pol);
-   if(r > static_cast<result_type>(std::numeric_limits<boost::long_long_type>::max()) || 
-      r < static_cast<result_type>(std::numeric_limits<boost::long_long_type>::min()))
+   if(r > static_cast<result_type>((std::numeric_limits<boost::long_long_type>::max)()) || 
+      r < static_cast<result_type>((std::numeric_limits<boost::long_long_type>::min)()))
    {
       return static_cast<boost::long_long_type>(policies::raise_rounding_error("boost::math::llround<%1%>(%1%)", 0, v, static_cast<boost::long_long_type>(0), pol));
    }

--- a/include/boost/math/special_functions/round.hpp
+++ b/include/boost/math/special_functions/round.hpp
@@ -84,7 +84,7 @@ inline int iround(const T& v, const Policy& pol)
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    T r = boost::math::round(v, pol);
-   if((r > static_cast<result_type>(std::numeric_limits<int>::max()) || (r < static_cast<result_type>(std::numeric_limits<int>::min()))))
+   if(r > static_cast<result_type>(std::numeric_limits<int>::max()) || r < static_cast<result_type>(std::numeric_limits<int>::min()))
       return static_cast<int>(policies::raise_rounding_error("boost::math::iround<%1%>(%1%)", 0, v, 0, pol));
    return static_cast<int>(r);
 }
@@ -100,7 +100,7 @@ inline long lround(const T& v, const Policy& pol)
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    T r = boost::math::round(v, pol);
-   if((r > static_cast<result_type>(std::numeric_limits<long>::max()) || (r < static_cast<result_type>(std::numeric_limits<long>::min()))))
+   if(r > static_cast<result_type>(std::numeric_limits<long>::max()) || r < static_cast<result_type>(std::numeric_limits<long>::min()))
       return static_cast<long int>(policies::raise_rounding_error("boost::math::lround<%1%>(%1%)", 0, v, 0L, pol));
    return static_cast<long int>(r);
 }
@@ -118,8 +118,8 @@ inline boost::long_long_type llround(const T& v, const Policy& pol)
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    T r = boost::math::round(v, pol);
-   if((r > static_cast<result_type>(std::numeric_limits<boost::long_long_type>::max()) || 
-      (r < static_cast<result_type>(std::numeric_limits<boost::long_long_type>::min()))))
+   if(r > static_cast<result_type>(std::numeric_limits<boost::long_long_type>::max()) || 
+      r < static_cast<result_type>(std::numeric_limits<boost::long_long_type>::min()))
    {
       return static_cast<boost::long_long_type>(policies::raise_rounding_error("boost::math::llround<%1%>(%1%)", 0, v, static_cast<boost::long_long_type>(0), pol));
    }

--- a/include/boost/math/special_functions/trunc.hpp
+++ b/include/boost/math/special_functions/trunc.hpp
@@ -62,7 +62,8 @@ inline int itrunc(const T& v, const Policy& pol)
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    result_type r = boost::math::trunc(v, pol);
-   if((r > static_cast<result_type>(std::numeric_limits<int>::max()) || (r < static_cast<result_type>(std::numeric_limits<int>::min()))))
+   
+   if(r > static_cast<result_type>(std::numeric_limits<int>::max()) || r < static_cast<result_type>(std::numeric_limits<int>::min()))
       return static_cast<int>(policies::raise_rounding_error("boost::math::itrunc<%1%>(%1%)", 0, static_cast<result_type>(v), 0, pol));
    return static_cast<int>(r);
 }
@@ -78,7 +79,7 @@ inline long ltrunc(const T& v, const Policy& pol)
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    result_type r = boost::math::trunc(v, pol);
-   if((r > static_cast<result_type>(std::numeric_limits<long>::max()) || (r < static_cast<result_type>(std::numeric_limits<long>::min()))))
+   if(r > static_cast<result_type>(std::numeric_limits<long>::max()) || r < static_cast<result_type>(std::numeric_limits<long>::min()))
       return static_cast<long>(policies::raise_rounding_error("boost::math::ltrunc<%1%>(%1%)", 0, static_cast<result_type>(v), 0L, pol));
    return static_cast<long>(r);
 }
@@ -96,8 +97,8 @@ inline boost::long_long_type lltrunc(const T& v, const Policy& pol)
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    result_type r = boost::math::trunc(v, pol);
-   if((r > static_cast<result_type>(std::numeric_limits<boost::long_long_type>::max()) || 
-      (r < static_cast<result_type>(std::numeric_limits<boost::long_long_type>::min()))))
+   if(r > static_cast<result_type>(std::numeric_limits<boost::long_long_type>::max()) || 
+      r < static_cast<result_type>(std::numeric_limits<boost::long_long_type>::min()))
    {
       return static_cast<boost::long_long_type>(policies::raise_rounding_error("boost::math::lltrunc<%1%>(%1%)", 0, v, static_cast<boost::long_long_type>(0), pol));
    }

--- a/include/boost/math/special_functions/trunc.hpp
+++ b/include/boost/math/special_functions/trunc.hpp
@@ -62,7 +62,7 @@ inline int itrunc(const T& v, const Policy& pol)
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    result_type r = boost::math::trunc(v, pol);
-   if((r > (std::numeric_limits<int>::max)()) || (r < (std::numeric_limits<int>::min)()))
+   if((r > static_cast<result_type>(std::numeric_limits<int>::max()) || (r < static_cast<result_type>(std::numeric_limits<int>::min()))))
       return static_cast<int>(policies::raise_rounding_error("boost::math::itrunc<%1%>(%1%)", 0, static_cast<result_type>(v), 0, pol));
    return static_cast<int>(r);
 }
@@ -78,7 +78,7 @@ inline long ltrunc(const T& v, const Policy& pol)
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    result_type r = boost::math::trunc(v, pol);
-   if((r > (std::numeric_limits<long>::max)()) || (r < (std::numeric_limits<long>::min)()))
+   if((r > static_cast<result_type>(std::numeric_limits<long>::max()) || (r < static_cast<result_type>(std::numeric_limits<long>::min()))))
       return static_cast<long>(policies::raise_rounding_error("boost::math::ltrunc<%1%>(%1%)", 0, static_cast<result_type>(v), 0L, pol));
    return static_cast<long>(r);
 }
@@ -96,8 +96,11 @@ inline boost::long_long_type lltrunc(const T& v, const Policy& pol)
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    result_type r = boost::math::trunc(v, pol);
-   if((r > (std::numeric_limits<boost::long_long_type>::max)()) || (r < (std::numeric_limits<boost::long_long_type>::min)()))
+   if((r > static_cast<result_type>(std::numeric_limits<boost::long_long_type>::max()) || 
+      (r < static_cast<result_type>(std::numeric_limits<boost::long_long_type>::min()))))
+   {
       return static_cast<boost::long_long_type>(policies::raise_rounding_error("boost::math::lltrunc<%1%>(%1%)", 0, v, static_cast<boost::long_long_type>(0), pol));
+   }
    return static_cast<boost::long_long_type>(r);
 }
 template <class T>

--- a/include/boost/math/special_functions/trunc.hpp
+++ b/include/boost/math/special_functions/trunc.hpp
@@ -56,14 +56,17 @@ inline typename tools::promote_args<T>::type trunc(const T& v)
 // namespace as the UDT: these will then be found via argument
 // dependent lookup.  See our concept archetypes for examples.
 //
+// Non-standard numeric limits syntax "(std::numeric_limits<int>::max)()" 
+// is to avoid macro substiution from MSVC
+// https://stackoverflow.com/questions/27442885/syntax-error-with-stdnumeric-limitsmax
+//
 template <class T, class Policy>
 inline int itrunc(const T& v, const Policy& pol)
 {
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    result_type r = boost::math::trunc(v, pol);
-   
-   if(r > static_cast<result_type>(std::numeric_limits<int>::max()) || r < static_cast<result_type>(std::numeric_limits<int>::min()))
+   if(r > static_cast<result_type>((std::numeric_limits<int>::max)()) || r < static_cast<result_type>((std::numeric_limits<int>::min)()))
       return static_cast<int>(policies::raise_rounding_error("boost::math::itrunc<%1%>(%1%)", 0, static_cast<result_type>(v), 0, pol));
    return static_cast<int>(r);
 }
@@ -79,7 +82,7 @@ inline long ltrunc(const T& v, const Policy& pol)
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    result_type r = boost::math::trunc(v, pol);
-   if(r > static_cast<result_type>(std::numeric_limits<long>::max()) || r < static_cast<result_type>(std::numeric_limits<long>::min()))
+   if(r > static_cast<result_type>((std::numeric_limits<long>::max)()) || r < static_cast<result_type>((std::numeric_limits<long>::min)()))
       return static_cast<long>(policies::raise_rounding_error("boost::math::ltrunc<%1%>(%1%)", 0, static_cast<result_type>(v), 0L, pol));
    return static_cast<long>(r);
 }
@@ -97,8 +100,8 @@ inline boost::long_long_type lltrunc(const T& v, const Policy& pol)
    BOOST_MATH_STD_USING
    typedef typename tools::promote_args<T>::type result_type;
    result_type r = boost::math::trunc(v, pol);
-   if(r > static_cast<result_type>(std::numeric_limits<boost::long_long_type>::max()) || 
-      r < static_cast<result_type>(std::numeric_limits<boost::long_long_type>::min()))
+   if(r > static_cast<result_type>((std::numeric_limits<boost::long_long_type>::max)()) || 
+      r < static_cast<result_type>((std::numeric_limits<boost::long_long_type>::min)()))
    {
       return static_cast<boost::long_long_type>(policies::raise_rounding_error("boost::math::lltrunc<%1%>(%1%)", 0, v, static_cast<boost::long_long_type>(0), pol));
    }

--- a/test/test_round.cpp
+++ b/test/test_round.cpp
@@ -139,7 +139,7 @@ void test_round_number(T arg)
    T frac = boost::math::modf(arg, &r);
    check_modf_result(arg, frac, r);
 
-   if(abs(r) < (std::numeric_limits<int>::max)())
+   if(abs(r) < static_cast<T>(std::numeric_limits<int>::max()))
    {
       int i = iround(arg);
       check_within_half(arg, i);
@@ -159,7 +159,7 @@ void test_round_number(T arg)
       si = itrunc(static_cast<T>((std::numeric_limits<int>::min)()));
       check_trunc_result(static_cast<T>((std::numeric_limits<int>::min)()), T(si));
    }
-   if(abs(r) < (std::numeric_limits<long>::max)())
+   if(abs(r) < static_cast<T>(std::numeric_limits<long>::max()))
    {
       long l = lround(arg);
       check_within_half(arg, l);
@@ -181,7 +181,7 @@ void test_round_number(T arg)
    }
 
 #ifdef BOOST_HAS_LONG_LONG
-   if(abs(r) < (std::numeric_limits<boost::long_long_type>::max)())
+   if(abs(r) < static_cast<T>(std::numeric_limits<boost::long_long_type>::max()))
    {
       boost::long_long_type ll = llround(arg);
       check_within_half(arg, ll);

--- a/test/test_round.cpp
+++ b/test/test_round.cpp
@@ -139,7 +139,7 @@ void test_round_number(T arg)
    T frac = boost::math::modf(arg, &r);
    check_modf_result(arg, frac, r);
 
-   if(abs(r) < static_cast<T>(std::numeric_limits<int>::max()))
+   if(abs(r) < static_cast<T>((std::numeric_limits<int>::max)()))
    {
       int i = iround(arg);
       check_within_half(arg, i);
@@ -159,7 +159,7 @@ void test_round_number(T arg)
       si = itrunc(static_cast<T>((std::numeric_limits<int>::min)()));
       check_trunc_result(static_cast<T>((std::numeric_limits<int>::min)()), T(si));
    }
-   if(abs(r) < static_cast<T>(std::numeric_limits<long>::max()))
+   if(abs(r) < static_cast<T>((std::numeric_limits<long>::max)()))
    {
       long l = lround(arg);
       check_within_half(arg, l);

--- a/test/test_round.cpp
+++ b/test/test_round.cpp
@@ -179,7 +179,7 @@ void test_round_number(T arg)
       k = ltrunc(static_cast<T>((std::numeric_limits<long>::min)()));
       check_trunc_result(static_cast<T>((std::numeric_limits<long>::min)()), T(k));
    }
-
+   
 #ifdef BOOST_HAS_LONG_LONG
    if(abs(r) < static_cast<T>(std::numeric_limits<boost::long_long_type>::max()))
    {
@@ -464,4 +464,10 @@ BOOST_AUTO_TEST_CASE( test_main )
 
    BOOST_CHECK_EQUAL(boost::math::round(9007199254740993.0), 9007199254740993.0);
    test_round_number(9007199254740993.0);
+
+   #ifdef BOOST_HAS_LONG_LONG
+   // std::numeric_limits<long long>::max() + 1
+   BOOST_CHECK_EQUAL(boost::math::round(9223372036854775808.0), 9223372036854775808.0);
+   test_round_number(9223372036854775808.0);
+   #endif
 }

--- a/test/test_round.cpp
+++ b/test/test_round.cpp
@@ -181,7 +181,7 @@ void test_round_number(T arg)
    }
    
 #ifdef BOOST_HAS_LONG_LONG
-   if(abs(r) < static_cast<T>(std::numeric_limits<boost::long_long_type>::max()))
+   if(abs(r) < static_cast<T>((std::numeric_limits<boost::long_long_type>::max)()))
    {
       boost::long_long_type ll = llround(arg);
       check_within_half(arg, ll);


### PR DESCRIPTION
Fix for issue #430 . Added explicit casting to eliminate `-Wimplicit-int-float-conversion` warnings on clang. Added test case of `std::numeric_limits<long long>::max() + 1` which passes ubsan.