### PR TITLE
Fix MSVC MINMAX CI Failures

### DIFF
--- a/test/pch_light.hpp
+++ b/test/pch_light.hpp
@@ -5,6 +5,10 @@
 
 #ifdef BOOST_BUILD_PCH_ENABLED
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif 
+
 #define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
 #include <boost/math/special_functions/math_fwd.hpp>
 #include <boost/math/tools/test.hpp>

--- a/test/test_carlson.cpp
+++ b/test/test_carlson.cpp
@@ -4,8 +4,9 @@
 //  Use, modification and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif 
 #include <pch_light.hpp>
 #include "test_carlson.hpp"
 

--- a/test/test_carlson.cpp
+++ b/test/test_carlson.cpp
@@ -5,6 +5,7 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#define NOMINMAX
 #include <pch_light.hpp>
 #include "test_carlson.hpp"
 

--- a/test/test_carlson.hpp
+++ b/test/test_carlson.hpp
@@ -4,6 +4,7 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#define NOMINMAX
 #include <boost/math/concepts/real_concept.hpp>
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>

--- a/test/test_carlson.hpp
+++ b/test/test_carlson.hpp
@@ -4,7 +4,15 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
 #include <boost/math/concepts/real_concept.hpp>
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>

--- a/test/test_carlson.hpp
+++ b/test/test_carlson.hpp
@@ -4,15 +4,6 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#ifdef min
-#undef min
-#endif
-#ifdef max
-#undef max
-#endif
 #include <boost/math/concepts/real_concept.hpp>
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>

--- a/test/test_jacobi_theta.hpp
+++ b/test/test_jacobi_theta.hpp
@@ -1,6 +1,7 @@
 // Copyright John Maddock 2006.
 // Copyright Evan Miller 2020
 #define BOOST_TEST_MAIN
+#define NOMINMAX
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 #include <boost/math/special_functions/ellint_rf.hpp>


### PR DESCRIPTION
Many of these errors continue to stem from https://github.com/boostorg/random/pull/76 not being resolved.