### PR TITLE
Remove MPL from e_float

### DIFF
--- a/include/boost/math/bindings/e_float.hpp
+++ b/include/boost/math/bindings/e_float.hpp
@@ -26,6 +26,10 @@
 #include <boost/math/bindings/detail/big_digamma.hpp>
 #include <boost/math/bindings/detail/big_lanczos.hpp>
 #include <boost/lexical_cast.hpp>
+#include <type_traits>
+#include <array>
+#include <cstdint>
+#include <cmath>
 
 
 namespace boost{ namespace math{ namespace ef{
@@ -72,11 +76,11 @@ public:
    }
    e_float(unsigned long c)
    {
-      m_value = ::e_float((UINT64)c);
+      m_value = ::e_float(static_cast<std::uint64_t>(c));
    }
    e_float(long c)
    {
-      m_value = ::e_float((INT64)c);
+      m_value = ::e_float(static_cast<std::int64_t>(c));
    }
 #ifdef BOOST_HAS_LONG_LONG
    e_float(boost::ulong_long_type c)
@@ -112,8 +116,8 @@ public:
    e_float& operator=(unsigned short c) { m_value = ::e_float(c); return *this; }
    e_float& operator=(int c) { m_value = ::e_float(c); return *this; }
    e_float& operator=(unsigned int c) { m_value = ::e_float(c); return *this; }
-   e_float& operator=(long c) { m_value = ::e_float((INT64)c); return *this; }
-   e_float& operator=(unsigned long c) { m_value = ::e_float((UINT64)c); return *this; }
+   e_float& operator=(long c) { m_value = ::e_float(static_cast<std::int64_t>(c)); return *this; }
+   e_float& operator=(unsigned long c) { m_value = ::e_float(static_cast<std::uint64_t>(c)); return *this; }
 #ifdef BOOST_HAS_LONG_LONG
    e_float& operator=(boost::long_long_type c) { m_value = ::e_float(c); return *this; }
    e_float& operator=(boost::ulong_long_type c) { m_value = ::e_float(c); return *this; }
@@ -143,7 +147,7 @@ public:
 private:
    ::e_float m_value;
 
-   template <class V>
+   template <typename V>
    void assign_large_real(const V& a)
    {
       using std::frexp;
@@ -186,7 +190,7 @@ private:
          term = floor(f);
          e -= 30;
          m_value *= shift;
-         m_value += ::e_float(static_cast<INT64>(term));
+         m_value += ::e_float(static_cast<std::int64_t>(term));
          f -= term;
       }
       m_value *= ::ef::pow2(e);
@@ -332,7 +336,7 @@ inline e_float ldexp(const e_float& v, int e)
 inline e_float frexp(const e_float& v, int* expon)
 {
    double d;
-   INT64 i;
+   std::int64_t i;
    v.value().extract_parts(d, i);
    *expon = static_cast<int>(i);
    return v.value() * ::ef::pow2(-i);
@@ -394,7 +398,7 @@ inline int fpclassify_imp< boost::math::ef::e_float> BOOST_NO_MACRO_EXPAND(boost
 
 } namespace ef{
 
-template <class Policy>
+template <typename Policy>
 inline int itrunc(const e_float& v, const Policy& pol)
 {
    BOOST_MATH_STD_USING
@@ -404,7 +408,7 @@ inline int itrunc(const e_float& v, const Policy& pol)
    return static_cast<int>(r.value().extract_int64());
 }
 
-template <class Policy>
+template <typename Policy>
 inline long ltrunc(const e_float& v, const Policy& pol)
 {
    BOOST_MATH_STD_USING
@@ -415,7 +419,7 @@ inline long ltrunc(const e_float& v, const Policy& pol)
 }
 
 #ifdef BOOST_HAS_LONG_LONG
-template <class Policy>
+template <typename Policy>
 inline boost::long_long_type lltrunc(const e_float& v, const Policy& pol)
 {
    BOOST_MATH_STD_USING
@@ -426,7 +430,7 @@ inline boost::long_long_type lltrunc(const e_float& v, const Policy& pol)
 }
 #endif
 
-template <class Policy>
+template <typename Policy>
 inline int iround(const e_float& v, const Policy& pol)
 {
    BOOST_MATH_STD_USING
@@ -436,7 +440,7 @@ inline int iround(const e_float& v, const Policy& pol)
    return static_cast<int>(r.value().extract_int64());
 }
 
-template <class Policy>
+template <typename Policy>
 inline long lround(const e_float& v, const Policy& pol)
 {
    BOOST_MATH_STD_USING
@@ -447,7 +451,7 @@ inline long lround(const e_float& v, const Policy& pol)
 }
 
 #ifdef BOOST_HAS_LONG_LONG
-template <class Policy>
+template <typename Policy>
 inline boost::long_long_type llround(const e_float& v, const Policy& pol)
 {
    BOOST_MATH_STD_USING
@@ -504,19 +508,19 @@ namespace boost{ namespace math{
 
 namespace policies{
 
-template <class Policy>
+template <typename Policy>
 struct precision< ::boost::math::ef::e_float, Policy>
 {
-   typedef typename Policy::precision_type precision_type;
-   typedef digits2<((::std::numeric_limits< ::boost::math::ef::e_float>::digits10 + 1) * 1000L) / 301L> digits_2;
-   typedef typename mpl::if_c<
+   using precision_type = typename Policy::precision_type;
+   using digits_2 = digits2<((::std::numeric_limits< ::boost::math::ef::e_float>::digits10 + 1) * 1000L) / 301L>;
+   using type = typename std::conditional<
       ((digits_2::value <= precision_type::value) 
       || (Policy::precision_type::value <= 0)),
       // Default case, full precision for RealType:
       digits_2,
       // User customised precision:
       precision_type
-   >::type type;
+      >::type;
 };
 
 }
@@ -532,44 +536,44 @@ inline int digits< ::boost::math::ef::e_float>(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE
 template <>
 inline  ::boost::math::ef::e_float root_epsilon< ::boost::math::ef::e_float>()
 {
-   return detail::root_epsilon_imp(static_cast< ::boost::math::ef::e_float const*>(0), boost::integral_constant<int, 0>());
+   return detail::root_epsilon_imp(static_cast< ::boost::math::ef::e_float const*>(0), std::integral_constant<int, 0>());
 }
 
 template <>
 inline  ::boost::math::ef::e_float forth_root_epsilon< ::boost::math::ef::e_float>()
 {
-   return detail::forth_root_epsilon_imp(static_cast< ::boost::math::ef::e_float const*>(0), boost::integral_constant<int, 0>());
+   return detail::forth_root_epsilon_imp(static_cast< ::boost::math::ef::e_float const*>(0), std::integral_constant<int, 0>());
 }
 
 }
 
 namespace lanczos{
 
-template<class Policy>
+template<typename Policy>
 struct lanczos<boost::math::ef::e_float, Policy>
 {
-   typedef typename mpl::if_c<
+   using type = typename std::conditional<
       std::numeric_limits< ::e_float>::digits10 < 22,
       lanczos13UDT,
-      typename mpl::if_c<
+      typename std::conditional<
          std::numeric_limits< ::e_float>::digits10 < 36,
          lanczos22UDT,
-         typename mpl::if_c<
+         typename std::conditional<
             std::numeric_limits< ::e_float>::digits10 < 50,
             lanczos31UDT,
-            typename mpl::if_c<
+            typename std::conditional<
                std::numeric_limits< ::e_float>::digits10 < 110,
                lanczos61UDT,
                undefined_lanczos
             >::type
          >::type
       >::type
-   >::type type;
+   >::type;
 };
 
 } // namespace lanczos
 
-template <class Policy>
+template <typename Policy>
 inline boost::math::ef::e_float skewness(const extreme_value_distribution<boost::math::ef::e_float, Policy>& /*dist*/)
 {
    //
@@ -579,7 +583,7 @@ inline boost::math::ef::e_float skewness(const extreme_value_distribution<boost:
    return boost::lexical_cast<boost::math::ef::e_float>("1.1395470994046486574927930193898461120875997958366");
 }
 
-template <class Policy>
+template <typename Policy>
 inline boost::math::ef::e_float skewness(const rayleigh_distribution<boost::math::ef::e_float, Policy>& /*dist*/)
 {
   // using namespace boost::math::constants;
@@ -588,7 +592,7 @@ inline boost::math::ef::e_float skewness(const rayleigh_distribution<boost::math
   // return 2 * root_pi<RealType>() * pi_minus_three<RealType>() / pow23_four_minus_pi<RealType>();
 }
 
-template <class Policy>
+template <typename Policy>
 inline boost::math::ef::e_float kurtosis(const rayleigh_distribution<boost::math::ef::e_float, Policy>& /*dist*/)
 {
   // using namespace boost::math::constants;
@@ -598,7 +602,7 @@ inline boost::math::ef::e_float kurtosis(const rayleigh_distribution<boost::math
   // (four_minus_pi<RealType>() * four_minus_pi<RealType>());
 }
 
-template <class Policy>
+template <typename Policy>
 inline boost::math::ef::e_float kurtosis_excess(const rayleigh_distribution<boost::math::ef::e_float, Policy>& /*dist*/)
 {
   //using namespace boost::math::constants;
@@ -613,8 +617,8 @@ namespace detail{
 //
 // Version of Digamma accurate to ~100 decimal digits.
 //
-template <class Policy>
-boost::math::ef::e_float digamma_imp(boost::math::ef::e_float x, const boost::integral_constant<int, 0>* , const Policy& pol)
+template <typename Policy>
+boost::math::ef::e_float digamma_imp(boost::math::ef::e_float x, const std::integral_constant<int, 0>* , const Policy& pol)
 {
    //
    // This handles reflection of negative arguments, and all our
@@ -651,155 +655,155 @@ boost::math::ef::e_float digamma_imp(boost::math::ef::e_float x, const boost::in
 }
 boost::math::ef::e_float bessel_i0(boost::math::ef::e_float x)
 {
-    static const boost::math::ef::e_float P1[] = {
-        boost::lexical_cast<boost::math::ef::e_float>("-2.2335582639474375249e+15"),
-        boost::lexical_cast<boost::math::ef::e_float>("-5.5050369673018427753e+14"),
-        boost::lexical_cast<boost::math::ef::e_float>("-3.2940087627407749166e+13"),
-        boost::lexical_cast<boost::math::ef::e_float>("-8.4925101247114157499e+11"),
-        boost::lexical_cast<boost::math::ef::e_float>("-1.1912746104985237192e+10"),
-        boost::lexical_cast<boost::math::ef::e_float>("-1.0313066708737980747e+08"),
-        boost::lexical_cast<boost::math::ef::e_float>("-5.9545626019847898221e+05"),
-        boost::lexical_cast<boost::math::ef::e_float>("-2.4125195876041896775e+03"),
-        boost::lexical_cast<boost::math::ef::e_float>("-7.0935347449210549190e+00"),
-        boost::lexical_cast<boost::math::ef::e_float>("-1.5453977791786851041e-02"),
-        boost::lexical_cast<boost::math::ef::e_float>("-2.5172644670688975051e-05"),
-        boost::lexical_cast<boost::math::ef::e_float>("-3.0517226450451067446e-08"),
-        boost::lexical_cast<boost::math::ef::e_float>("-2.6843448573468483278e-11"),
-        boost::lexical_cast<boost::math::ef::e_float>("-1.5982226675653184646e-14"),
-        boost::lexical_cast<boost::math::ef::e_float>("-5.2487866627945699800e-18"),
-    };
-    static const boost::math::ef::e_float Q1[] = {
-        boost::lexical_cast<boost::math::ef::e_float>("-2.2335582639474375245e+15"),
-        boost::lexical_cast<boost::math::ef::e_float>("7.8858692566751002988e+12"),
-        boost::lexical_cast<boost::math::ef::e_float>("-1.2207067397808979846e+10"),
-        boost::lexical_cast<boost::math::ef::e_float>("1.0377081058062166144e+07"),
-        boost::lexical_cast<boost::math::ef::e_float>("-4.8527560179962773045e+03"),
-        boost::lexical_cast<boost::math::ef::e_float>("1.0"),
-    };
-    static const boost::math::ef::e_float P2[] = {
-        boost::lexical_cast<boost::math::ef::e_float>("-2.2210262233306573296e-04"),
-        boost::lexical_cast<boost::math::ef::e_float>("1.3067392038106924055e-02"),
-        boost::lexical_cast<boost::math::ef::e_float>("-4.4700805721174453923e-01"),
-        boost::lexical_cast<boost::math::ef::e_float>("5.5674518371240761397e+00"),
-        boost::lexical_cast<boost::math::ef::e_float>("-2.3517945679239481621e+01"),
-        boost::lexical_cast<boost::math::ef::e_float>("3.1611322818701131207e+01"),
-        boost::lexical_cast<boost::math::ef::e_float>("-9.6090021968656180000e+00"),
-    };
-    static const boost::math::ef::e_float Q2[] = {
-        boost::lexical_cast<boost::math::ef::e_float>("-5.5194330231005480228e-04"),
-        boost::lexical_cast<boost::math::ef::e_float>("3.2547697594819615062e-02"),
-        boost::lexical_cast<boost::math::ef::e_float>("-1.1151759188741312645e+00"),
-        boost::lexical_cast<boost::math::ef::e_float>("1.3982595353892851542e+01"),
-        boost::lexical_cast<boost::math::ef::e_float>("-6.0228002066743340583e+01"),
-        boost::lexical_cast<boost::math::ef::e_float>("8.5539563258012929600e+01"),
-        boost::lexical_cast<boost::math::ef::e_float>("-3.1446690275135491500e+01"),
-        boost::lexical_cast<boost::math::ef::e_float>("1.0"),
-    };
-    boost::math::ef::e_float value, factor, r;
+   static const std::array<boost::math::ef::e_float, 15> P1 = {
+      boost::lexical_cast<boost::math::ef::e_float>("-2.2335582639474375249e+15"),
+      boost::lexical_cast<boost::math::ef::e_float>("-5.5050369673018427753e+14"),
+      boost::lexical_cast<boost::math::ef::e_float>("-3.2940087627407749166e+13"),
+      boost::lexical_cast<boost::math::ef::e_float>("-8.4925101247114157499e+11"),
+      boost::lexical_cast<boost::math::ef::e_float>("-1.1912746104985237192e+10"),
+      boost::lexical_cast<boost::math::ef::e_float>("-1.0313066708737980747e+08"),
+      boost::lexical_cast<boost::math::ef::e_float>("-5.9545626019847898221e+05"),
+      boost::lexical_cast<boost::math::ef::e_float>("-2.4125195876041896775e+03"),
+      boost::lexical_cast<boost::math::ef::e_float>("-7.0935347449210549190e+00"),
+      boost::lexical_cast<boost::math::ef::e_float>("-1.5453977791786851041e-02"),
+      boost::lexical_cast<boost::math::ef::e_float>("-2.5172644670688975051e-05"),
+      boost::lexical_cast<boost::math::ef::e_float>("-3.0517226450451067446e-08"),
+      boost::lexical_cast<boost::math::ef::e_float>("-2.6843448573468483278e-11"),
+      boost::lexical_cast<boost::math::ef::e_float>("-1.5982226675653184646e-14"),
+      boost::lexical_cast<boost::math::ef::e_float>("-5.2487866627945699800e-18"),
+   };
+   static const std::array<boost::math::ef::e_float, 6> Q1 = {
+      boost::lexical_cast<boost::math::ef::e_float>("-2.2335582639474375245e+15"),
+      boost::lexical_cast<boost::math::ef::e_float>("7.8858692566751002988e+12"),
+      boost::lexical_cast<boost::math::ef::e_float>("-1.2207067397808979846e+10"),
+      boost::lexical_cast<boost::math::ef::e_float>("1.0377081058062166144e+07"),
+      boost::lexical_cast<boost::math::ef::e_float>("-4.8527560179962773045e+03"),
+      boost::lexical_cast<boost::math::ef::e_float>("1.0"),
+   };
+   static const std::array<boost::math::ef::e_float, 7> P2 = {
+      boost::lexical_cast<boost::math::ef::e_float>("-2.2210262233306573296e-04"),
+      boost::lexical_cast<boost::math::ef::e_float>("1.3067392038106924055e-02"),
+      boost::lexical_cast<boost::math::ef::e_float>("-4.4700805721174453923e-01"),
+      boost::lexical_cast<boost::math::ef::e_float>("5.5674518371240761397e+00"),
+      boost::lexical_cast<boost::math::ef::e_float>("-2.3517945679239481621e+01"),
+      boost::lexical_cast<boost::math::ef::e_float>("3.1611322818701131207e+01"),
+      boost::lexical_cast<boost::math::ef::e_float>("-9.6090021968656180000e+00"),
+   };
+   static const std::array<boost::math::ef::e_float, 8> Q2 = {
+      boost::lexical_cast<boost::math::ef::e_float>("-5.5194330231005480228e-04"),
+      boost::lexical_cast<boost::math::ef::e_float>("3.2547697594819615062e-02"),
+      boost::lexical_cast<boost::math::ef::e_float>("-1.1151759188741312645e+00"),
+      boost::lexical_cast<boost::math::ef::e_float>("1.3982595353892851542e+01"),
+      boost::lexical_cast<boost::math::ef::e_float>("-6.0228002066743340583e+01"),
+      boost::lexical_cast<boost::math::ef::e_float>("8.5539563258012929600e+01"),
+      boost::lexical_cast<boost::math::ef::e_float>("-3.1446690275135491500e+01"),
+      boost::lexical_cast<boost::math::ef::e_float>("1.0"),
+   };
+   boost::math::ef::e_float value, factor, r;
 
-    BOOST_MATH_STD_USING
-    using namespace boost::math::tools;
+   BOOST_MATH_STD_USING
+   using namespace boost::math::tools;
 
-    if (x < 0)
-    {
-        x = -x;                         // even function
-    }
-    if (x == 0)
-    {
-        return static_cast<boost::math::ef::e_float>(1);
-    }
-    if (x <= 15)                        // x in (0, 15]
-    {
-        boost::math::ef::e_float y = x * x;
-        value = evaluate_polynomial(P1, y) / evaluate_polynomial(Q1, y);
-    }
-    else                                // x in (15, \infty)
-    {
-        boost::math::ef::e_float y = 1 / x - boost::math::ef::e_float(1) / 15;
-        r = evaluate_polynomial(P2, y) / evaluate_polynomial(Q2, y);
-        factor = exp(x) / sqrt(x);
-        value = factor * r;
-    }
+   if (x < 0)
+   {
+      x = -x;                         // even function
+   }
+   if (x == 0)
+   {
+      return static_cast<boost::math::ef::e_float>(1);
+   }
+   if (x <= 15)                        // x in (0, 15]
+   {
+      boost::math::ef::e_float y = x * x;
+      value = evaluate_polynomial(P1, y) / evaluate_polynomial(Q1, y);
+   }
+   else                                // x in (15, \infty)
+   {
+      boost::math::ef::e_float y = 1 / x - boost::math::ef::e_float(1) / 15;
+      r = evaluate_polynomial(P2, y) / evaluate_polynomial(Q2, y);
+      factor = exp(x) / sqrt(x);
+      value = factor * r;
+   }
 
-    return value;
+   return value;
 }
 
 boost::math::ef::e_float bessel_i1(boost::math::ef::e_float x)
 {
-    static const boost::math::ef::e_float P1[] = {
-        lexical_cast<boost::math::ef::e_float>("-1.4577180278143463643e+15"),
-        lexical_cast<boost::math::ef::e_float>("-1.7732037840791591320e+14"),
-        lexical_cast<boost::math::ef::e_float>("-6.9876779648010090070e+12"),
-        lexical_cast<boost::math::ef::e_float>("-1.3357437682275493024e+11"),
-        lexical_cast<boost::math::ef::e_float>("-1.4828267606612366099e+09"),
-        lexical_cast<boost::math::ef::e_float>("-1.0588550724769347106e+07"),
-        lexical_cast<boost::math::ef::e_float>("-5.1894091982308017540e+04"),
-        lexical_cast<boost::math::ef::e_float>("-1.8225946631657315931e+02"),
-        lexical_cast<boost::math::ef::e_float>("-4.7207090827310162436e-01"),
-        lexical_cast<boost::math::ef::e_float>("-9.1746443287817501309e-04"),
-        lexical_cast<boost::math::ef::e_float>("-1.3466829827635152875e-06"),
-        lexical_cast<boost::math::ef::e_float>("-1.4831904935994647675e-09"),
-        lexical_cast<boost::math::ef::e_float>("-1.1928788903603238754e-12"),
-        lexical_cast<boost::math::ef::e_float>("-6.5245515583151902910e-16"),
-        lexical_cast<boost::math::ef::e_float>("-1.9705291802535139930e-19"),
-    };
-    static const boost::math::ef::e_float Q1[] = {
-        lexical_cast<boost::math::ef::e_float>("-2.9154360556286927285e+15"),
-        lexical_cast<boost::math::ef::e_float>("9.7887501377547640438e+12"),
-        lexical_cast<boost::math::ef::e_float>("-1.4386907088588283434e+10"),
-        lexical_cast<boost::math::ef::e_float>("1.1594225856856884006e+07"),
-        lexical_cast<boost::math::ef::e_float>("-5.1326864679904189920e+03"),
-        lexical_cast<boost::math::ef::e_float>("1.0"),
-    };
-    static const boost::math::ef::e_float P2[] = {
-        lexical_cast<boost::math::ef::e_float>("1.4582087408985668208e-05"),
-        lexical_cast<boost::math::ef::e_float>("-8.9359825138577646443e-04"),
-        lexical_cast<boost::math::ef::e_float>("2.9204895411257790122e-02"),
-        lexical_cast<boost::math::ef::e_float>("-3.4198728018058047439e-01"),
-        lexical_cast<boost::math::ef::e_float>("1.3960118277609544334e+00"),
-        lexical_cast<boost::math::ef::e_float>("-1.9746376087200685843e+00"),
-        lexical_cast<boost::math::ef::e_float>("8.5591872901933459000e-01"),
-        lexical_cast<boost::math::ef::e_float>("-6.0437159056137599999e-02"),
-    };
-    static const boost::math::ef::e_float Q2[] = {
-        lexical_cast<boost::math::ef::e_float>("3.7510433111922824643e-05"),
-        lexical_cast<boost::math::ef::e_float>("-2.2835624489492512649e-03"),
-        lexical_cast<boost::math::ef::e_float>("7.4212010813186530069e-02"),
-        lexical_cast<boost::math::ef::e_float>("-8.5017476463217924408e-01"),
-        lexical_cast<boost::math::ef::e_float>("3.2593714889036996297e+00"),
-        lexical_cast<boost::math::ef::e_float>("-3.8806586721556593450e+00"),
-        lexical_cast<boost::math::ef::e_float>("1.0"),
-    };
-    boost::math::ef::e_float value, factor, r, w;
+   static const std::array<boost::math::ef::e_float, 15> P1 = {
+      lexical_cast<boost::math::ef::e_float>("-1.4577180278143463643e+15"),
+      lexical_cast<boost::math::ef::e_float>("-1.7732037840791591320e+14"),
+      lexical_cast<boost::math::ef::e_float>("-6.9876779648010090070e+12"),
+      lexical_cast<boost::math::ef::e_float>("-1.3357437682275493024e+11"),
+      lexical_cast<boost::math::ef::e_float>("-1.4828267606612366099e+09"),
+      lexical_cast<boost::math::ef::e_float>("-1.0588550724769347106e+07"),
+      lexical_cast<boost::math::ef::e_float>("-5.1894091982308017540e+04"),
+      lexical_cast<boost::math::ef::e_float>("-1.8225946631657315931e+02"),
+      lexical_cast<boost::math::ef::e_float>("-4.7207090827310162436e-01"),
+      lexical_cast<boost::math::ef::e_float>("-9.1746443287817501309e-04"),
+      lexical_cast<boost::math::ef::e_float>("-1.3466829827635152875e-06"),
+      lexical_cast<boost::math::ef::e_float>("-1.4831904935994647675e-09"),
+      lexical_cast<boost::math::ef::e_float>("-1.1928788903603238754e-12"),
+      lexical_cast<boost::math::ef::e_float>("-6.5245515583151902910e-16"),
+      lexical_cast<boost::math::ef::e_float>("-1.9705291802535139930e-19"),
+   };
+   static const std::array<boost::math::ef::e_float, 6> Q1 = {
+      lexical_cast<boost::math::ef::e_float>("-2.9154360556286927285e+15"),
+      lexical_cast<boost::math::ef::e_float>("9.7887501377547640438e+12"),
+      lexical_cast<boost::math::ef::e_float>("-1.4386907088588283434e+10"),
+      lexical_cast<boost::math::ef::e_float>("1.1594225856856884006e+07"),
+      lexical_cast<boost::math::ef::e_float>("-5.1326864679904189920e+03"),
+      lexical_cast<boost::math::ef::e_float>("1.0"),
+   };
+   static const std::array<boost::math::ef::e_float, 8> P2 = {
+      lexical_cast<boost::math::ef::e_float>("1.4582087408985668208e-05"),
+      lexical_cast<boost::math::ef::e_float>("-8.9359825138577646443e-04"),
+      lexical_cast<boost::math::ef::e_float>("2.9204895411257790122e-02"),
+      lexical_cast<boost::math::ef::e_float>("-3.4198728018058047439e-01"),
+      lexical_cast<boost::math::ef::e_float>("1.3960118277609544334e+00"),
+      lexical_cast<boost::math::ef::e_float>("-1.9746376087200685843e+00"),
+      lexical_cast<boost::math::ef::e_float>("8.5591872901933459000e-01"),
+      lexical_cast<boost::math::ef::e_float>("-6.0437159056137599999e-02"),
+   };
+   static const std::array<boost::math::ef::e_float, 7> Q2 = {
+      lexical_cast<boost::math::ef::e_float>("3.7510433111922824643e-05"),
+      lexical_cast<boost::math::ef::e_float>("-2.2835624489492512649e-03"),
+      lexical_cast<boost::math::ef::e_float>("7.4212010813186530069e-02"),
+      lexical_cast<boost::math::ef::e_float>("-8.5017476463217924408e-01"),
+      lexical_cast<boost::math::ef::e_float>("3.2593714889036996297e+00"),
+      lexical_cast<boost::math::ef::e_float>("-3.8806586721556593450e+00"),
+      lexical_cast<boost::math::ef::e_float>("1.0"),
+   };
+   boost::math::ef::e_float value, factor, r, w;
 
-    BOOST_MATH_STD_USING
-    using namespace boost::math::tools;
+   BOOST_MATH_STD_USING
+   using namespace boost::math::tools;
 
-    w = abs(x);
-    if (x == 0)
-    {
-        return static_cast<boost::math::ef::e_float>(0);
-    }
-    if (w <= 15)                        // w in (0, 15]
-    {
-        boost::math::ef::e_float y = x * x;
-        r = evaluate_polynomial(P1, y) / evaluate_polynomial(Q1, y);
-        factor = w;
-        value = factor * r;
-    }
-    else                                // w in (15, \infty)
-    {
-        boost::math::ef::e_float y = 1 / w - boost::math::ef::e_float(1) / 15;
-        r = evaluate_polynomial(P2, y) / evaluate_polynomial(Q2, y);
-        factor = exp(w) / sqrt(w);
-        value = factor * r;
-    }
+   w = abs(x);
+   if (x == 0)
+   {
+      return static_cast<boost::math::ef::e_float>(0);
+   }
+   if (w <= 15)                        // w in (0, 15]
+   {
+      boost::math::ef::e_float y = x * x;
+      r = evaluate_polynomial(P1, y) / evaluate_polynomial(Q1, y);
+      factor = w;
+      value = factor * r;
+   }
+   else                                // w in (15, \infty)
+   {
+      boost::math::ef::e_float y = 1 / w - boost::math::ef::e_float(1) / 15;
+      r = evaluate_polynomial(P2, y) / evaluate_polynomial(Q2, y);
+      factor = exp(w) / sqrt(w);
+      value = factor * r;
+   }
 
-    if (x < 0)
-    {
-        value *= -value;                 // odd function
-    }
-    return value;
+   if (x < 0)
+   {
+      value *= -value;                 // odd function
+   }
+   return value;
 }
 
 } // namespace detail


### PR DESCRIPTION
Removes use of MPL from e_float. Also replaces: C style casts, C style arrays, and others with C++11 isms. 