### PR TITLE
Rework __float128 configuration to take account of Boost.Config.

### DIFF
--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -274,16 +274,17 @@ struct non_type {};
 //
 // And then the actual configuration:
 //
-#if defined(_GLIBCXX_USE_FLOAT128) && defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__) && !defined(__STRICT_ANSI__) \
-   && !defined(BOOST_MATH_DISABLE_FLOAT128) || defined(BOOST_MATH_USE_FLOAT128)
+#if defined(BOOST_MATH_STANDALONE) && defined(_GLIBCXX_USE_FLOAT128) && defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__) && !defined(__STRICT_ANSI__) \
+   && !defined(BOOST_MATH_DISABLE_FLOAT128) && !defined(BOOST_MATH_USE_FLOAT128)
+#  define BOOST_MATH_USE_FLOAT128
+#elif defined(BOOST_HAS_FLOAT128) && !defined(BOOST_MATH_USE_FLOAT128)
+#  define BOOST_MATH_USE_FLOAT128
+#endif
+#ifdef BOOST_MATH_USE_FLOAT128
 //
 // Only enable this when the compiler really is GCC as clang and probably 
 // intel too don't support __float128 yet :-(
 //
-#ifndef BOOST_MATH_USE_FLOAT128
-#  define BOOST_MATH_USE_FLOAT128
-#endif
-
 #  if defined(__INTEL_COMPILER) && defined(__GNUC__)
 #    if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 6))
 #      define BOOST_MATH_FLOAT128_TYPE __float128


### PR DESCRIPTION
Brings us into line with Multiprecision.