### PR TITLE
Fixes for special_fun suite warnings

### DIFF
--- a/include/boost/math/special_functions/detail/airy_ai_bi_zero.hpp
+++ b/include/boost/math/special_functions/detail/airy_ai_bi_zero.hpp
@@ -98,7 +98,7 @@
 
         private:
           const Policy& my_pol;
-          const function_object_ai_and_ai_prime& operator=(const function_object_ai_and_ai_prime&);
+          const function_object_ai_and_ai_prime& operator=(const function_object_ai_and_ai_prime&) = delete;
         };
       } // namespace airy_ai_zero_detail
 
@@ -149,7 +149,7 @@
 
         private:
           const Policy& my_pol;
-          const function_object_bi_and_bi_prime& operator=(const function_object_bi_and_bi_prime&);
+          const function_object_bi_and_bi_prime& operator=(const function_object_bi_and_bi_prime&) = delete;
         };
       } // namespace airy_bi_zero_detail
     } // namespace airy_zero

--- a/include/boost/math/special_functions/detail/bessel_jy_zero.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jy_zero.hpp
@@ -79,7 +79,7 @@
         }
 
       private:
-        const equation_as_9_3_39_and_its_derivative& operator=(const equation_as_9_3_39_and_its_derivative&);
+        const equation_as_9_3_39_and_its_derivative& operator=(const equation_as_9_3_39_and_its_derivative&) = delete;
         const T zeta;
       };
 
@@ -195,7 +195,7 @@
         private:
           const T my_v;
           const Policy& my_pol;
-          const function_object_jv& operator=(const function_object_jv&);
+          const function_object_jv& operator=(const function_object_jv&) = delete;
         };
 
         template<class T, class Policy>
@@ -237,7 +237,7 @@
           const T my_v;
           const bool my_order_is_zero;
           const Policy& my_pol;
-          const function_object_jv_and_jv_prime& operator=(const function_object_jv_and_jv_prime&);
+          const function_object_jv_and_jv_prime& operator=(const function_object_jv_and_jv_prime&) = delete;
         };
 
         template<class T> bool my_bisection_unreachable_tolerance(const T&, const T&) { return false; }
@@ -413,7 +413,7 @@
         private:
           const T my_v;
           const Policy& my_pol;
-          const function_object_yv& operator=(const function_object_yv&);
+          const function_object_yv& operator=(const function_object_yv&) = delete;
         };
 
         template<class T, class Policy>
@@ -456,7 +456,7 @@
         private:
           const T my_v;
           const Policy& my_pol;
-          const function_object_yv_and_yv_prime& operator=(const function_object_yv_and_yv_prime&);
+          const function_object_yv_and_yv_prime& operator=(const function_object_yv_and_yv_prime&) = delete;
         };
 
         template<class T> bool my_bisection_unreachable_tolerance(const T&, const T&) { return false; }

--- a/include/boost/math/special_functions/detail/bessel_k0.hpp
+++ b/include/boost/math/special_functions/detail/bessel_k0.hpp
@@ -81,7 +81,7 @@ const typename bessel_k0_initializer<T, tag>::init bessel_k0_initializer<T, tag>
 
 
 template <typename T, int N>
-T bessel_k0_imp(const T& x, const std::integral_constant<int, N>&)
+T bessel_k0_imp(const T&, const std::integral_constant<int, N>&)
 {
    BOOST_MATH_ASSERT(0);
    return 0;

--- a/include/boost/math/special_functions/detail/bessel_k1.hpp
+++ b/include/boost/math/special_functions/detail/bessel_k1.hpp
@@ -44,7 +44,7 @@
 namespace boost { namespace math { namespace detail{
 
    template <typename T>
-   T bessel_k1(const T& x);
+   T bessel_k1(const T&);
 
    template <class T, class tag>
    struct bessel_k1_initializer
@@ -82,7 +82,7 @@ namespace boost { namespace math { namespace detail{
 
 
    template <typename T, int N>
-   inline T bessel_k1_imp(const T& x, const std::integral_constant<int, N>&)
+   inline T bessel_k1_imp(const T&, const std::integral_constant<int, N>&)
    {
       BOOST_MATH_ASSERT(0);
       return 0;

--- a/include/boost/math/special_functions/detail/hypergeometric_1F1_recurrence.hpp
+++ b/include/boost/math/special_functions/detail/hypergeometric_1F1_recurrence.hpp
@@ -75,7 +75,7 @@
 
   private:
     const T a, b, z;
-    hypergeometric_1F1_recurrence_b_coefficients& operator=(const hypergeometric_1F1_recurrence_b_coefficients&);
+    hypergeometric_1F1_recurrence_b_coefficients& operator=(const hypergeometric_1F1_recurrence_b_coefficients&) = delete;
   };
   //
   // for use when we're recursing to a small b:
@@ -103,7 +103,7 @@
      }
 
   private:
-     hypergeometric_1F1_recurrence_small_b_coefficients operator=(const hypergeometric_1F1_recurrence_small_b_coefficients&);
+     hypergeometric_1F1_recurrence_small_b_coefficients operator=(const hypergeometric_1F1_recurrence_small_b_coefficients&) = delete;
      const T a, b, z;
      int N;
   };
@@ -133,7 +133,7 @@
   private:
     const T a, b, z;
     int offset;
-    hypergeometric_1F1_recurrence_a_and_b_coefficients operator=(const hypergeometric_1F1_recurrence_a_and_b_coefficients&);
+    hypergeometric_1F1_recurrence_a_and_b_coefficients operator=(const hypergeometric_1F1_recurrence_a_and_b_coefficients&) = delete;
   };
 #if 0
   //

--- a/include/boost/math/special_functions/detail/hypergeometric_asym.hpp
+++ b/include/boost/math/special_functions/detail/hypergeometric_asym.hpp
@@ -44,7 +44,7 @@
         }
         else
         {
-           e = z > (std::numeric_limits<long long>::max)() ? (std::numeric_limits<long long>::max)() : lltrunc(z, pol);
+           e = z > static_cast<T>((std::numeric_limits<long long>::max)()) ? (std::numeric_limits<long long>::max)() : lltrunc(z, pol);
            log_scaling += e;
            prefix = exp(z - e);
         }

--- a/include/boost/math/special_functions/detail/hypergeometric_pade.hpp
+++ b/include/boost/math/special_functions/detail/hypergeometric_pade.hpp
@@ -72,7 +72,7 @@
   // Luke: C -------- SUBROUTINE R2F1P(BP, CP, Z, A, B, N) --------
   // Luke: C ---- PADE APPROXIMATION OF 2F1( 1 , BP; CP ; -Z ) ----
   template <class T, class Policy>
-  inline T hypergeometric_2F1_pade(const T& bp, const T& cp, const T& zp, const Policy& pol)
+  inline T hypergeometric_2F1_pade(const T& bp, const T& cp, const T& zp, const Policy&)
   {
     BOOST_MATH_STD_USING
 


### PR DESCRIPTION
Several instances of `-Wdeprecated-copy` and `-Wunused-variable` plus one instance of `-Wimplicit-const-int-float-conversion`. I am sure there will be other PRs here and in Boost.Random to address instances of deprecated copy.