### PR TITLE
Stats Class

### DIFF
--- a/doc/math.qbk
+++ b/doc/math.qbk
@@ -606,6 +606,7 @@ and as a CD ISBN 0-9504833-2-X  978-0-9504833-2-0, Classification 519.2-dc22.
 
 [mathpart statistics Statistics ]
 [include statistics/univariate_statistics.qbk]
+[include statistics/stats_set.qbk]
 [include statistics/bivariate_statistics.qbk]
 [include statistics/signal_statistics.qbk]
 [include statistics/anderson_darling.qbk]

--- a/doc/statistics/stats_set.qbk
+++ b/doc/statistics/stats_set.qbk
@@ -1,0 +1,104 @@
+[/
+Copyright (c) 2021 Matt Borland
+Use, modification and distribution are subject to the
+Boost Software License, Version 1.0. (See accompanying file
+LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+]
+
+[section:stats_set Statistics Set]
+
+[heading Synopsis]
+
+```
+#include <boost/math/statistics/set.hpp>
+
+namespace boost::math::statistics {
+
+    enum class metrics
+    {
+        mean,
+        median,
+        mode,
+        stddev,
+        variance,
+        skewness,
+        first_four_moments,
+        all
+    };
+    
+    template<typename ExecutionPolicy, typename ForwardIterator, typename T,
+             typename T2 = typename std::iterator_traits<ForwardIterator>::value_type>
+    class stats
+    {
+    public:
+        stats(ExecutionPolicy exec, ForwardIterator first, ForwardIterator last, metrics metric);
+        stats(ExecutionPolicy exec, ForwardIterator first, ForwardIterator last);
+        stats(ForwardIterator first, ForwardIterator last, metrics metric);
+        stats(ForwardIterator first, ForwardIterator last);
+
+        // Getters
+        [[nodiscard]] inline T mean() const noexcept;
+        [[nodiscard]] inline T median() const noexcept;
+        [[nodiscard]] inline std::list<T2> mode() const noexcept;
+        [[nodiscard]] inline T stddev() const noexcept;
+        [[nodiscard]] inline T variance() const noexcept;
+        [[nodiscard]] inline T skewness() const noexcept;
+        [[nodiscard]] inline std::tuple<T, T, T, T> first_four_moments() const noexcept;
+
+        // Setter
+        void calc(metrics metric);
+    };
+}
+```
+
+[heading Description]
+The statistics set is a wrapper class around the core univariate statistics functions contained in boost.math.
+This class is compatible with C++11 and above. C++17 is required to utilize execution policies and class template argument deduction.
+See the documentation for univariate_statistics for additional information on each of the functions provided.
+
+/Nota bene:/ To use integer types replace the type stats with integer_stats. The type T will be deduced as a double precision type.
+
+[heading C++11 Example]
+
+```
+using boost::math::statistics::metrics;
+
+std::vector<double> test {...};
+
+boost::math::statistics::stats<decltype(test.begin()), double> set(test.begin(), test.end());
+set.calc(metrics::mean);
+
+double mean = set.mean();
+
+// With integers
+std::vector<int> int_test {...};
+
+boost::math::statistics::stats<decltype(int_test.begin()), int> int_set(int_test.begin(), int_test.end(), metrics::all);
+
+double variance = int_set.variance();
+```
+
+[heading C++17 Example]
+
+```
+using boost::math::statistics::metrics;
+
+std::vector<double> test {...};
+
+boost::math::statistics::stats set(std::execution::par, test.begin(), test.end());
+set.calc(metrics::mean);
+
+double mean = set.mean();
+
+// With integers
+std::vector<int> int_test {...};
+
+boost::math::statistics::stats int_set(int_test.begin(), int_test.end(), metrics::all);
+
+double variance = int_set.variance();
+```
+
+/Nota bene:/ In the C++17 case if an execution policy is not provided the defualt is sequential policy.
+
+[endsect]
+[/section:section:stats_set Statistics Set]

--- a/include/boost/math/statistics/detail/single_pass.hpp
+++ b/include/boost/math/statistics/detail/single_pass.hpp
@@ -19,6 +19,7 @@
 #include <valarray>
 #include <stdexcept>
 #include <functional>
+#include <vector>
 
 namespace boost { namespace math { namespace statistics { namespace detail {
 

--- a/include/boost/math/statistics/detail/single_pass.hpp
+++ b/include/boost/math/statistics/detail/single_pass.hpp
@@ -7,6 +7,7 @@
 #ifndef BOOST_MATH_STATISTICS_UNIVARIATE_STATISTICS_DETAIL_SINGLE_PASS_HPP
 #define BOOST_MATH_STATISTICS_UNIVARIATE_STATISTICS_DETAIL_SINGLE_PASS_HPP
 
+#include <boost/assert.hpp>
 #include <tuple>
 #include <iterator>
 #include <atomic>

--- a/include/boost/math/statistics/set.hpp
+++ b/include/boost/math/statistics/set.hpp
@@ -59,7 +59,8 @@ public:
     [[nodiscard]] inline T median() const noexcept { return median_; }
     [[nodiscard]] inline std::list<T> mode() const noexcept { return mode_; }
     [[nodiscard]] inline T stddev() const noexcept { return stddev_; }
-    [[nodiscard]] inline T variance() const noexcept {return variance_; }
+    [[nodiscard]] inline T variance() const noexcept { return variance_; }
+    [[nodiscard]] inline T skewness() const noexcept { return skewness_; }
     [[nodiscard]] inline std::tuple<T, T, T, T> first_four_moments() const noexcept { return first_four_moments_; }
 };
 
@@ -93,6 +94,11 @@ void stats_base<ExecutionPolicy, ForwardIterator, T>::calc_all()
         stddev_ = sqrt(variance_);
     }
     
+    if(skewness_ == T(0))
+    {
+        skewness_ = boost::math::statistics::skewness(exec_, first_, last_);
+    }
+
     if(first_four_moments_ == std::make_tuple(T(0), T(0), T(0), T(0)))
     {
         first_four_moments_ = boost::math::statistics::first_four_moments(exec_, first_, last_);

--- a/include/boost/math/statistics/set.hpp
+++ b/include/boost/math/statistics/set.hpp
@@ -1,0 +1,169 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_STATISTICS_SET
+#define BOOST_MATH_STATISTICS_SET
+
+#include <boost/math/statistics/univariate_statistics.hpp>
+#include <tuple>
+#include <iterator>
+#include <utility>
+#include <type_traits>
+#include <list>
+#include <execution>
+#include <cmath>
+
+namespace boost::math::statistics
+{
+
+enum class metrics : unsigned
+{
+    mean = 0b0000001,
+    median = 0b0000010,
+    mode = 0b0000100,
+    stddev = 0b0001000,
+    variance = 0b0010000,
+    skewness = 0b0100000,
+    first_four_moments = 0b1000000,
+    all = 0b1111111
+};
+
+namespace detail
+{
+template<typename ExecutionPolicy, typename ForwardIterator, typename T>
+class stats_base
+{
+
+protected:
+    ExecutionPolicy exec_;
+    ForwardIterator first_;
+    ForwardIterator last_;
+    T mean_ = T(0);
+    T median_= T(0);
+    std::list<T> mode_;
+    T stddev_= T(0);
+    T variance_= T(0);
+    T skewness_= T(0);
+    std::tuple<T, T, T, T> first_four_moments_ = std::make_tuple(T(0), T(0), T(0), T(0));
+
+    void calc_all();
+
+public:
+    stats_base(ExecutionPolicy exec, ForwardIterator first, ForwardIterator last) noexcept : exec_ {exec}, first_ {first}, last_ {last} {}
+
+    void calc(metrics);
+
+    [[nodiscard]] inline T mean() const noexcept { return mean_; }
+    [[nodiscard]] inline T median() const noexcept { return median_; }
+    [[nodiscard]] inline std::list<T> mode() const noexcept { return mode_; }
+    [[nodiscard]] inline T stddev() const noexcept { return stddev_; }
+    [[nodiscard]] inline T variance() const noexcept {return variance_; }
+    [[nodiscard]] inline std::tuple<T, T, T, T> first_four_moments() const noexcept { return first_four_moments_; }
+};
+
+template<typename ExecutionPolicy, typename ForwardIterator, typename T>
+void stats_base<ExecutionPolicy, ForwardIterator, T>::calc_all()
+{
+    using std::sqrt;
+    
+    if(mean_ == T(0))
+    {
+        mean_ = boost::math::statistics::mean(exec_, first_, last_);
+    }
+
+    if(median_ == T(0))
+    {
+        median_ = boost::math::statistics::median(exec_, first_, last_);
+    }
+    
+    if(mode_.empty())
+    {
+        boost::math::statistics::mode(exec_, first_, last_, std::inserter(mode_, mode_.begin()));
+    }
+    
+    if(variance_ == T(0))
+    {
+        variance_ = boost::math::statistics::variance(exec_, first_, last_);
+    }
+    
+    if(stddev_ == T(0))
+    {
+        stddev_ = sqrt(variance_);
+    }
+    
+    if(first_four_moments_ == std::make_tuple(T(0), T(0), T(0), T(0)))
+    {
+        first_four_moments_ = boost::math::statistics::first_four_moments(exec_, first_, last_);
+    }
+}
+
+template<typename ExecutionPolicy, typename ForwardIterator, typename T>
+void stats_base<ExecutionPolicy, ForwardIterator, T>::calc(metrics metric)
+{
+    using std::sqrt;
+    
+    switch(metric)
+    {
+        case metrics::mean:
+        {
+            mean_ = boost::math::statistics::mean(exec_, first_, last_);
+            break;
+        }
+        case metrics::median:
+        {
+            median_ = boost::math::statistics::median(exec_, first_, last_);
+            break;
+        }
+        case metrics::mode:
+        {
+            boost::math::statistics::mode(exec_, first_, last_, std::inserter(mode_, mode_.begin()));
+            break;
+        }
+        case metrics::stddev:
+        {
+            T temp = boost::math::statistics::variance(exec_, first_, last_);
+            stddev_ = sqrt(temp);
+            break;
+        }
+        case metrics::variance:
+        {
+            variance_ = boost::math::statistics::variance(exec_, first_, last_);
+            break;
+        }
+        case metrics::skewness:
+        {
+            skewness_ = boost::math::statistics::skewness(exec_, first_, last_);
+            break;
+        }
+        case metrics::first_four_moments:
+        {
+            first_four_moments_ = boost::math::statistics::first_four_moments(exec_, first_, last_);
+            break;
+        }
+        case metrics::all:
+            [[fallthrough]];
+        default:
+            calc_all();
+    }
+}
+
+} // End namespace detail
+
+// Allow multiple interfaces to base allowing an execution policy to be passed or not
+template<typename ExecutionPolicy = decltype(std::execution::seq), typename ForwardIterator = void, 
+         typename T = typename std::iterator_traits<ForwardIterator>::value_type>
+class stats : public detail::stats_base<ExecutionPolicy, ForwardIterator, T>
+{
+public:
+    stats(ExecutionPolicy exec, ForwardIterator first, ForwardIterator last) : 
+        detail::stats_base<ExecutionPolicy, ForwardIterator, T>(exec, first, last) {}
+       
+    stats(ForwardIterator first, ForwardIterator last) : 
+        detail::stats_base<decltype(std::execution::seq), ForwardIterator, T>(std::execution::seq, first, last) {}
+};
+
+} // namespace boost::math::statistics
+
+#endif // BOOST_MATH_STATISTICS_SET

--- a/include/boost/math/statistics/set.hpp
+++ b/include/boost/math/statistics/set.hpp
@@ -35,6 +35,8 @@ namespace detail
 template<typename ExecutionPolicy, typename ForwardIterator, typename T>
 class stats_base
 {
+// Differs in the case of integer stats where T = double but the underlying type is an integer
+using T2 = typename std::iterator_traits<ForwardIterator>::value_type;
 
 protected:
     ExecutionPolicy exec_;
@@ -42,7 +44,7 @@ protected:
     ForwardIterator last_;
     T mean_ = T(0);
     T median_= T(0);
-    std::list<T> mode_;
+    std::list<T2> mode_;
     T stddev_= T(0);
     T variance_= T(0);
     T skewness_= T(0);
@@ -57,7 +59,7 @@ public:
 
     [[nodiscard]] inline T mean() const noexcept { return mean_; }
     [[nodiscard]] inline T median() const noexcept { return median_; }
-    [[nodiscard]] inline std::list<T> mode() const noexcept { return mode_; }
+    [[nodiscard]] inline std::list<T2> mode() const noexcept { return mode_; }
     [[nodiscard]] inline T stddev() const noexcept { return stddev_; }
     [[nodiscard]] inline T variance() const noexcept { return variance_; }
     [[nodiscard]] inline T skewness() const noexcept { return skewness_; }
@@ -168,6 +170,18 @@ public:
        
     stats(ForwardIterator first, ForwardIterator last) : 
         detail::stats_base<decltype(std::execution::seq), ForwardIterator, T>(std::execution::seq, first, last) {}
+};
+
+template<typename ExecutionPolicy = decltype(std::execution::seq), typename ForwardIterator = void, 
+         typename T = typename std::iterator_traits<ForwardIterator>::value_type>
+class integer_stats : public detail::stats_base<ExecutionPolicy, ForwardIterator, double>
+{
+public:
+    integer_stats(ExecutionPolicy exec, ForwardIterator first, ForwardIterator last) : 
+        detail::stats_base<ExecutionPolicy, ForwardIterator, double>(exec, first, last) {}
+       
+    integer_stats(ForwardIterator first, ForwardIterator last) : 
+        detail::stats_base<decltype(std::execution::seq), ForwardIterator, double>(std::execution::seq, first, last) {}
 };
 
 } // namespace boost::math::statistics

--- a/include/boost/math/statistics/set.hpp
+++ b/include/boost/math/statistics/set.hpp
@@ -75,41 +75,23 @@ template<typename ExecutionPolicy, typename ForwardIterator, typename T>
 void stats_base<ExecutionPolicy, ForwardIterator, T>::calc_all()
 {
     using std::sqrt;
-    
-    if(mean_ == T(0))
+
+    first_four_moments_ = boost::math::statistics::first_four_moments(exec_, first_, last_);
+    mean_ = std::get<0>(first_four_moments_);
+    variance_ = std::get<1>(first_four_moments_);
+    stddev_ = sqrt(variance_);
+
+    // A constant dataset has no skewness
+    if(variance_ != 0)
     {
-        mean_ = boost::math::statistics::mean(exec_, first_, last_);
+        const auto n = std::distance(first_, last_);
+        const T var = variance_/(n-1);
+
+        skewness_ = std::get<2>(first_four_moments_)/(variance_*sqrt(var)) / T(2);
     }
 
-    if(median_ == T(0))
-    {
-        median_ = boost::math::statistics::median(exec_, first_, last_);
-    }
-    
-    if(mode_.empty())
-    {
-        boost::math::statistics::mode(exec_, first_, last_, std::inserter(mode_, mode_.begin()));
-    }
-    
-    if(variance_ == T(0))
-    {
-        variance_ = boost::math::statistics::variance(exec_, first_, last_);
-    }
-    
-    if(stddev_ == T(0))
-    {
-        stddev_ = sqrt(variance_);
-    }
-    
-    if(skewness_ == T(0))
-    {
-        skewness_ = boost::math::statistics::skewness(exec_, first_, last_);
-    }
-
-    if(first_four_moments_ == std::make_tuple(T(0), T(0), T(0), T(0)))
-    {
-        first_four_moments_ = boost::math::statistics::first_four_moments(exec_, first_, last_);
-    }
+    median_ = boost::math::statistics::median(exec_, first_, last_);
+    mode_ = boost::math::statistics::mode(exec_, first_, last_);
 }
 
 template<typename ExecutionPolicy, typename ForwardIterator, typename T>

--- a/include/boost/math/statistics/univariate_statistics.hpp
+++ b/include/boost/math/statistics/univariate_statistics.hpp
@@ -260,6 +260,7 @@ template<class ExecutionPolicy, class ForwardIterator>
 inline auto skewness(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last)
 {
     using Real = typename std::iterator_traits<ForwardIterator>::value_type;
+    using std::sqrt;
 
     if constexpr (std::is_same_v<std::remove_reference_t<decltype(exec)>, decltype(std::execution::seq)>)
     {

--- a/include/boost/math/tools/random_vector.hpp
+++ b/include/boost/math/tools/random_vector.hpp
@@ -1,0 +1,129 @@
+//  (C) Copyright Nick Thompson 2018.
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_TOOLS_RANDOM_VECTOR
+#define BOOST_MATH_TOOLS_RANDOM_VECTOR
+
+#include <boost/multiprecision/cpp_bin_float.hpp>
+#include <boost/multiprecision/cpp_complex.hpp>
+#include <vector>
+#include <random>
+#include <type_traits>
+#include <limits>
+#include <cstddef>
+
+using boost::multiprecision::cpp_bin_float_50;
+using boost::multiprecision::cpp_complex_50;
+
+// To stress test, set global_seed = 0, global_size = huge.
+static const std::size_t global_seed = 0;
+static const std::size_t global_size = 128;
+
+template<bool B, class T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
+template<class T, enable_if_t<std::is_floating_point<T>::value, bool> = true>
+std::vector<T> generate_random_vector(std::size_t size, std::size_t seed)
+{
+    if (seed == 0)
+    {
+        std::random_device rd;
+        seed = rd();
+    }
+    std::vector<T> v(size);
+
+    std::mt19937 gen(seed);
+
+    std::normal_distribution<T> dis(0, 1);
+    for(std::size_t i = 0; i < v.size(); ++i)
+    {
+        v[i] = dis(gen);
+    }
+    return v;
+}
+
+template<class T, enable_if_t<std::is_integral<T>::value, bool> = true>
+std::vector<T> generate_random_vector(std::size_t size, std::size_t seed)
+{
+    if (seed == 0)
+    {
+        std::random_device rd;
+        seed = rd();
+    }
+    std::vector<T> v(size);
+
+    std::mt19937 gen(seed);
+
+    // Rescaling by larger than 2 is UB!
+    std::uniform_int_distribution<T> dis(std::numeric_limits<T>::lowest()/2, (std::numeric_limits<T>::max)()/2);
+    for (std::size_t i = 0; i < v.size(); ++i)
+    {
+        v[i] = dis(gen);
+    }
+    return v;
+}
+
+template<class T, enable_if_t<boost::is_complex<T>::value, bool> = true>
+std::vector<T> generate_random_vector(std::size_t size, std::size_t seed)
+{
+    if (seed == 0)
+    {
+        std::random_device rd;
+        seed = rd();
+    }
+    std::vector<T> v(size);
+
+    std::mt19937 gen(seed);
+    
+    std::normal_distribution<typename T::value_type> dis(0, 1);
+    for (std::size_t i = 0; i < v.size(); ++i)
+    {
+        v[i] = {dis(gen), dis(gen)};
+    }
+    return v;  
+}
+
+template<class T, enable_if_t<std::is_same<T, cpp_complex_50>::value , bool> = true>
+std::vector<T> generate_random_vector(std::size_t size, std::size_t seed)
+{
+    if (seed == 0)
+    {
+        std::random_device rd;
+        seed = rd();
+    }
+    std::vector<T> v(size);
+
+    std::mt19937 gen(seed);
+    
+    std::normal_distribution<long double> dis(0, 1);
+    for (std::size_t i = 0; i < v.size(); ++i)
+    {
+        v[i] = {dis(gen), dis(gen)};
+    }
+    return v;
+}
+
+template<class T, enable_if_t<std::is_same<T, cpp_bin_float_50>::value , bool> = true>
+std::vector<T> generate_random_vector(std::size_t size, std::size_t seed)
+{
+    if (seed == 0)
+    {
+        std::random_device rd;
+        seed = rd();
+    }
+    std::vector<T> v(size);
+
+    std::mt19937 gen(seed);
+
+    std::normal_distribution<long double> dis(0, 1);
+    for (std::size_t i = 0; i < v.size(); ++i)
+    {
+        v[i] = dis(gen);
+    }
+    return v;
+}
+
+#endif // BOOST_MATH_TOOLS_RANDOM_VECTOR

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -973,6 +973,7 @@ test-suite misc :
    [ run compile_test/catmull_rom_concept_test.cpp compile_test_main   : : : [ requires cxx11_hdr_array cxx11_hdr_initializer_list ] ]
    [ run univariate_statistics_test.cpp ../../test/build//boost_unit_test_framework : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run univariate_statistics_backwards_compatible_test.cpp ../../test/build//boost_unit_test_framework : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx11_hdr_forward_list cxx11_hdr_atomic cxx11_hdr_thread cxx11_hdr_tuple cxx11_hdr_future cxx11_sfinae_expr ] ]
+   [ run test_statistics_set.cpp ../../test/build//boost_unit_test_framework : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run ooura_fourier_integral_test.cpp ../../test/build//boost_unit_test_framework : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run empirical_cumulative_distribution_test.cpp  : : :  [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run norms_test.cpp ../../test/build//boost_unit_test_framework : : :  [ requires cxx17_if_constexpr cxx17_std_apply ] ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -973,7 +973,7 @@ test-suite misc :
    [ run compile_test/catmull_rom_concept_test.cpp compile_test_main   : : : [ requires cxx11_hdr_array cxx11_hdr_initializer_list ] ]
    [ run univariate_statistics_test.cpp ../../test/build//boost_unit_test_framework : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run univariate_statistics_backwards_compatible_test.cpp ../../test/build//boost_unit_test_framework : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx11_hdr_forward_list cxx11_hdr_atomic cxx11_hdr_thread cxx11_hdr_tuple cxx11_hdr_future cxx11_sfinae_expr ] ]
-   [ run test_statistics_set.cpp ../../test/build//boost_unit_test_framework : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx17_if_constexpr cxx17_std_apply ] ]
+   [ run test_statistics_set.cpp ../../test/build//boost_unit_test_framework : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx11_hdr_forward_list cxx11_hdr_atomic cxx11_hdr_thread cxx11_hdr_tuple cxx11_hdr_future cxx11_sfinae_expr ] ]
    [ run ooura_fourier_integral_test.cpp ../../test/build//boost_unit_test_framework : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run empirical_cumulative_distribution_test.cpp  : : :  [ requires cxx17_if_constexpr cxx17_std_apply ] ]
    [ run norms_test.cpp ../../test/build//boost_unit_test_framework : : :  [ requires cxx17_if_constexpr cxx17_std_apply ] ]

--- a/test/test_statistics_set.cpp
+++ b/test/test_statistics_set.cpp
@@ -109,7 +109,7 @@ void test_integer(ExecutionPolicy&& exec)
     test.emplace_back(2.0);
     test.emplace_back(2.0);
 
-    boost::math::statistics::stats set(exec, test.begin(), test.end());
+    boost::math::statistics::integer_stats set(exec, test.begin(), test.end());
     set.calc(metrics::all);
 
     BOOST_TEST(abs(set.mean() - boost::math::statistics::mean(exec, test.begin(), test.end())) < tol);
@@ -138,7 +138,14 @@ int main(void)
     //test<cpp_bin_float_50>(std::execution::seq);
     //test<cpp_bin_float_50>(std::execution::par);
 
-    //test<int>(std::execution::seq);
+    test_integer<int>(std::execution::seq);
+    test_integer<int>(std::execution::par);
+    test_integer<int32_t>(std::execution::seq);
+    test_integer<int32_t>(std::execution::par);
+    test_integer<int64_t>(std::execution::seq);
+    test_integer<int64_t>(std::execution::par);
+    test_integer<uint32_t>(std::execution::seq);
+    test_integer<uint32_t>(std::execution::par);
     
     #endif
     return boost::report_errors();

--- a/test/test_statistics_set.cpp
+++ b/test/test_statistics_set.cpp
@@ -96,6 +96,32 @@ void test(ExecutionPolicy&& exec)
     BOOST_TEST(abs(std::get<0>(set.first_four_moments()) - std::get<0>(boost::math::statistics::first_four_moments(exec, test.begin(), test.end()))) < tol);
 }
 
+template<typename Z, typename ExecutionPolicy>
+void test_integer(ExecutionPolicy&& exec)
+{
+    using boost::math::statistics::metrics;
+    using std::sqrt;
+    
+    const double tol = 10*std::numeric_limits<double>::epsilon();
+
+    std::vector<double> test {generate_random_vector<double>(global_size, global_seed)};
+    // Add a pair of values to guarantee there is a mode
+    test.emplace_back(2.0);
+    test.emplace_back(2.0);
+
+    boost::math::statistics::stats set(exec, test.begin(), test.end());
+    set.calc(metrics::all);
+
+    BOOST_TEST(abs(set.mean() - boost::math::statistics::mean(exec, test.begin(), test.end())) < tol);
+    BOOST_TEST(abs(set.median() - boost::math::statistics::median(exec, test.begin(), test.end())) < tol);
+    BOOST_TEST(set.mode().size() != 0);
+    
+    const double var = boost::math::statistics::variance(exec, test.begin(), test.end());
+    BOOST_TEST(abs(set.stddev() - sqrt(var)) < tol);
+    BOOST_TEST(abs(set.variance() - var) < tol);
+    BOOST_TEST(abs(std::get<0>(set.first_four_moments()) - std::get<0>(boost::math::statistics::first_four_moments(exec, test.begin(), test.end()))) < tol);
+}
+
 int main(void)
 {   
     // Support compilers with P0024R2 implemented without linking TBB
@@ -111,6 +137,8 @@ int main(void)
     // Expensive using CI:
     //test<cpp_bin_float_50>(std::execution::seq);
     //test<cpp_bin_float_50>(std::execution::par);
+
+    //test<int>(std::execution::seq);
     
     #endif
     return boost::report_errors();

--- a/test/test_statistics_set.cpp
+++ b/test/test_statistics_set.cpp
@@ -7,68 +7,17 @@
 #include <boost/math/statistics/set.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/multiprecision/cpp_bin_float.hpp>
+#include <boost/math/tools/random_vector.hpp>
 #include <random>
 #include <algorithm>
 #include <iostream>
 #include <cstddef>
 #include <cmath>
 
+// Support compilers with P0024R2 implemented without linking TBB
+// https://en.cppreference.com/w/cpp/compiler_support
 #if (__cplusplus > 201700 || _MSVC_LANG > 201700) && (__GNUC__ > 9 || (__clang_major__ > 9 && defined __GLIBCXX__)  || _MSC_VER > 1927)
 #include <execution>
-#endif
-
-using boost::multiprecision::cpp_bin_float_50;
-
-// To stress test, set global_seed = 0, global_size = huge.
-static constexpr std::size_t global_seed = 0;
-static constexpr std::size_t global_size = 128;
-
-template<typename T>
-std::vector<T> generate_random_vector(std::size_t size, std::size_t seed)
-{
-    if (seed == 0)
-    {
-        std::random_device rd;
-        seed = rd();
-    }
-    std::vector<T> v(size);
-
-    std::mt19937 gen(seed);
-
-    if constexpr (std::is_floating_point<T>::value)
-    {
-        std::normal_distribution<T> dis(0, 1);
-        for (std::size_t i = 0; i < v.size(); ++i)
-        {
-         v[i] = dis(gen);
-        }
-        return v;
-    }
-    else if constexpr (std::is_integral<T>::value)
-    {
-        // Rescaling by larger than 2 is UB!
-        std::uniform_int_distribution<T> dis(std::numeric_limits<T>::lowest()/2, (std::numeric_limits<T>::max)()/2);
-        for (std::size_t i = 0; i < v.size(); ++i)
-        {
-         v[i] = dis(gen);
-        }
-        return v;
-    }
-    else if constexpr (boost::multiprecision::number_category<T>::value == boost::multiprecision::number_kind_floating_point)
-    {
-        std::normal_distribution<long double> dis(0, 1);
-        for (std::size_t i = 0; i < v.size(); ++i)
-        {
-            v[i] = dis(gen);
-        }
-        return v;
-    }
-    else
-    {
-        BOOST_ASSERT_MSG(false, "Could not identify type for random vector generation.");
-        return v;
-    }
-}
 
 template<typename Real, typename ExecutionPolicy>
 void test(ExecutionPolicy&& exec)
@@ -123,11 +72,7 @@ void test_integer(ExecutionPolicy&& exec)
 }
 
 int main(void)
-{   
-    // Support compilers with P0024R2 implemented without linking TBB
-    // https://en.cppreference.com/w/cpp/compiler_support
-    #if (__cplusplus > 201700 || _MSVC_LANG > 201700) && (__GNUC__ > 9 || (__clang_major__ > 9 && defined __GLIBCXX__)  || _MSC_VER > 1927)
-    
+{       
     test<float>(std::execution::seq);
     test<float>(std::execution::par);
     test<double>(std::execution::seq);
@@ -147,6 +92,83 @@ int main(void)
     test_integer<uint32_t>(std::execution::seq);
     test_integer<uint32_t>(std::execution::par);
     
-    #endif
     return boost::report_errors();
 }
+#else
+
+template<typename Real>
+void test()
+{
+    using boost::math::statistics::metrics;
+    using std::sqrt;
+    
+    const Real tol = 10*std::numeric_limits<Real>::epsilon();
+
+    std::vector<Real> test {generate_random_vector<Real>(global_size, global_seed)};
+    // Add a pair of values to guarantee there is a mode
+    test.emplace_back(Real(2));
+    test.emplace_back(Real(2));
+    
+    boost::math::statistics::stats<decltype(test.begin()), Real> set(test.begin(), test.end());
+    set.calc(metrics::all);
+
+    BOOST_TEST(abs(set.mean() - boost::math::statistics::mean(test.begin(), test.end())) < tol);
+    BOOST_TEST(abs(set.median() - boost::math::statistics::median(test.begin(), test.end())) < tol);
+    BOOST_TEST(set.mode().size() != 0);
+    
+    const Real var = boost::math::statistics::variance(test.begin(), test.end());
+    BOOST_TEST(abs(set.stddev() - sqrt(var)) < tol);
+    BOOST_TEST(abs(set.variance() - var) < tol);
+    BOOST_TEST(abs(std::get<0>(set.first_four_moments()) - std::get<0>(boost::math::statistics::first_four_moments(test.begin(), test.end()))) < tol);
+}
+
+template<typename Z>
+void test_integer()
+{
+    using boost::math::statistics::metrics;
+    using std::sqrt;
+    
+    const double tol = 10*std::numeric_limits<double>::epsilon();
+
+    std::vector<double> test {generate_random_vector<double>(global_size, global_seed)};
+    // Add a pair of values to guarantee there is a mode
+    test.emplace_back(2.0);
+    test.emplace_back(2.0);
+
+    boost::math::statistics::integer_stats<decltype(test.begin()), Z> set(test.begin(), test.end());
+    set.calc(metrics::all);
+
+    BOOST_TEST(abs(set.mean() - boost::math::statistics::mean(test.begin(), test.end())) < tol);
+    BOOST_TEST(abs(set.median() - boost::math::statistics::median(test.begin(), test.end())) < tol);
+    BOOST_TEST(set.mode().size() != 0);
+    
+    const double var = boost::math::statistics::variance(test.begin(), test.end());
+    BOOST_TEST(abs(set.stddev() - sqrt(var)) < tol);
+    BOOST_TEST(abs(set.variance() - var) < tol);
+    BOOST_TEST(abs(std::get<0>(set.first_four_moments()) - std::get<0>(boost::math::statistics::first_four_moments(test.begin(), test.end()))) < tol);
+}
+
+int main(void) 
+{
+    test<float>();
+    test<float>();
+    test<double>();
+    test<double>();
+    test<long double>();
+    test<long double>();
+    // Expensive using CI:
+    //test<cpp_bin_float_50>();
+    //test<cpp_bin_float_50>();
+
+    test_integer<int>();
+    test_integer<int>();
+    test_integer<int32_t>();
+    test_integer<int32_t>();
+    test_integer<int64_t>();
+    test_integer<int64_t>();
+    test_integer<uint32_t>();
+    test_integer<uint32_t>();
+    
+    return boost::report_errors();
+}
+#endif

--- a/test/test_statistics_set.cpp
+++ b/test/test_statistics_set.cpp
@@ -1,0 +1,117 @@
+//  (C) Copyright Nick Thompson 2018.
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/math/statistics/set.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <boost/multiprecision/cpp_bin_float.hpp>
+#include <random>
+#include <algorithm>
+#include <iostream>
+#include <cstddef>
+#include <cmath>
+
+#if (__cplusplus > 201700 || _MSVC_LANG > 201700) && (__GNUC__ > 9 || (__clang_major__ > 9 && defined __GLIBCXX__)  || _MSC_VER > 1927)
+#include <execution>
+#endif
+
+using boost::multiprecision::cpp_bin_float_50;
+
+// To stress test, set global_seed = 0, global_size = huge.
+static constexpr std::size_t global_seed = 0;
+static constexpr std::size_t global_size = 128;
+
+template<typename T>
+std::vector<T> generate_random_vector(std::size_t size, std::size_t seed)
+{
+    if (seed == 0)
+    {
+        std::random_device rd;
+        seed = rd();
+    }
+    std::vector<T> v(size);
+
+    std::mt19937 gen(seed);
+
+    if constexpr (std::is_floating_point<T>::value)
+    {
+        std::normal_distribution<T> dis(0, 1);
+        for (std::size_t i = 0; i < v.size(); ++i)
+        {
+         v[i] = dis(gen);
+        }
+        return v;
+    }
+    else if constexpr (std::is_integral<T>::value)
+    {
+        // Rescaling by larger than 2 is UB!
+        std::uniform_int_distribution<T> dis(std::numeric_limits<T>::lowest()/2, (std::numeric_limits<T>::max)()/2);
+        for (std::size_t i = 0; i < v.size(); ++i)
+        {
+         v[i] = dis(gen);
+        }
+        return v;
+    }
+    else if constexpr (boost::multiprecision::number_category<T>::value == boost::multiprecision::number_kind_floating_point)
+    {
+        std::normal_distribution<long double> dis(0, 1);
+        for (std::size_t i = 0; i < v.size(); ++i)
+        {
+            v[i] = dis(gen);
+        }
+        return v;
+    }
+    else
+    {
+        BOOST_ASSERT_MSG(false, "Could not identify type for random vector generation.");
+        return v;
+    }
+}
+
+template<typename Real, typename ExecutionPolicy>
+void test(ExecutionPolicy&& exec)
+{
+    using boost::math::statistics::metrics;
+    using std::sqrt;
+    
+    const Real tol = 10*std::numeric_limits<Real>::epsilon();
+
+    std::vector<Real> test {generate_random_vector<Real>(global_size, global_seed)};
+    // Add a pair of values to guarantee there is a mode
+    test.emplace_back(Real(2));
+    test.emplace_back(Real(2));
+    
+    boost::math::statistics::stats set(exec, test.begin(), test.end());
+    set.calc(metrics::all);
+
+    BOOST_TEST(abs(set.mean() - boost::math::statistics::mean(exec, test.begin(), test.end())) < tol);
+    BOOST_TEST(abs(set.median() - boost::math::statistics::median(exec, test.begin(), test.end())) < tol);
+    BOOST_TEST(set.mode().size() != 0);
+    
+    const Real var = boost::math::statistics::variance(exec, test.begin(), test.end());
+    BOOST_TEST(abs(set.stddev() - sqrt(var)) < tol);
+    BOOST_TEST(abs(set.variance() - var) < tol);
+    BOOST_TEST(abs(std::get<0>(set.first_four_moments()) - std::get<0>(boost::math::statistics::first_four_moments(exec, test.begin(), test.end()))) < tol);
+}
+
+int main(void)
+{   
+    // Support compilers with P0024R2 implemented without linking TBB
+    // https://en.cppreference.com/w/cpp/compiler_support
+    #if (__cplusplus > 201700 || _MSVC_LANG > 201700) && (__GNUC__ > 9 || (__clang_major__ > 9 && defined __GLIBCXX__)  || _MSC_VER > 1927)
+    
+    test<float>(std::execution::seq);
+    test<float>(std::execution::par);
+    test<double>(std::execution::seq);
+    test<double>(std::execution::par);
+    test<long double>(std::execution::seq);
+    test<long double>(std::execution::par);
+    // Expensive using CI:
+    //test<cpp_bin_float_50>(std::execution::seq);
+    //test<cpp_bin_float_50>(std::execution::par);
+    
+    #endif
+    return boost::report_errors();
+}


### PR DESCRIPTION
My cut at implementing the statistics class outlined in [P1708](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1708r2.pdf). Until meta-classes are added there is not an obvious (to me) way to offer more interfaces under `stats` instead of resorting to using `integer_stats` 