### PR TITLE
Default to Standalone

### DIFF
--- a/include/boost/math/special_functions/detail/fp_traits.hpp
+++ b/include/boost/math/special_functions/detail/fp_traits.hpp
@@ -24,6 +24,7 @@ With these techniques, the code could be simplified.
 #include <cstdint>
 #include <limits>
 #include <type_traits>
+#include <boost/math/tools/is_standalone.hpp>
 #include <boost/math/tools/assert.hpp>
 
 // Determine endinaness

--- a/include/boost/math/tools/assert.hpp
+++ b/include/boost/math/tools/assert.hpp
@@ -10,6 +10,8 @@
 #ifndef BOOST_MATH_TOOLS_ASSERT_HPP
 #define BOOST_MATH_TOOLS_ASSERT_HPP
 
+#include <boost/math/tools/is_standalone.hpp>
+
 #ifndef BOOST_MATH_STANDALONE
 
 #include <boost/assert.hpp>

--- a/include/boost/math/tools/centered_continued_fraction.hpp
+++ b/include/boost/math/tools/centered_continued_fraction.hpp
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <array>
 #include <type_traits>
+#include <boost/math/tools/is_standalone.hpp>
 
 #ifndef BOOST_MATH_STANDALONE
 #include <boost/core/demangle.hpp>

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -11,6 +11,8 @@
 #pragma once
 #endif
 
+#include <boost/math/tools/is_standalone.hpp>
+
 #ifndef BOOST_MATH_STANDALONE
 #include <boost/config.hpp>
 

--- a/include/boost/math/tools/is_standalone.hpp
+++ b/include/boost/math/tools/is_standalone.hpp
@@ -1,0 +1,16 @@
+//  Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_TOOLS_IS_STANDALONE_HPP
+#define BOOST_MATH_TOOLS_IS_STANDALONE_HPP
+
+#ifdef __has_include
+#if !__has_include(<boost/config.hpp>) || !__has_include(<boost/assert.hpp>) || !__has_include(<boost/lexical_cast.hpp>) || \
+    !__has_include(<boost/throw_exception.hpp>) || !__has_include(<boost/predef/other/endian.h>)
+#   define BOOST_MATH_STANDALONE
+#endif
+#endif
+
+#endif // BOOST_MATH_TOOLS_IS_STANDALONE_HPP

--- a/include/boost/math/tools/lexical_cast.hpp
+++ b/include/boost/math/tools/lexical_cast.hpp
@@ -6,6 +6,8 @@
 #ifndef BOOST_MATH_TOOLS_LEXICAL_CAST
 #define BOOST_MATH_TOOLS_LEXICAL_CAST
 
+#include <boost/math/tools/is_standalone.hpp>
+
 #ifndef BOOST_MATH_STANDALONE
 #include <boost/lexical_cast.hpp>
 #else

--- a/include/boost/math/tools/polynomial_gcd.hpp
+++ b/include/boost/math/tools/polynomial_gcd.hpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <type_traits>
+#include <boost/math/tools/is_standalone.hpp>
 #include <boost/math/tools/polynomial.hpp>
 
 #ifndef BOOST_MATH_STANDALONE

--- a/include/boost/math/tools/simple_continued_fraction.hpp
+++ b/include/boost/math/tools/simple_continued_fraction.hpp
@@ -14,6 +14,7 @@
 #include <limits>
 #include <stdexcept>
 #include <sstream>
+#include <boost/math/tools/is_standalone.hpp>
 
 #ifndef BOOST_MATH_STANDALONE
 #include <boost/core/demangle.hpp>

--- a/include/boost/math/tools/throw_exception.hpp
+++ b/include/boost/math/tools/throw_exception.hpp
@@ -6,6 +6,8 @@
 #ifndef BOOST_MATH_TOOLS_THROW_EXCEPTION_HPP
 #define BOOST_MATH_TOOLS_THROW_EXCEPTION_HPP
 
+#include <boost/math/tools/is_standalone.hpp>
+
 #ifndef BOOST_MATH_STANDALONE
 
 #include <boost/throw_exception.hpp>

--- a/include/boost/math/tools/ulps_plot.hpp
+++ b/include/boost/math/tools/ulps_plot.hpp
@@ -16,6 +16,7 @@
 #include <random>
 #include <limits>
 #include <stdexcept>
+#include <boost/math/tools/is_standalone.hpp>
 #include <boost/math/tools/condition_numbers.hpp>
 
 #ifndef BOOST_MATH_STANDALONE

--- a/include/boost/math/tr1.hpp
+++ b/include/boost/math/tr1.hpp
@@ -15,6 +15,7 @@
 
 #ifdef __cplusplus
 
+#include <boost/math/tools/is_standalone.hpp>
 #include <boost/math/tools/assert.hpp>
 
 namespace boost{ namespace math{ namespace tr1{ extern "C"{


### PR DESCRIPTION
If commonly used boost headers that have standalone workarounds are not present default to standalone mode. Suggested in #578.