### PR TITLE
Newton-Raphson instrumented message improvements

### DIFF
--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -10,29 +10,16 @@
 #pragma once
 #endif
 
-#include <iostream>
 #include <utility>
 #include <cmath>
-#include <stdexcept>
+#include <tuple>
 
 #include <boost/math/tools/config.hpp>
 #include <boost/cstdint.hpp>
-#include <boost/assert.hpp>
-#include <boost/throw_exception.hpp>
 #include <boost/math/tools/cxx03_warn.hpp>
-
-#ifdef BOOST_MSVC
-#pragma warning(push)
-#pragma warning(disable: 4512)
-#endif
-#include <boost/math/tools/tuple.hpp>
-#ifdef BOOST_MSVC
-#pragma warning(pop)
-#endif
 
 #include <boost/math/special_functions/sign.hpp>
 #include <boost/math/special_functions/next.hpp>
-#include <boost/math/tools/toms748_solve.hpp>
 #include <boost/math/policies/error_handling.hpp>
 
 namespace boost {

--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -9,6 +9,7 @@
 #ifdef _MSC_VER
 #pragma once
 #endif
+#include <boost/math/tools/complex.hpp> // test for multiprecision types in complex Newton
 
 #include <utility>
 #include <cmath>

--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -9,11 +9,10 @@
 #ifdef _MSC_VER
 #pragma once
 #endif
-#include <boost/math/tools/complex.hpp> // test for multiprecision types.
 
 #include <iostream>
 #include <utility>
-#include <boost/config/no_tr1/cmath.hpp>
+#include <cmath.hpp>
 #include <stdexcept>
 
 #include <boost/math/tools/config.hpp>
@@ -498,7 +497,7 @@ namespace detail {
 
 #ifdef BOOST_MATH_INSTRUMENT
         std::cout << "Second order root iteration, guess = " << guess << ", min = " << min << ", max = " << max
-        << ", digits = " << digits << ", max_iter = " << max_iter << std::endl;
+        << ", digits = " << digits << ", max_iter = " << max_iter << "\n";
 #endif
       static const char* function = "boost::math::tools::halley_iterate<%1%>";
       if (min >= max)
@@ -517,7 +516,7 @@ namespace detail {
       bool out_of_bounds_sentry = false;
 
    #ifdef BOOST_MATH_INSTRUMENT
-      std::cout << "Second order root iteration, limit = " << factor << std::endl;
+      std::cout << "Second order root iteration, limit = " << factor << "\n";
    #endif
 
       //
@@ -551,9 +550,6 @@ namespace detail {
          if (f1 == 0)
          {
             // Oops zero derivative!!!
-   #ifdef BOOST_MATH_INSTRUMENT
-            std::cout << "Second order root iteration, zero derivative found!" << std::endl;
-   #endif
             detail::handle_zero_derivative(f, last_f0, f0, delta, result, guess, min, max);
          }
          else
@@ -581,7 +577,7 @@ namespace detail {
                delta = f0 / f1;
          }
    #ifdef BOOST_MATH_INSTRUMENT
-         std::cout << "Second order root iteration, delta = " << delta << std::endl;
+         std::cout << "Second order root iteration, delta = " << delta << ", residual = " << f0 << "\n";
    #endif
          T convergence = fabs(delta / delta2);
          if ((convergence > 0.8) && (convergence < 2))
@@ -679,7 +675,7 @@ namespace detail {
       max_iter -= count;
 
    #ifdef BOOST_MATH_INSTRUMENT
-      std::cout << "Second order root finder, final iteration count = " << max_iter << std::endl;
+      std::cout << "Second order root finder required " << max_iter << " iterations.\n";
    #endif
 
       return result;

--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -205,14 +205,7 @@ std::pair<T, T> bisect(F f, T min, T max, Tol tol, boost::uintmax_t& max_iter, c
    max_iter -= count;
 
 #ifdef BOOST_MATH_INSTRUMENT
-   std::cout << "Bisection iteration, final count = " << max_iter << std::endl;
-
-   static boost::uintmax_t max_count = 0;
-   if (max_iter > max_count)
-   {
-      max_count = max_iter;
-      std::cout << "Maximum iterations: " << max_iter << std::endl;
-   }
+   std::cout << "Bisection required " << max_iter << " iterations.\n";
 #endif
 
    return std::make_pair(min, max);
@@ -238,7 +231,7 @@ T newton_raphson_iterate(F f, T guess, T min, T max, int digits, boost::uintmax_
    BOOST_MATH_STD_USING
 
    static const char* function = "boost::math::tools::newton_raphson_iterate<%1%>";
-   if (min >= max)
+   if (min > max)
    {
       return policies::raise_evaluation_error(function, "Range arguments in wrong order in boost::math::tools::newton_raphson_iterate(first arg=%1%)", min, boost::math::policies::policy<>());
    }
@@ -268,7 +261,7 @@ T newton_raphson_iterate(F f, T guess, T min, T max, int digits, boost::uintmax_
 
 #ifdef BOOST_MATH_INSTRUMENT
    std::cout << "Newton_raphson_iterate, guess = " << guess << ", min = " << min << ", max = " << max
-      << ", digits = " << digits << ", max_iter = " << max_iter << std::endl;
+      << ", digits = " << digits << ", max_iter = " << max_iter << "\n";
 #endif
 
    do {
@@ -282,9 +275,6 @@ T newton_raphson_iterate(F f, T guess, T min, T max, int digits, boost::uintmax_
       if (f1 == 0)
       {
          // Oops zero derivative!!!
-#ifdef BOOST_MATH_INSTRUMENT
-         std::cout << "Newton iteration, zero derivative found!" << std::endl;
-#endif
          detail::handle_zero_derivative(f, last_f0, f0, delta, result, guess, min, max);
       }
       else
@@ -292,7 +282,7 @@ T newton_raphson_iterate(F f, T guess, T min, T max, int digits, boost::uintmax_
          delta = f0 / f1;
       }
 #ifdef BOOST_MATH_INSTRUMENT
-      std::cout << "Newton iteration " << max_iter - count << ", delta = " << delta << std::endl;
+      std::cout << "Newton iteration " << max_iter - count << ", delta = " << delta << ", residual = " << f0 << "\n";
 #endif
       if (fabs(delta * 2) > fabs(delta2))
       {
@@ -348,15 +338,7 @@ T newton_raphson_iterate(F f, T guess, T min, T max, int digits, boost::uintmax_
    max_iter -= count;
 
 #ifdef BOOST_MATH_INSTRUMENT
-   std::cout << "Newton Raphson final iteration count = " << max_iter << std::endl;
-
-   static boost::uintmax_t max_count = 0;
-   if (max_iter > max_count)
-   {
-      max_count = max_iter;
-      // std::cout << "Maximum iterations: " << max_iter << std::endl;
-      // Puzzled what this tells us, so commented out for now?
-   }
+   std::cout << "Newton Raphson required " << max_iter << " iterations\n";
 #endif
 
    return result;

--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -21,6 +21,7 @@
 
 #include <boost/math/special_functions/sign.hpp>
 #include <boost/math/special_functions/next.hpp>
+#include <boost/math/tools/toms748_solve.hpp>
 #include <boost/math/policies/error_handling.hpp>
 
 namespace boost {

--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -12,7 +12,7 @@
 
 #include <iostream>
 #include <utility>
-#include <cmath.hpp>
+#include <cmath>
 #include <stdexcept>
 
 #include <boost/math/tools/config.hpp>

--- a/test/test_root_finding_concepts.cpp
+++ b/test/test_root_finding_concepts.cpp
@@ -13,9 +13,8 @@
 #include <boost/tuple/tuple.hpp>
 #include <boost/fusion/include/tuple.hpp>
 #include <boost/fusion/include/std_pair.hpp>
-#ifndef BOOST_NO_CXX11_HDR_TUPLE
+#include <boost/math/tools/toms748_solve.hpp>
 #include <tuple>
-#endif
 
 #include <iostream>
 #include <iomanip>
@@ -49,7 +48,7 @@ struct cbtr_functor_2a
 private:
    double m_target;
 };
-#ifndef BOOST_NO_CXX11_HDR_TUPLE
+
 struct cbtr_functor_2b
 {
    cbtr_functor_2b(double x) : m_target(x) {}
@@ -60,7 +59,6 @@ struct cbtr_functor_2b
 private:
    double m_target;
 };
-#endif
 struct cbtr_functor_2c
 {
    cbtr_functor_2c(double x) : m_target(x) {}
@@ -82,7 +80,6 @@ private:
    double m_target;
 };
 
-#ifndef BOOST_NO_CXX11_HDR_TUPLE
 struct cbtr_functor_3b
 {
    cbtr_functor_3b(double x) : m_target(x) {}
@@ -93,7 +90,7 @@ struct cbtr_functor_3b
 private:
    double m_target;
 };
-#endif
+
 struct cbtr_functor_3c
 {
    cbtr_functor_3c(double x) : m_target(x) {}
@@ -146,7 +143,6 @@ BOOST_AUTO_TEST_CASE( test_main )
    result = (p.first + p.second) / 2;
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
 
-#ifndef BOOST_NO_CXX11_LAMBDAS
    //
    // Now try again with C++11 lambda's
    //
@@ -167,24 +163,19 @@ BOOST_AUTO_TEST_CASE( test_main )
    p = boost::math::tools::toms748_solve([x](double z){ return z * z * z - x; }, 0.0, x, t, max_iter);
    result = (p.first + p.second) / 2;
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
-#endif
 
    cbtr_functor_2a f2(x);
-#ifndef BOOST_NO_CXX11_HDR_TUPLE
    cbtr_functor_2b f3(x);
-#endif
    cbtr_functor_2c f4(x);
    cbtr_functor_2d f5(x);
 
    //
    // Binary Functors - newton_raphson_iterate - test each possible tuple type:
    //
-#ifndef BOOST_NO_CXX11_HDR_TUPLE
    result = boost::math::tools::newton_raphson_iterate(f2, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
    result = boost::math::tools::newton_raphson_iterate(f3, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
-#endif
    result = boost::math::tools::newton_raphson_iterate(f4, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
    result = boost::math::tools::newton_raphson_iterate(f5, x, 0.0, x, std::numeric_limits<double>::digits - 1);
@@ -192,63 +183,44 @@ BOOST_AUTO_TEST_CASE( test_main )
    //
    // And again but with lambdas:
    //
-#ifndef BOOST_NO_CXX11_LAMBDAS
    result = boost::math::tools::newton_raphson_iterate([x](double z){ return std::make_pair(z * z * z - x, 3 * z * z); }, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
-#ifndef BOOST_NO_CXX11_HDR_TUPLE
    result = boost::math::tools::newton_raphson_iterate([x](double z){ return std::make_tuple(z * z * z - x, 3 * z * z); }, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
-#endif
    result = boost::math::tools::newton_raphson_iterate([x](double z){ return boost::tuple<double, double>(z * z * z - x, 3 * z * z); }, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
    result = boost::math::tools::newton_raphson_iterate([x](double z){ return boost::fusion::tuple<double, double>(z * z * z - x, 3 * z * z); }, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
-#endif
-
-#ifndef BOOST_NO_CXX11_HDR_TUPLE
    cbtr_functor_3b f6(x);
-#endif
    cbtr_functor_3c f7(x);
    cbtr_functor_3d f8(x);
 
    //
    // Ternary functors:
    //
-#ifndef BOOST_NO_CXX11_HDR_TUPLE
    result = boost::math::tools::halley_iterate(f6, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
-#endif
    result = boost::math::tools::halley_iterate(f7, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
    result = boost::math::tools::halley_iterate(f8, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
-#ifndef BOOST_NO_CXX11_LAMBDAS
-#ifndef BOOST_NO_CXX11_HDR_TUPLE
    result = boost::math::tools::halley_iterate([x](double z){ return std::make_tuple(z * z * z - x, 3 * z * z, 6 * z); }, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
-#endif
    result = boost::math::tools::halley_iterate([x](double z){ return boost::tuple<double, double, double>(z * z * z - x, 3 * z * z, 6 * z); }, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
    result = boost::math::tools::halley_iterate([x](double z){ return boost::fusion::tuple<double, double, double>(z * z * z - x, 3 * z * z, 6 * z); }, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
-#endif
-#ifndef BOOST_NO_CXX11_HDR_TUPLE
    result = boost::math::tools::schroder_iterate(f6, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
-#endif
    result = boost::math::tools::schroder_iterate(f7, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
    result = boost::math::tools::schroder_iterate(f8, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
-#ifndef BOOST_NO_CXX11_LAMBDAS
-#ifndef BOOST_NO_CXX11_HDR_TUPLE
    result = boost::math::tools::schroder_iterate([x](double z){ return std::make_tuple(z * z * z - x, 3 * z * z, 6 * z); }, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
-#endif
    result = boost::math::tools::schroder_iterate([x](double z){ return boost::tuple<double, double, double>(z * z * z - x, 3 * z * z, 6 * z); }, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
    result = boost::math::tools::schroder_iterate([x](double z){ return boost::fusion::tuple<double, double, double>(z * z * z - x, 3 * z * z, 6 * z); }, x, 0.0, x, std::numeric_limits<double>::digits - 1);
    BOOST_CHECK_CLOSE_FRACTION(expected, result, tolerance);
-#endif
 } // BOOST_AUTO_TEST_CASE( test_main )
 

--- a/test/test_root_iterations.cpp
+++ b/test/test_root_iterations.cpp
@@ -3,9 +3,7 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <pch.hpp>
-
-#ifndef BOOST_NO_CXX11_HDR_TUPLE
+#include "pch.hpp"
 
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
@@ -322,8 +320,3 @@ BOOST_AUTO_TEST_CASE( test_main )
 
 }
 
-#else
-
-int main() { return 0; }
-
-#endif


### PR DESCRIPTION
The Newton-Raphson method has an option to log convergence via `BOOST_MATH_INSTRUMENT`. However, too much information was give about some things which were not super helpful, and too little about residuals.

In addition, remove buffer flushes as they slow down the process dramatically.