### PR TITLE
Add integer support to bivariate statistics

### DIFF
--- a/include/boost/math/statistics/bivariate_statistics.hpp
+++ b/include/boost/math/statistics/bivariate_statistics.hpp
@@ -1,4 +1,5 @@
 //  (C) Copyright Nick Thompson 2018.
+//  (C) Copyright Matt Borland 2021.
 //  Use, modification and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -8,25 +9,28 @@
 
 #include <iterator>
 #include <tuple>
+#include <type_traits>
+#include <cmath>
+#include <cstddef>
 #include <boost/assert.hpp>
 
 
-namespace boost{ namespace math{ namespace statistics {
+namespace boost{ namespace math{ namespace statistics { namespace detail {
 
-template<class Container>
-auto means_and_covariance(Container const & u, Container const & v)
+template<class ReturnType, class Container>
+ReturnType means_and_covariance_impl(Container const & u, Container const & v)
 {
-    using Real = typename Container::value_type;
-    using std::size;
-    BOOST_ASSERT_MSG(size(u) == size(v), "The size of each vector must be the same to compute covariance.");
-    BOOST_ASSERT_MSG(size(u) > 0, "Computing covariance requires at least one sample.");
+    using Real = typename std::tuple_element<0, ReturnType>::type;
+
+    BOOST_ASSERT_MSG(u.size() == v.size(), "The size of each vector must be the same to compute covariance.");
+    BOOST_ASSERT_MSG(u.size() > 0, "Computing covariance requires at least one sample.");
 
     // See Equation III.9 of "Numerically Stable, Single-Pass, Parallel Statistics Algorithms", Bennet et al.
     Real cov = 0;
     Real mu_u = u[0];
     Real mu_v = v[0];
 
-    for(size_t i = 1; i < size(u); ++i)
+    for(std::size_t i = 1; i < u.size(); ++i)
     {
         Real u_tmp = (u[i] - mu_u)/(i+1);
         Real v_tmp = v[i] - mu_v;
@@ -35,23 +39,16 @@ auto means_and_covariance(Container const & u, Container const & v)
         mu_v = mu_v + v_tmp/(i+1);
     }
 
-    return std::make_tuple(mu_u, mu_v, cov/size(u));
+    return std::make_tuple(mu_u, mu_v, cov/u.size());
 }
 
-template<class Container>
-auto covariance(Container const & u, Container const & v)
+template<class ReturnType, class Container>
+ReturnType correlation_coefficient_impl(Container const & u, Container const & v)
 {
-    auto [mu_u, mu_v, cov] = boost::math::statistics::means_and_covariance(u, v);
-    return cov;
-}
-
-template<class Container>
-auto correlation_coefficient(Container const & u, Container const & v)
-{
-    using Real = typename Container::value_type;
-    using std::size;
-    BOOST_ASSERT_MSG(size(u) == size(v), "The size of each vector must be the same to compute covariance.");
-    BOOST_ASSERT_MSG(size(u) > 0, "Computing covariance requires at least two samples.");
+    using Real = ReturnType;
+    using std::sqrt;
+    BOOST_ASSERT_MSG(u.size() == v.size(), "The size of each vector must be the same to compute covariance.");
+    BOOST_ASSERT_MSG(u.size() > 0, "Computing covariance requires at least two samples.");
 
     Real cov = 0;
     Real mu_u = u[0];
@@ -59,7 +56,7 @@ auto correlation_coefficient(Container const & u, Container const & v)
     Real Qu = 0;
     Real Qv = 0;
 
-    for(size_t i = 1; i < size(u); ++i)
+    for(std::size_t i = 1; i < u.size(); ++i)
     {
         Real u_tmp = u[i] - mu_u;
         Real v_tmp = v[i] - mu_v;
@@ -91,6 +88,45 @@ auto correlation_coefficient(Container const & u, Container const & v)
     }
     return rho;
 }
+} // namespace detail
 
-}}}
+template<typename Container, typename Real = typename Container::value_type, typename std::enable_if<std::is_integral<Real>::value, bool>::type = true>
+inline auto means_and_covariance(Container const & u, Container const & v) -> std::tuple<double, double, double>
+{
+    return detail::means_and_covariance_impl<std::tuple<double, double, double>>(u, v);
+}
+
+template<typename Container, typename Real = typename Container::value_type, typename std::enable_if<!std::is_integral<Real>::value, bool>::type = true>
+inline auto means_and_covariance(Container const & u, Container const & v) -> std::tuple<Real, Real, Real>
+{
+    return detail::means_and_covariance_impl<std::tuple<Real, Real, Real>>(u, v);
+}
+
+template<typename Container, typename Real = typename Container::value_type, typename std::enable_if<std::is_integral<Real>::value, bool>::type = true>
+inline double covariance(Container const & u, Container const & v)
+{
+    std::tuple<double, double, double> temp = detail::means_and_covariance_impl<std::tuple<double, double, double>>(u, v);
+    return std::get<2>(temp);
+}
+
+template<typename Container, typename Real = typename Container::value_type, typename std::enable_if<!std::is_integral<Real>::value, bool>::type = true>
+inline Real covariance(Container const & u, Container const & v)
+{
+    std::tuple<Real, Real, Real> temp = detail::means_and_covariance_impl<std::tuple<Real, Real, Real>>(u, v);
+    return std::get<2>(temp);
+}
+
+template<typename Container, typename Real = typename Container::value_type, typename std::enable_if<std::is_integral<Real>::value, bool>::type = true>
+inline double correlation_coefficient(Container const & u, Container const & v)
+{
+    return detail::correlation_coefficient_impl<double>(u, v);
+}
+
+template<typename Container, typename Real = typename Container::value_type, typename std::enable_if<!std::is_integral<Real>::value, bool>::type = true>
+inline Real correlation_coefficient(Container const & u, Container const & v)
+{
+    return detail::correlation_coefficient_impl<Real>(u, v);
+}
+
+}}} // namespace boost::math::statistics
 #endif

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -979,7 +979,7 @@ test-suite misc :
    [ run anderson_darling_test.cpp : : : [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run ljung_box_test.cpp : : : [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run test_t_test.cpp : : : [ requires cxx17_if_constexpr cxx17_std_apply ] ]
-   [ run bivariate_statistics_test.cpp : : : [ requires cxx11_hdr_forward_list cxx11_hdr_tuple ] ]
+   [ run bivariate_statistics_test.cpp : : : [ requires cxx11_hdr_forward_list cxx11_hdr_tuple cxx11_sfinae_expr ] ]
    [ run linear_regression_test.cpp : : : [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run test_runs_test.cpp : : : [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run lanczos_smoothing_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr cxx17_std_apply ] ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -979,7 +979,7 @@ test-suite misc :
    [ run anderson_darling_test.cpp : : : [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run ljung_box_test.cpp : : : [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run test_t_test.cpp : : : [ requires cxx17_if_constexpr cxx17_std_apply ] ]
-   [ run bivariate_statistics_test.cpp : : : [ requires cxx17_if_constexpr cxx17_std_apply ] ]
+   [ run bivariate_statistics_test.cpp : : : [ requires cxx11_hdr_forward_list cxx11_hdr_tuple ] ]
    [ run linear_regression_test.cpp : : : [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run test_runs_test.cpp : : : [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run lanczos_smoothing_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr cxx17_std_apply ] ]


### PR DESCRIPTION
Add support for integers to bivariate statistics. Add unit tests with same tolerances as Real types. Remove uses of structured bindings and `std::size()` to reduce the required language standard from 17 to 11. 