### PR TITLE
Remove boost.throw_exception dependency

### DIFF
--- a/doc/overview/error_handling.qbk
+++ b/doc/overview/error_handling.qbk
@@ -12,6 +12,10 @@ Handling of errors by this library is split into two orthogonal parts:
 [warning The default error actions are to throw an exception with an informative error message.
 [role red If you do not try to catch the exception, you will not see the message!]]
 
+The default behavior is for exceptions to be thrown using boost::throw_exception.
+This facility has special handling for exception free environments.
+If BOOST_MATH_STANDALONE is defined standard library facilities (e.g. throw) are used for exception handling.
+
 The kinds of errors that can be raised are:
 
 [variablelist

--- a/include/boost/math/cstdfloat/cstdfloat_cmath.hpp
+++ b/include/boost/math/cstdfloat/cstdfloat_cmath.hpp
@@ -24,7 +24,7 @@
 #include <type_traits>
 #include <memory>
 #include <boost/math/tools/assert.hpp>
-#include <boost/throw_exception.hpp>
+#include <boost/math/tools/throw_exception.hpp>
 
 #if defined(_WIN32) && defined(__GNUC__)
   // Several versions of Mingw and probably cygwin too have broken
@@ -988,7 +988,7 @@ namespace std
          v = quadmath_snprintf(&buf2[0], v_max + 3, format.c_str(), digits, m_value);
          if (v >= v_max + 3)
          {
-            BOOST_THROW_EXCEPTION(std::runtime_error("Formatting of float128_type failed."));
+            BOOST_MATH_THROW_EXCEPTION(std::runtime_error("Formatting of float128_type failed."));
          }
          s = &buf2[0];
       }

--- a/include/boost/math/cstdfloat/cstdfloat_iostream.hpp
+++ b/include/boost/math/cstdfloat/cstdfloat_iostream.hpp
@@ -29,7 +29,7 @@
   #include <stdexcept>
   #include <string>
   #include <boost/math/tools/assert.hpp>
-  #include <boost/throw_exception.hpp>
+  #include <boost/math/tools/throw_exception.hpp>
 
 //  #if (0)
   #if defined(__GNUC__)
@@ -86,7 +86,7 @@
                                         my_digits,
                                         x);
 
-      if(v < 0) { BOOST_THROW_EXCEPTION(std::runtime_error("Formatting of boost::float128_t failed internally in quadmath_snprintf().")); }
+      if(v < 0) { BOOST_MATH_THROW_EXCEPTION(std::runtime_error("Formatting of boost::float128_t failed internally in quadmath_snprintf().")); }
 
       if(v >= static_cast<int>(sizeof(my_buffer) - 1U))
       {
@@ -106,7 +106,7 @@
         }
         catch(const std::bad_alloc&)
         {
-          BOOST_THROW_EXCEPTION(std::runtime_error("Formatting of boost::float128_t failed while allocating memory."));
+          BOOST_MATH_THROW_EXCEPTION(std::runtime_error("Formatting of boost::float128_t failed while allocating memory."));
         }
 #endif
         const int v2 = ::quadmath_snprintf(my_buffer2,
@@ -117,7 +117,7 @@
 
         if(v2 >= v + 3)
         {
-          BOOST_THROW_EXCEPTION(std::runtime_error("Formatting of boost::float128_t failed."));
+          BOOST_MATH_THROW_EXCEPTION(std::runtime_error("Formatting of boost::float128_t failed."));
         }
 
         static_cast<void>(ostr << my_buffer2);
@@ -152,7 +152,7 @@
 
         is.setstate(ios_base::failbit);
 
-        BOOST_THROW_EXCEPTION(std::runtime_error("Unable to interpret input string as a boost::float128_t"));
+        BOOST_MATH_THROW_EXCEPTION(std::runtime_error("Unable to interpret input string as a boost::float128_t"));
       }
 
       return is;
@@ -760,7 +760,7 @@
 
         is.setstate(ios_base::failbit);
 
-        BOOST_THROW_EXCEPTION(std::runtime_error("Unable to interpret input string as a boost::float128_t"));
+        BOOST_MATH_THROW_EXCEPTION(std::runtime_error("Unable to interpret input string as a boost::float128_t"));
       }
 
       return is;

