### PR TITLE
Fixes for test_std_lib CI failures in float128

### DIFF
--- a/test/float128/test_std_lib.cpp
+++ b/test/float128/test_std_lib.cpp
@@ -8,6 +8,13 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 #include <iostream>
+#include <complex>
+
+using std::real;
+using std::imag;
+using std::arg;
+using std::norm;
+using std::proj;
 
 BOOST_AUTO_TEST_CASE( test_main )
 {


### PR DESCRIPTION
Fix for large number of CI failures in `test_std_lib` in float128 tests. [Example here](https://travis-ci.org/github/mborland/math/jobs/757277541#L873).