### PR TITLE
Add integer support to linear regression

### DIFF
--- a/include/boost/math/statistics/linear_regression.hpp
+++ b/include/boost/math/statistics/linear_regression.hpp
@@ -11,17 +11,20 @@
 #include <cmath>
 #include <algorithm>
 #include <utility>
+#include <tuple>
+#include <stdexcept>
+#include <type_traits>
 #include <boost/math/statistics/univariate_statistics.hpp>
 #include <boost/math/statistics/bivariate_statistics.hpp>
 
-namespace boost::math::statistics {
+namespace boost { namespace math { namespace statistics { namespace detail {
 
 
-template<class RandomAccessContainer>
-auto simple_ordinary_least_squares(RandomAccessContainer const & x,
-                                   RandomAccessContainer const & y)
+template<class ReturnType, class RandomAccessContainer>
+ReturnType simple_ordinary_least_squares(RandomAccessContainer const & x,
+                                         RandomAccessContainer const & y)
 {
-    using Real = typename RandomAccessContainer::value_type;
+    using Real = typename std::tuple_element<0, ReturnType>::type;
     if (x.size() <= 1)
     {
         throw std::domain_error("At least 2 samples are required to perform a linear regression.");
@@ -31,9 +34,12 @@ auto simple_ordinary_least_squares(RandomAccessContainer const & x,
     {
         throw std::domain_error("The same number of samples must be in the independent and dependent variable.");
     }
-    auto [mu_x, mu_y, cov_xy] = boost::math::statistics::means_and_covariance(x, y);
+    std::tuple<Real, Real, Real> temp = boost::math::statistics::means_and_covariance(x, y);
+    Real mu_x = std::get<0>(temp);
+    Real mu_y = std::get<1>(temp);
+    Real cov_xy = std::get<2>(temp);
 
-    auto var_x = boost::math::statistics::variance(x);
+    Real var_x = boost::math::statistics::variance(x);
 
     if (var_x <= 0) {
         throw std::domain_error("Independent variable has no variance; this breaks linear regression.");
@@ -46,11 +52,11 @@ auto simple_ordinary_least_squares(RandomAccessContainer const & x,
     return std::make_pair(c0, c1);
 }
 
-template<class RandomAccessContainer>
-auto simple_ordinary_least_squares_with_R_squared(RandomAccessContainer const & x,
-                                   RandomAccessContainer const & y)
+template<class ReturnType, class RandomAccessContainer>
+ReturnType simple_ordinary_least_squares_with_R_squared(RandomAccessContainer const & x,
+                                                        RandomAccessContainer const & y)
 {
-    using Real = typename RandomAccessContainer::value_type;
+    using Real = typename std::tuple_element<0, ReturnType>::type;
     if (x.size() <= 1)
     {
         throw std::domain_error("At least 2 samples are required to perform a linear regression.");
@@ -60,9 +66,12 @@ auto simple_ordinary_least_squares_with_R_squared(RandomAccessContainer const & 
     {
         throw std::domain_error("The same number of samples must be in the independent and dependent variable.");
     }
-    auto [mu_x, mu_y, cov_xy] = boost::math::statistics::means_and_covariance(x, y);
+    std::tuple<Real, Real, Real> temp = boost::math::statistics::means_and_covariance(x, y);
+    Real mu_x = std::get<0>(temp);
+    Real mu_y = std::get<1>(temp);
+    Real cov_xy = std::get<2>(temp);
 
-    auto var_x = boost::math::statistics::variance(x);
+    Real var_x = boost::math::statistics::variance(x);
 
     if (var_x <= 0) {
         throw std::domain_error("Independent variable has no variance; this breaks linear regression.");
@@ -90,6 +99,34 @@ auto simple_ordinary_least_squares_with_R_squared(RandomAccessContainer const & 
 
     return std::make_tuple(c0, c1, Rsquared);
 }
+} // namespace detail
 
+template<typename RandomAccessContainer, typename Real = typename RandomAccessContainer::value_type, 
+         typename std::enable_if<std::is_integral<Real>::value, bool>::type = true>
+inline auto simple_ordinary_least_squares(RandomAccessContainer const & x, RandomAccessContainer const & y) -> std::pair<double, double>
+{
+    return detail::simple_ordinary_least_squares<std::pair<double, double>>(x, y);
 }
+
+template<typename RandomAccessContainer, typename Real = typename RandomAccessContainer::value_type, 
+         typename std::enable_if<!std::is_integral<Real>::value, bool>::type = true>
+inline auto simple_ordinary_least_squares(RandomAccessContainer const & x, RandomAccessContainer const & y) -> std::pair<Real, Real>
+{
+    return detail::simple_ordinary_least_squares<std::pair<Real, Real>>(x, y);
+}
+
+template<typename RandomAccessContainer, typename Real = typename RandomAccessContainer::value_type, 
+         typename std::enable_if<std::is_integral<Real>::value, bool>::type = true>
+inline auto simple_ordinary_least_squares_with_R_squared(RandomAccessContainer const & x, RandomAccessContainer const & y) -> std::tuple<double, double, double>
+{
+    return detail::simple_ordinary_least_squares_with_R_squared<std::tuple<double, double, double>>(x, y);
+}
+
+template<typename RandomAccessContainer, typename Real = typename RandomAccessContainer::value_type, 
+         typename std::enable_if<!std::is_integral<Real>::value, bool>::type = true>
+inline auto simple_ordinary_least_squares_with_R_squared(RandomAccessContainer const & x, RandomAccessContainer const & y) -> std::tuple<Real, Real, Real>
+{
+    return detail::simple_ordinary_least_squares_with_R_squared<std::tuple<Real, Real, Real>>(x, y);
+}
+}}} // namespace boost::math::statistics
 #endif

--- a/include/boost/math/statistics/linear_regression.hpp
+++ b/include/boost/math/statistics/linear_regression.hpp
@@ -22,8 +22,8 @@ namespace boost { namespace math { namespace statistics { namespace detail {
 
 
 template<class ReturnType, class RandomAccessContainer>
-ReturnType simple_ordinary_least_squares(RandomAccessContainer const & x,
-                                         RandomAccessContainer const & y)
+ReturnType simple_ordinary_least_squares_impl(RandomAccessContainer const & x,
+                                              RandomAccessContainer const & y)
 {
     using Real = typename std::tuple_element<0, ReturnType>::type;
     if (x.size() <= 1)
@@ -54,8 +54,8 @@ ReturnType simple_ordinary_least_squares(RandomAccessContainer const & x,
 }
 
 template<class ReturnType, class RandomAccessContainer>
-ReturnType simple_ordinary_least_squares_with_R_squared(RandomAccessContainer const & x,
-                                                        RandomAccessContainer const & y)
+ReturnType simple_ordinary_least_squares_with_R_squared_impl(RandomAccessContainer const & x,
+                                                             RandomAccessContainer const & y)
 {
     using Real = typename std::tuple_element<0, ReturnType>::type;
     if (x.size() <= 1)
@@ -106,28 +106,28 @@ template<typename RandomAccessContainer, typename Real = typename RandomAccessCo
          typename std::enable_if<std::is_integral<Real>::value, bool>::type = true>
 inline auto simple_ordinary_least_squares(RandomAccessContainer const & x, RandomAccessContainer const & y) -> std::pair<double, double>
 {
-    return detail::simple_ordinary_least_squares<std::pair<double, double>>(x, y);
+    return detail::simple_ordinary_least_squares_impl<std::pair<double, double>>(x, y);
 }
 
 template<typename RandomAccessContainer, typename Real = typename RandomAccessContainer::value_type, 
          typename std::enable_if<!std::is_integral<Real>::value, bool>::type = true>
 inline auto simple_ordinary_least_squares(RandomAccessContainer const & x, RandomAccessContainer const & y) -> std::pair<Real, Real>
 {
-    return detail::simple_ordinary_least_squares<std::pair<Real, Real>>(x, y);
+    return detail::simple_ordinary_least_squares_impl<std::pair<Real, Real>>(x, y);
 }
 
 template<typename RandomAccessContainer, typename Real = typename RandomAccessContainer::value_type, 
          typename std::enable_if<std::is_integral<Real>::value, bool>::type = true>
 inline auto simple_ordinary_least_squares_with_R_squared(RandomAccessContainer const & x, RandomAccessContainer const & y) -> std::tuple<double, double, double>
 {
-    return detail::simple_ordinary_least_squares_with_R_squared<std::tuple<double, double, double>>(x, y);
+    return detail::simple_ordinary_least_squares_with_R_squared_impl<std::tuple<double, double, double>>(x, y);
 }
 
 template<typename RandomAccessContainer, typename Real = typename RandomAccessContainer::value_type, 
          typename std::enable_if<!std::is_integral<Real>::value, bool>::type = true>
 inline auto simple_ordinary_least_squares_with_R_squared(RandomAccessContainer const & x, RandomAccessContainer const & y) -> std::tuple<Real, Real, Real>
 {
-    return detail::simple_ordinary_least_squares_with_R_squared<std::tuple<Real, Real, Real>>(x, y);
+    return detail::simple_ordinary_least_squares_with_R_squared_impl<std::tuple<Real, Real, Real>>(x, y);
 }
 }}} // namespace boost::math::statistics
 #endif

--- a/include/boost/math/statistics/linear_regression.hpp
+++ b/include/boost/math/statistics/linear_regression.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright Nick Thompson, 2019
+ * Copyright Matt Borland, 2021
  * Use, modification and distribution are subject to the
  * Boost Software License, Version 1.0. (See accompanying file
  * LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/test/linear_regression_test.cpp
+++ b/test/linear_regression_test.cpp
@@ -8,6 +8,9 @@
 #include "math_unit_test.hpp"
 #include <vector>
 #include <random>
+#include <utility>
+#include <tuple>
+#include <algorithm>
 #include <boost/math/statistics/linear_regression.hpp>
 
 using boost::math::statistics::simple_ordinary_least_squares;
@@ -25,16 +28,52 @@ void test_line()
         y[i] = expected_c0 + expected_c1*x[i];
     }
 
-    auto [computed_c0, computed_c1] = simple_ordinary_least_squares(x, y);
+    std::pair<Real, Real> temp = simple_ordinary_least_squares(x, y);
+    Real computed_c0 = std::get<0>(temp);
+    Real computed_c1 = std::get<1>(temp);
 
     CHECK_ULP_CLOSE(expected_c0, computed_c0, 0);
     CHECK_ULP_CLOSE(expected_c1, computed_c1, 0);
 
-    auto [computed_c0_R, computed_c1_R, Rsquared] = simple_ordinary_least_squares_with_R_squared(x, y);
+    std::tuple<Real, Real, Real> temp_with_R = simple_ordinary_least_squares_with_R_squared(x, y);
+    Real computed_c0_R = std::get<0>(temp_with_R);
+    Real computed_c1_R = std::get<1>(temp_with_R);
+    Real Rsquared = std::get<2>(temp_with_R);
 
     Real expected_Rsquared = 1;
+    CHECK_ULP_CLOSE(expected_c0, computed_c0_R, 0);
+    CHECK_ULP_CLOSE(expected_c1, computed_c1_R, 0);
+    CHECK_ULP_CLOSE(expected_Rsquared, Rsquared, 0);
+
+}
+
+template<typename Z>
+void test_integer_line()
+{
+    std::vector<Z> x(128);
+    std::vector<Z> y(128);
+    double expected_c0 = 7;
+    double expected_c1 = 12;
+    for (size_t i = 0; i < x.size(); ++i) {
+        x[i] = i;
+        y[i] = expected_c0 + expected_c1*x[i];
+    }
+
+    std::pair<double, double> temp = simple_ordinary_least_squares(x, y);
+    double computed_c0 = std::get<0>(temp);
+    double computed_c1 = std::get<1>(temp);
+
     CHECK_ULP_CLOSE(expected_c0, computed_c0, 0);
     CHECK_ULP_CLOSE(expected_c1, computed_c1, 0);
+
+    std::tuple<double, double, double> temp_with_R = simple_ordinary_least_squares_with_R_squared(x, y);
+    double computed_c0_R = std::get<0>(temp_with_R);
+    double computed_c1_R = std::get<1>(temp_with_R);
+    double Rsquared = std::get<2>(temp_with_R);
+
+    double expected_Rsquared = 1;
+    CHECK_ULP_CLOSE(expected_c0, computed_c0_R, 0);
+    CHECK_ULP_CLOSE(expected_c1, computed_c1_R, 0);
     CHECK_ULP_CLOSE(expected_Rsquared, Rsquared, 0);
 
 }
@@ -51,16 +90,52 @@ void test_constant()
         y[i] = expected_c0 + expected_c1*x[i];
     }
 
-    auto [computed_c0, computed_c1] = simple_ordinary_least_squares(x, y);
+    std::pair<Real, Real> temp = simple_ordinary_least_squares(x, y);
+    Real computed_c0 = std::get<0>(temp);
+    Real computed_c1 = std::get<1>(temp);
 
     CHECK_ULP_CLOSE(expected_c0, computed_c0, 0);
     CHECK_ULP_CLOSE(expected_c1, computed_c1, 0);
 
-    auto [computed_c0_R, computed_c1_R, Rsquared] = simple_ordinary_least_squares_with_R_squared(x, y);
+    std::tuple<Real, Real, Real> temp_with_R = simple_ordinary_least_squares_with_R_squared(x, y);
+    Real computed_c0_R = std::get<0>(temp_with_R);
+    Real computed_c1_R = std::get<1>(temp_with_R);
+    Real Rsquared = std::get<2>(temp_with_R);
 
     Real expected_Rsquared = 1;
+    CHECK_ULP_CLOSE(expected_c0, computed_c0_R, 0);
+    CHECK_ULP_CLOSE(expected_c1, computed_c1_R, 0);
+    CHECK_ULP_CLOSE(expected_Rsquared, Rsquared, 0);
+
+}
+
+template<typename Z>
+void test_integer_constant()
+{
+    std::vector<Z> x(128);
+    std::vector<Z> y(128);
+    Z expected_c0 = 7;
+    Z expected_c1 = 0;
+    for (size_t i = 0; i < x.size(); ++i) {
+        x[i] = i;
+        y[i] = expected_c0 + expected_c1*x[i];
+    }
+
+    std::pair<double, double> temp = simple_ordinary_least_squares(x, y);
+    double computed_c0 = std::get<0>(temp);
+    double computed_c1 = std::get<1>(temp);
+
     CHECK_ULP_CLOSE(expected_c0, computed_c0, 0);
     CHECK_ULP_CLOSE(expected_c1, computed_c1, 0);
+
+    std::tuple<double, double, double> temp_with_R = simple_ordinary_least_squares_with_R_squared(x, y);
+    double computed_c0_R = std::get<0>(temp_with_R);
+    double computed_c1_R = std::get<1>(temp_with_R);
+    double Rsquared = std::get<2>(temp_with_R);
+
+    double expected_Rsquared = 1;
+    CHECK_ULP_CLOSE(expected_c0, computed_c0_R, 0);
+    CHECK_ULP_CLOSE(expected_c1, computed_c1_R, 0);
     CHECK_ULP_CLOSE(expected_Rsquared, Rsquared, 0);
 
 }
@@ -84,7 +159,10 @@ void test_permutation_invariance()
         y[i] = expected_c0 + expected_c1*x[i] + dis(gen);
     }
 
-    auto [c0, c1, Rsquared] = simple_ordinary_least_squares_with_R_squared(x, y);
+    std::tuple<Real, Real, Real> temp = simple_ordinary_least_squares_with_R_squared(x, y);
+    Real c0 = std::get<0>(temp);
+    Real c1 = std::get<1>(temp);
+    Real Rsquared = std::get<2>(temp);
     CHECK_MOLLIFIED_CLOSE(expected_c0, c0, 0.002);
     CHECK_MOLLIFIED_CLOSE(expected_c1, c1, 0.002);
 
@@ -94,7 +172,11 @@ void test_permutation_invariance()
     while(j++ < 10) {
         std::shuffle(x.begin(), x.end(), gen1);
         std::shuffle(y.begin(), y.end(), gen2);
-        auto [c0_, c1_, Rsquared_] = simple_ordinary_least_squares_with_R_squared(x, y);
+
+        std::tuple<Real, Real, Real> temp_ = simple_ordinary_least_squares_with_R_squared(x, y);
+        Real c0_ = std::get<0>(temp_);
+        Real c1_ = std::get<1>(temp_);
+        Real Rsquared_ = std::get<2>(temp_);
 
         CHECK_ULP_CLOSE(c0, c0_, 100);
         CHECK_ULP_CLOSE(c1, c1_, 100);
@@ -121,7 +203,10 @@ void test_scaling_relations()
         y[i] = expected_c0 + expected_c1*x[i] + dis(gen);
     }
 
-    auto [c0, c1, Rsquared] = simple_ordinary_least_squares_with_R_squared(x, y);
+    std::tuple<Real, Real, Real> temp = simple_ordinary_least_squares_with_R_squared(x, y);
+    Real c0 = std::get<0>(temp);
+    Real c1 = std::get<1>(temp);
+    Real Rsquared = std::get<2>(temp);
     CHECK_MOLLIFIED_CLOSE(expected_c0, c0, 0.005);
     CHECK_MOLLIFIED_CLOSE(expected_c1, c1, 0.005);
 
@@ -132,7 +217,10 @@ void test_scaling_relations()
         s *= lambda;
     }
 
-    auto [c0_lambda, c1_lambda, Rsquared_lambda] = simple_ordinary_least_squares_with_R_squared(x, y);
+    temp = simple_ordinary_least_squares_with_R_squared(x, y);
+    Real c0_lambda = std::get<0>(temp);
+    Real c1_lambda = std::get<1>(temp);
+    Real Rsquared_lambda = std::get<2>(temp);
 
     CHECK_ULP_CLOSE(lambda*c0, c0_lambda, 30);
     CHECK_ULP_CLOSE(lambda*c1, c1_lambda, 30);
@@ -146,7 +234,11 @@ void test_scaling_relations()
     for (auto& s : y) {
         s /= lambda;
     }
-    auto [c0_, c1_, Rsquared_] = simple_ordinary_least_squares_with_R_squared(x, y);
+
+    temp = simple_ordinary_least_squares_with_R_squared(x, y);
+    Real c0_ = std::get<0>(temp);
+    Real c1_ = std::get<1>(temp);
+    Real Rsquared_ = std::get<2>(temp);
 
     CHECK_ULP_CLOSE(c0, c0_, 50);
     CHECK_ULP_CLOSE(c1, c1_*lambda, 50);
@@ -160,10 +252,18 @@ int main()
     test_line<float>();
     test_line<double>();
     test_line<long double>();
+    test_integer_line<int>();
+    test_integer_line<int32_t>();
+    test_integer_line<int64_t>();
+    test_integer_line<uint32_t>();
 
     test_constant<float>();
     test_constant<double>();
     test_constant<long double>();
+    test_integer_constant<int>();
+    test_integer_constant<int32_t>();
+    test_integer_constant<int64_t>();
+    test_integer_constant<uint32_t>();
 
     test_permutation_invariance<float>();
     test_permutation_invariance<double>();

--- a/test/linear_regression_test.cpp
+++ b/test/linear_regression_test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright Nick Thompson, 2019
+ * Copyright Matt Borland, 2021
  * Use, modification and distribution are subject to the
  * Boost Software License, Version 1.0. (See accompanying file
  * LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -114,8 +115,8 @@ void test_integer_constant()
 {
     std::vector<Z> x(128);
     std::vector<Z> y(128);
-    Z expected_c0 = 7;
-    Z expected_c1 = 0;
+    double expected_c0 = 7;
+    double expected_c1 = 0;
     for (size_t i = 0; i < x.size(); ++i) {
         x[i] = i;
         y[i] = expected_c0 + expected_c1*x[i];


### PR DESCRIPTION
Add support for integer types to linear regression. Will be compatible with C++11 once PR #434 is merged since it is dependent on univariate statistics becoming C++11 compatible. Does not fix issue #462.