--- a/include/boost/math/policies/error_handling.hpp
+++ b/include/boost/math/policies/error_handling.hpp
@@ -8,20 +8,20 @@
 #ifndef BOOST_MATH_POLICY_ERROR_HANDLING_HPP
 #define BOOST_MATH_POLICY_ERROR_HANDLING_HPP
 
-#include <stdexcept>
 #include <iomanip>
 #include <string>
 #include <cstring>
 #include <typeinfo>
 #include <cerrno>
-#include <boost/config/no_tr1/complex.hpp>
-#include <boost/config/no_tr1/cmath.hpp>
+#include <complex>
+#include <cmath>
+#include <cstdint>
 #include <stdexcept>
 #include <boost/math/tools/config.hpp>
 #include <boost/math/policies/policy.hpp>
 #include <boost/math/tools/precision.hpp>
-#include <boost/throw_exception.hpp>
-#include <boost/cstdint.hpp>
+#include <boost/math/tools/throw_exception.hpp>
+
 #ifdef BOOST_MSVC
 #  pragma warning(push) // Quiet warnings in boost/format.hpp
 #  pragma warning(disable: 4996) // _SCL_SECURE_NO_DEPRECATE
@@ -140,7 +140,7 @@ void raise_error(const char* pfunction, const char* message)
   msg += message;
 
   E e(msg);
-  boost::throw_exception(e);
+  BOOST_MATH_THROW_EXCEPTION(e)
 }
 
 template <class E, class T>
@@ -167,7 +167,7 @@ void raise_error(const char* pfunction, const char* pmessage, const T& val)
   msg += message;
 
   E e(msg);
-  boost::throw_exception(e);
+  BOOST_MATH_THROW_EXCEPTION(e)
 }
 
 template <class T>
@@ -804,7 +804,7 @@ inline R checked_narrowing_cast(T val, const char* function) BOOST_NOEXCEPT_IF(B
 }
 
 template <class T, class Policy>
