### PR TITLE
Fix parameter for test 8 of test_toms748_solve.cpp.

### DIFF
--- a/test/test_toms748_solve.cpp
+++ b/test/test_toms748_solve.cpp
@@ -71,7 +71,7 @@ struct toms748tester
       case 7:
          return (1 + (1 - ip) * (1 - ip)) * x - (1 - ip * x) * (1 - ip * x);
       case 8:
-         return x * x - pow(1 - x, a);
+         return x * x - pow(1 - x, ip);
       case 9:
          return (1 + (1 - ip) * (1 - ip) * (1 - ip) * (1 - ip)) * x - (1 - ip * x) * (1 - ip * x) * (1 - ip * x) * (1 - ip * x);
       case 10:


### PR DESCRIPTION
Fixes https://github.com/boostorg/math/issues/530.