### PR TITLE
Remove MP11 dependency

### DIFF
--- a/include/boost/math/differentiation/autodiff_cpp11.hpp
+++ b/include/boost/math/differentiation/autodiff_cpp11.hpp
@@ -19,7 +19,10 @@
     "Do not #include this file directly. This should only be #included by autodiff.hpp for C++11 compatibility."
 #endif
 
-#include <boost/mp11/integer_sequence.hpp>
+#include <type_traits>
+#include <boost/math/tools/mp.hpp>
+
+namespace mp = boost::math::tools::meta_programming;
 
 namespace boost {
 namespace math {
@@ -354,27 +357,27 @@ fvar<RealType, Order>& fvar<RealType, Order>::set_root(root_type const& root) {
 }
 
 template <typename RealType, size_t Order, size_t... Is>
-auto make_fvar_for_tuple(mp11::index_sequence<Is...>, RealType const& ca)
+auto make_fvar_for_tuple(mp::index_sequence<Is...>, RealType const& ca)
     -> decltype(make_fvar<RealType, zero<Is>::value..., Order>(ca)) {
   return make_fvar<RealType, zero<Is>::value..., Order>(ca);
 }
 
 template <typename RealType, size_t... Orders, size_t... Is, typename... RealTypes>
-auto make_ftuple_impl(mp11::index_sequence<Is...>, RealTypes const&... ca)
-    -> decltype(std::make_tuple(make_fvar_for_tuple<RealType, Orders>(mp11::make_index_sequence<Is>{},
+auto make_ftuple_impl(mp::index_sequence<Is...>, RealTypes const&... ca)
+    -> decltype(std::make_tuple(make_fvar_for_tuple<RealType, Orders>(mp::make_index_sequence<Is>{},
                                                                       ca)...)) {
-  return std::make_tuple(make_fvar_for_tuple<RealType, Orders>(mp11::make_index_sequence<Is>{}, ca)...);
+  return std::make_tuple(make_fvar_for_tuple<RealType, Orders>(mp::make_index_sequence<Is>{}, ca)...);
 }
 
 }  // namespace detail
 
 template <typename RealType, size_t... Orders, typename... RealTypes>
 auto make_ftuple(RealTypes const&... ca)
-    -> decltype(detail::make_ftuple_impl<RealType, Orders...>(mp11::index_sequence_for<RealTypes...>{},
+    -> decltype(detail::make_ftuple_impl<RealType, Orders...>(mp::index_sequence_for<RealTypes...>{},
                                                               ca...)) {
   static_assert(sizeof...(Orders) == sizeof...(RealTypes),
                 "Number of Orders must match number of function parameters.");
-  return detail::make_ftuple_impl<RealType, Orders...>(mp11::index_sequence_for<RealTypes...>{}, ca...);
+  return detail::make_ftuple_impl<RealType, Orders...>(mp::index_sequence_for<RealTypes...>{}, ca...);
 }
 
 }  // namespace autodiff_v1

--- a/include/boost/math/tools/mp.hpp
+++ b/include/boost/math/tools/mp.hpp
@@ -337,7 +337,7 @@ using mp_remove_if_q = mp_remove_if<L, Q::template fn>;
 
 // Index sequence
 // Use C++14 index sequence if available
-#ifndef BOOST_NO_CXX14_VARIABLE_TEMPLATES
+#if defined(__cpp_lib_integer_sequence) && (__cpp_lib_integer_sequence >= 201304)
 #include <utility>
 template<std::size_t... I>
 using index_sequence = std::index_sequence<I...>;

--- a/include/boost/math/tools/mp.hpp
+++ b/include/boost/math/tools/mp.hpp
@@ -388,7 +388,7 @@ struct append_integer_sequence {};
 template<typename T, T... I, T... J>
 struct append_integer_sequence<integer_sequence<T, I...>, integer_sequence<T, J...>>
 {
-    using type = integer_sequence<T, I..., (J + sizeof(I))...>;
+    using type = integer_sequence<T, I..., (J + sizeof...(I))...>;
 };
 
 template<typename T, T N>


### PR DESCRIPTION
Removes the only MP11 dependency. Does not need to make it in for release.