### PR TITLE
Enable c++11,14 use on compilers with <execution>

### DIFF
--- a/include/boost/math/statistics/bivariate_statistics.hpp
+++ b/include/boost/math/statistics/bivariate_statistics.hpp
@@ -17,11 +17,10 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
-#include <boost/assert.hpp>
 
 // Support compilers with P0024R2 implemented without linking TBB
 // https://en.cppreference.com/w/cpp/compiler_support
-#ifndef BOOST_NO_CXX17_HDR_EXECUTION
+#if !defined(BOOST_NO_CXX17_HDR_EXECUTION) && (__cplusplus > 201700L || _MSVC_LANG > 201700L)
 #include <execution>
 #define EXEC_COMPATIBLE
 #endif

--- a/include/boost/math/statistics/univariate_statistics.hpp
+++ b/include/boost/math/statistics/univariate_statistics.hpp
@@ -22,7 +22,7 @@
 
 // Support compilers with P0024R2 implemented without linking TBB
 // https://en.cppreference.com/w/cpp/compiler_support
-#ifndef BOOST_NO_CXX17_HDR_EXECUTION
+#if !defined(BOOST_NO_CXX17_HDR_EXECUTION) && (__cplusplus > 201700L || _MSVC_LANG > 201700L)
 #include <execution>
 
 namespace boost::math::statistics {

--- a/test/bivariate_statistics_test.cpp
+++ b/test/bivariate_statistics_test.cpp
@@ -38,7 +38,7 @@ using boost::multiprecision::cpp_complex_50;
 using  boost::math::statistics::means_and_covariance;
 using  boost::math::statistics::covariance;
 
-#ifndef BOOST_NO_CXX17_HDR_EXECUTION
+#if !defined(BOOST_NO_CXX17_HDR_EXECUTION) && (__cplusplus > 201700L || _MSVC_LANG > 201700L)
 #include <execution>
 
 template<typename Real, typename ExecutionPolicy>


### PR DESCRIPTION
BOOST_NO_CXX17_HDR_EXECUTION fails as a guard if using std=c++11 or c++14 on a compiler that has `<execution>` e.g. GCC10 (default is c++14). Found while poking around on issue #535. @jzmaddock I know we have been going back and forth on this logic, but I think this addition gets it right.