-inline void check_series_iterations(const char* function, boost::uintmax_t max_iter, const Policy& pol) BOOST_NOEXCEPT_IF(BOOST_MATH_IS_FLOAT(T) && is_noexcept_error_policy<Policy>::value)
+inline void check_series_iterations(const char* function, std::uintmax_t max_iter, const Policy& pol) BOOST_NOEXCEPT_IF(BOOST_MATH_IS_FLOAT(T) && is_noexcept_error_policy<Policy>::value)
 {
    if(max_iter >= policies::get_max_series_iterations<Policy>())
       raise_evaluation_error<T>(
@@ -813,7 +813,7 @@ inline void check_series_iterations(const char* function, boost::uintmax_t max_i
 }
 
 template <class T, class Policy>
-inline void check_root_iterations(const char* function, boost::uintmax_t max_iter, const Policy& pol) BOOST_NOEXCEPT_IF(BOOST_MATH_IS_FLOAT(T) && is_noexcept_error_policy<Policy>::value)
+inline void check_root_iterations(const char* function, std::uintmax_t max_iter, const Policy& pol) BOOST_NOEXCEPT_IF(BOOST_MATH_IS_FLOAT(T) && is_noexcept_error_policy<Policy>::value)
 {
    if(max_iter >= policies::get_max_root_iterations<Policy>())
       raise_evaluation_error<T>(

--- a/include/boost/math/special_functions/nonfinite_num_facets.hpp
+++ b/include/boost/math/special_functions/nonfinite_num_facets.hpp
@@ -22,10 +22,7 @@
 #include <ios>
 #include <limits>
 #include <locale>
-
-#include <boost/version.hpp>
-#include <boost/throw_exception.hpp>
-
+#include <boost/math/tools/throw_exception.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/math/special_functions/sign.hpp>
 
@@ -104,7 +101,7 @@ namespace boost {
         case FP_INFINITE:
           if(flags_ & trap_infinity)
           {
-            BOOST_THROW_EXCEPTION(std::ios_base::failure("Infinity"));
+            BOOST_MATH_THROW_EXCEPTION(std::ios_base::failure("Infinity"));
           }
           else if((boost::math::signbit)(val))
           { // negative infinity.
@@ -123,7 +120,7 @@ namespace boost {
         case FP_NAN:
           if(flags_ & trap_nan)
           {
-            BOOST_THROW_EXCEPTION(std::ios_base::failure("NaN"));
+            BOOST_MATH_THROW_EXCEPTION(std::ios_base::failure("NaN"));
           }
           else if((boost::math::signbit)(val))
           { // negative so "-nan".

--- a/include/boost/math/special_functions/owens_t.hpp
+++ b/include/boost/math/special_functions/owens_t.hpp
@@ -17,15 +17,15 @@
 #endif
 
 #include <boost/math/special_functions/math_fwd.hpp>
-#include <boost/config/no_tr1/cmath.hpp>
 #include <boost/math/special_functions/erf.hpp>
 #include <boost/math/special_functions/expm1.hpp>
-#include <boost/throw_exception.hpp>
+#include <boost/math/tools/throw_exception.hpp>
 #include <boost/math/tools/assert.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/tools/big_constant.hpp>
 
 #include <stdexcept>
+#include <cmath>
 
 #ifdef BOOST_MSVC
 #pragma warning(push)
@@ -829,7 +829,7 @@ namespace boost
                val = owens_t_T6(h,a, pol);
                break;
             default:
-               BOOST_THROW_EXCEPTION(std::logic_error("selection routine in Owen's T function failed"));
+               BOOST_MATH_THROW_EXCEPTION(std::logic_error("selection routine in Owen's T function failed"));
             }
             return val;
          }

--- a/include/boost/math/tools/throw_exception.hpp
+++ b/include/boost/math/tools/throw_exception.hpp
@@ -1,0 +1,20 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_TOOLS_THROW_EXCEPTION_HPP
+#define BOOST_MATH_TOOLS_THROW_EXCEPTION_HPP
+#define BOOST_MATH_STANDALONE
+#ifndef BOOST_MATH_STANDALONE
+
+#include <boost/throw_exception.hpp>
+#define BOOST_MATH_THROW_EXCEPTION(expr) boost::throw_exception(expr);
+
+#else // Standalone mode - use standard library facilities
+
+#define BOOST_MATH_THROW_EXCEPTION(expr) throw expr;
+
+#endif // BOOST_MATH_STANDALONE
+
+#endif // BOOST_MATH_TOOLS_THROW_EXCEPTION_HPP

--- a/include/boost/math/tools/throw_exception.hpp
+++ b/include/boost/math/tools/throw_exception.hpp
@@ -5,7 +5,7 @@
 
 #ifndef BOOST_MATH_TOOLS_THROW_EXCEPTION_HPP
 #define BOOST_MATH_TOOLS_THROW_EXCEPTION_HPP
-#define BOOST_MATH_STANDALONE
+
 #ifndef BOOST_MATH_STANDALONE
 
 #include <boost/throw_exception.hpp>

--- a/test/compile_test/sf_prime_incl_test.cpp
+++ b/test/compile_test/sf_prime_incl_test.cpp
@@ -12,17 +12,18 @@
 // important if this test is to be meaningful:
 //
 #include "test_compile_result.hpp"
+#include <cstdint>
 
 void compile_and_link_test()
 {
-   check_result<boost::uint32_t>(boost::math::prime(u));
+   check_result<std::uint32_t>(boost::math::prime(u));
    //
    // Add constexpr tests here:
    //
 #ifdef BOOST_MATH_HAVE_CONSTEXPR_TABLES
-   constexpr boost::uint32_t ce_f = boost::math::prime(boost::math::max_prime);
+   constexpr std::uint32_t ce_f = boost::math::prime(boost::math::max_prime);
    static_assert(ce_f == 104729, "max_prime had incorrect value");
-   check_result<boost::uint32_t>(ce_f);
+   check_result<std::uint32_t>(ce_f);
 #endif
 }
 


### PR DESCRIPTION
Contains `#define BOOST_MATH_STANDALONE` so that the CI system will test standalone mode. Will remove before merge.