### PR TITLE
Allow Bernoulli numbers to support different precisions in different threads

### DIFF
--- a/include/boost/math/special_functions/detail/bernoulli_details.hpp
+++ b/include/boost/math/special_functions/detail/bernoulli_details.hpp
@@ -538,7 +538,12 @@ inline bernoulli_numbers_cache<T, Policy>& get_bernoulli_numbers_cache()
    // get initialized then (thread safety).
    //
    bernoulli_initializer<T, Policy>::force_instantiate();
-   static bernoulli_numbers_cache<T, Policy> data;
+   static 
+#ifndef BOOST_MATH_NO_THREAD_LOCAL_WITH_NON_TRIVIAL_TYPES
+#error 1
+      BOOST_MATH_THREAD_LOCAL
+#endif
+      bernoulli_numbers_cache<T, Policy> data;
    return data;
 }
 

--- a/include/boost/math/special_functions/detail/bernoulli_details.hpp
+++ b/include/boost/math/special_functions/detail/bernoulli_details.hpp
@@ -143,39 +143,6 @@ inline T tangent_scale_factor()
 {
    return tools::min_value<T>() * 16;
 }
-//
-// Initializer: ensure all our constants are initialized prior to the first call of main:
-//
-template <class T, class Policy>
-struct bernoulli_initializer
-{
-   struct init
-   {
-      init()
-      {
-         //
-         // We call twice, once to initialize our static table, and once to
-         // initialize our dymanic table:
-         //
-         boost::math::bernoulli_b2n<T>(2, Policy());
-
-         try{
-            boost::math::bernoulli_b2n<T>(max_bernoulli_b2n<T>::value + 1, Policy());
-         } catch(const std::overflow_error&){}
-
-         boost::math::tangent_t2n<T>(2, Policy());
-      }
-      void force_instantiate()const{}
-   };
-   static const init initializer;
-   static void force_instantiate()
-   {
-      initializer.force_instantiate();
-   }
-};
-
-template <class T, class Policy>
-const typename bernoulli_initializer<T, Policy>::init bernoulli_initializer<T, Policy>::initializer;
 
 //
 // We need something to act as a cache for our calculated Bernoulli numbers.  In order to
@@ -537,10 +504,8 @@ inline bernoulli_numbers_cache<T, Policy>& get_bernoulli_numbers_cache()
    // Force this function to be called at program startup so all the static variables
    // get initialized then (thread safety).
    //
-   bernoulli_initializer<T, Policy>::force_instantiate();
    static 
 #ifndef BOOST_MATH_NO_THREAD_LOCAL_WITH_NON_TRIVIAL_TYPES
-#error 1
       BOOST_MATH_THREAD_LOCAL
 #endif
       bernoulli_numbers_cache<T, Policy> data;

--- a/include/boost/math/special_functions/detail/bernoulli_details.hpp
+++ b/include/boost/math/special_functions/detail/bernoulli_details.hpp
@@ -144,40 +144,6 @@ inline T tangent_scale_factor()
    return tools::min_value<T>() * 16;
 }
 //
-// Initializer: ensure all our constants are initialized prior to the first call of main:
-//
-template <class T, class Policy>
-struct bernoulli_initializer
-{
-   struct init
-   {
-      init()
-      {
-         //
-         // We call twice, once to initialize our static table, and once to
-         // initialize our dymanic table:
-         //
-         boost::math::bernoulli_b2n<T>(2, Policy());
-
-         try{
-            boost::math::bernoulli_b2n<T>(max_bernoulli_b2n<T>::value + 1, Policy());
-         } catch(const std::overflow_error&){}
-
-         boost::math::tangent_t2n<T>(2, Policy());
-      }
-      void force_instantiate()const{}
-   };
-   static const init initializer;
-   static void force_instantiate()
-   {
-      initializer.force_instantiate();
-   }
-};
-
-template <class T, class Policy>
-const typename bernoulli_initializer<T, Policy>::init bernoulli_initializer<T, Policy>::initializer;
-
-//
 // We need something to act as a cache for our calculated Bernoulli numbers.  In order to
 // ensure both fast access and thread safety, we need a stable table which may be extended
 // in size, but which never reallocates: that way values already calculated may be accessed
@@ -530,16 +496,33 @@ private:
    atomic_counter_type m_counter, m_current_precision;
 };
 
+template <class T, class Policy, int N>
+inline bernoulli_numbers_cache<T, Policy>& get_bernoulli_numbers_cache_imp(const std::integral_constant<int, N>&)
+{
+   //
+   // Regular case, rely on C++11 thread safe initialization of the static variable:
+   //
+   static bernoulli_numbers_cache<T, Policy> data;
+   return data;
+}
+
+template <class T, class Policy>
+inline bernoulli_numbers_cache<T, Policy>& get_bernoulli_numbers_cache_imp(const std::integral_constant<int, 0>&)
+{
+   //
+   // If we get here, then the precision of T is unknown at compile time, which means
+   // there's a fair chance it's a variable precision type.  In that case we *must*
+   // make our cache thread local, that way we can have different threads operating
+   // at differing precisions:
+   //
+   static BOOST_MATH_THREAD_LOCAL bernoulli_numbers_cache<T, Policy> data;
+   return data;
+}
+
 template <class T, class Policy>
 inline bernoulli_numbers_cache<T, Policy>& get_bernoulli_numbers_cache()
 {
-   //
-   // Force this function to be called at program startup so all the static variables
-   // get initialized then (thread safety).
-   //
-   bernoulli_initializer<T, Policy>::force_instantiate();
-   static bernoulli_numbers_cache<T, Policy> data;
-   return data;
+   return get_bernoulli_numbers_cache_imp<T, Policy>(typename policies::precision<T, Policy>::type());
 }
 
 }}}

--- a/include/boost/math/special_functions/detail/bernoulli_details.hpp
+++ b/include/boost/math/special_functions/detail/bernoulli_details.hpp
@@ -515,7 +515,11 @@ inline bernoulli_numbers_cache<T, Policy>& get_bernoulli_numbers_cache_imp(const
    // make our cache thread local, that way we can have different threads operating
    // at differing precisions:
    //
-   static BOOST_MATH_THREAD_LOCAL bernoulli_numbers_cache<T, Policy> data;
+   static 
+#ifndef BOOST_MATH_NO_THREAD_LOCAL_WITH_NON_TRIVIAL_TYPES
+      BOOST_MATH_THREAD_LOCAL 
+#endif
+      bernoulli_numbers_cache<T, Policy> data;
    return data;
 }
 

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -463,7 +463,7 @@ namespace boost{ namespace math{
 // Some mingw flavours have issues with thread_local and types with non-trivial destructors
 // See https://sourceforge.net/p/mingw-w64/bugs/527/
 //
-#if (defined(__MINGW32__) || defined(__MINGW64__)) && !defined(_REENTRANT) && !defined(__clang__)
+#if (defined(__MINGW32__) && (__GNUC__ < 9) && !defined(__clang__))
 #  define BOOST_MATH_NO_THREAD_LOCAL_WITH_NON_TRIVIAL_TYPES
 #endif
 


### PR DESCRIPTION
Fixes issue found while working on thread safe variable precision multiprecision types.

Without this we have a race condition where a thread may spot that the cache is of the wrong precision and invalidate it while another thread is still using it.