### PR TITLE
Remove duplicate runs from GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,14 @@
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
 name: CI
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+  release:
+    types: [published, created, edited]
 jobs:
   ubuntu-focal:
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ You can either run all the tests listed in `Jamfile.v2` or run a single test:
 ### Continuous Integration ###
 The default action for a PR or commit to a PR is for CI to run the full complement of tests. The following can be appended to the end of a commit message to modify behavior:
 
-    * [CI SKIP] to skip all tests
-    * [LINUX] to test using GCC Versions 5-10 and Clang Versions 5-10 on Ubuntu LTS versions 16.04-20.04.
-    * [APPLE] to test Apple Clang on the latest version of MacOS.
-    * [WINDOWS] to test MSVC-14.0, MSVC-14.2 and mingw on the latest version of Windows.
+    * [ci skip] to skip all tests
+    * [linux] to test using GCC Versions 5-10 and Clang Versions 5-10 on Ubuntu LTS versions 16.04-20.04.
+    * [apple] to test Apple Clang on the latest version of MacOS.
+    * [windows] to test MSVC-14.0, MSVC-14.2 and mingw on the latest version of Windows.
      
 ### Building documentation ###
 


### PR DESCRIPTION
GHA currently runs twice for a commit to a branch that is also a pull request [such as this.](https://github.com/boostorg/math/pull/541) This change will narrow down the runs to just PRs and a push to master or develop. Also adds CI runs to releases since there is one upcoming. Update readme now that GHA [natively supports [ci skip].](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/)