### PR TITLE
Add supported compilers section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,15 @@ The full documentation is available on [boost.org](http://www.boost.org/doc/libs
 
 Defining BOOST_MATH_STANDALONE allows Boost.Math to be used without any Boost dependencies. Some functionality is reduced in this mode. A static_assert message will alert you if a particular feature has been disabled by standalone mode.
 
-### Build Status
+## Supported Compilers ##
+
+The following compilers are tested with the CI system, and are known to work. Starting with Boost 1.76 (April 2021 Release) a compiler that is fully compliant with C++11 is required to use Boost.Math.
+
+* g++ 5 or later
+* clang++ 5 or later
+* Visual Studio 2015 (14.0) or later
+
+## Build Status ##
 
 |                  |  Master  |   Develop   |
 |------------------|----------|-------------|
@@ -115,7 +123,7 @@ The default action for a PR or commit to a PR is for CI to run the full compleme
     * [linux] to test using GCC Versions 5-10 and Clang Versions 5-10 on Ubuntu LTS versions 16.04-20.04.
     * [apple] to test Apple Clang on the latest version of MacOS.
     * [windows] to test MSVC-14.0, MSVC-14.2 and mingw on the latest version of Windows.
-    * [standalone] to run standalone mode commpile tests
+    * [standalone] to run standalone mode compile tests
      
 ### Building documentation ###
 


### PR DESCRIPTION
Based off discussion surrounding https://github.com/boostorg/math/issues/571 adds the tested compilers and support requirements to the README.