### PR TITLE
Add thread guard to polygamma

### DIFF
--- a/include/boost/math/special_functions/detail/polygamma.hpp
+++ b/include/boost/math/special_functions/detail/polygamma.hpp
@@ -13,7 +13,6 @@
 
 #include <cmath>
 #include <limits>
-#include <mutex>
 #include <string>
 #include <boost/math/policies/policy.hpp>
 #include <boost/math/special_functions/bernoulli.hpp>
@@ -25,6 +24,10 @@
 #include <boost/math/special_functions/pow.hpp>
 #include <boost/math/tools/assert.hpp>
 #include <boost/math/tools/config.hpp>
+
+#ifdef BOOST_HAS_THREADS
+#include <mutex>
+#endif
 
 #ifdef _MSC_VER
 #pragma once
@@ -302,93 +305,93 @@ namespace boost { namespace math { namespace detail{
      }
      case 3:
      {
-        int P[] = { -2, -4 };
+        constexpr int P[] = { -2, -4 };
         return boost::math::pow<3>(constants::pi<T, Policy>(), pol) * tools::evaluate_even_polynomial(P, c) / boost::math::pow<4>(s, pol);
      }
      case 4:
      {
-        int P[] = { 16, 8 };
+        constexpr int P[] = { 16, 8 };
         return boost::math::pow<4>(constants::pi<T, Policy>(), pol) * c * tools::evaluate_even_polynomial(P, c) / boost::math::pow<5>(s, pol);
      }
      case 5:
      {
-        int P[] = { -16, -88, -16 };
+        constexpr int P[] = { -16, -88, -16 };
         return boost::math::pow<5>(constants::pi<T, Policy>(), pol) * tools::evaluate_even_polynomial(P, c) / boost::math::pow<6>(s, pol);
      }
      case 6:
      {
-        int P[] = { 272, 416, 32 };
+        constexpr int P[] = { 272, 416, 32 };
         return boost::math::pow<6>(constants::pi<T, Policy>(), pol) * c * tools::evaluate_even_polynomial(P, c) / boost::math::pow<7>(s, pol);
      }
      case 7:
      {
-        int P[] = { -272, -2880, -1824, -64 };
+        constexpr int P[] = { -272, -2880, -1824, -64 };
         return boost::math::pow<7>(constants::pi<T, Policy>(), pol) * tools::evaluate_even_polynomial(P, c) / boost::math::pow<8>(s, pol);
      }
      case 8:
      {
-        int P[] = { 7936, 24576, 7680, 128 };
+        constexpr int P[] = { 7936, 24576, 7680, 128 };
         return boost::math::pow<8>(constants::pi<T, Policy>(), pol) * c * tools::evaluate_even_polynomial(P, c) / boost::math::pow<9>(s, pol);
      }
      case 9:
      {
-        int P[] = { -7936, -137216, -185856, -31616, -256 };
+        constexpr int P[] = { -7936, -137216, -185856, -31616, -256 };
         return boost::math::pow<9>(constants::pi<T, Policy>(), pol) * tools::evaluate_even_polynomial(P, c) / boost::math::pow<10>(s, pol);
      }
      case 10:
      {
-        int P[] = { 353792, 1841152, 1304832, 128512, 512 };
+        constexpr int P[] = { 353792, 1841152, 1304832, 128512, 512 };
         return boost::math::pow<10>(constants::pi<T, Policy>(), pol) * c * tools::evaluate_even_polynomial(P, c) / boost::math::pow<11>(s, pol);
      }
      case 11:
      {
-        int P[] = { -353792, -9061376, -21253376, -8728576, -518656, -1024};
+        constexpr int P[] = { -353792, -9061376, -21253376, -8728576, -518656, -1024};
         return boost::math::pow<11>(constants::pi<T, Policy>(), pol) * tools::evaluate_even_polynomial(P, c) / boost::math::pow<12>(s, pol);
      }
      case 12:
      {
-        int P[] = { 22368256, 175627264, 222398464, 56520704, 2084864, 2048 };
+        constexpr int P[] = { 22368256, 175627264, 222398464, 56520704, 2084864, 2048 };
         return boost::math::pow<12>(constants::pi<T, Policy>(), pol) * c * tools::evaluate_even_polynomial(P, c) / boost::math::pow<13>(s, pol);
      }
 #ifndef BOOST_NO_LONG_LONG
      case 13:
      {
-        long long P[] = { -22368256LL, -795300864LL, -2868264960LL, -2174832640LL, -357888000LL, -8361984LL, -4096 };
+        constexpr long long P[] = { -22368256LL, -795300864LL, -2868264960LL, -2174832640LL, -357888000LL, -8361984LL, -4096 };
         return boost::math::pow<13>(constants::pi<T, Policy>(), pol) * tools::evaluate_even_polynomial(P, c) / boost::math::pow<14>(s, pol);
      }
      case 14:
      {
-        long long P[] = { 1903757312LL, 21016670208LL, 41731645440LL, 20261765120LL, 2230947840LL, 33497088LL, 8192 };
+        constexpr long long P[] = { 1903757312LL, 21016670208LL, 41731645440LL, 20261765120LL, 2230947840LL, 33497088LL, 8192 };
         return boost::math::pow<14>(constants::pi<T, Policy>(), pol) * c * tools::evaluate_even_polynomial(P, c) / boost::math::pow<15>(s, pol);
      }
      case 15:
      {
-        long long P[] = { -1903757312LL, -89702612992LL, -460858269696LL, -559148810240LL, -182172651520LL, -13754155008LL, -134094848LL, -16384 };
+        constexpr long long P[] = { -1903757312LL, -89702612992LL, -460858269696LL, -559148810240LL, -182172651520LL, -13754155008LL, -134094848LL, -16384 };
         return boost::math::pow<15>(constants::pi<T, Policy>(), pol) * tools::evaluate_even_polynomial(P, c) / boost::math::pow<16>(s, pol);
      }
      case 16:
      {
-        long long P[] = { 209865342976LL, 3099269660672LL, 8885192097792LL, 7048869314560LL, 1594922762240LL, 84134068224LL, 536608768LL, 32768 };
+        constexpr long long P[] = { 209865342976LL, 3099269660672LL, 8885192097792LL, 7048869314560LL, 1594922762240LL, 84134068224LL, 536608768LL, 32768 };
         return boost::math::pow<16>(constants::pi<T, Policy>(), pol) * c * tools::evaluate_even_polynomial(P, c) / boost::math::pow<17>(s, pol);
      }
      case 17:
      {
-        long long P[] = { -209865342976LL, -12655654469632LL, -87815735738368LL, -155964390375424LL, -84842998005760LL, -13684856848384LL, -511780323328LL, -2146926592LL, -65536 };
+        constexpr long long P[] = { -209865342976LL, -12655654469632LL, -87815735738368LL, -155964390375424LL, -84842998005760LL, -13684856848384LL, -511780323328LL, -2146926592LL, -65536 };
         return boost::math::pow<17>(constants::pi<T, Policy>(), pol) * tools::evaluate_even_polynomial(P, c) / boost::math::pow<18>(s, pol);
      }
      case 18:
      {
-        long long P[] = { 29088885112832LL, 553753414467584LL, 2165206642589696LL, 2550316668551168LL, 985278548541440LL, 115620218667008LL, 3100738912256LL, 8588754944LL, 131072 };
+        constexpr long long P[] = { 29088885112832LL, 553753414467584LL, 2165206642589696LL, 2550316668551168LL, 985278548541440LL, 115620218667008LL, 3100738912256LL, 8588754944LL, 131072 };
         return boost::math::pow<18>(constants::pi<T, Policy>(), pol) * c * tools::evaluate_even_polynomial(P, c) / boost::math::pow<19>(s, pol);
      }
      case 19:
      {
-        long long P[] = { -29088885112832LL, -2184860175433728LL, -19686087844429824LL, -48165109676113920LL, -39471306959486976LL, -11124607890751488LL, -965271355195392LL, -18733264797696LL, -34357248000LL, -262144 };
+        constexpr long long P[] = { -29088885112832LL, -2184860175433728LL, -19686087844429824LL, -48165109676113920LL, -39471306959486976LL, -11124607890751488LL, -965271355195392LL, -18733264797696LL, -34357248000LL, -262144 };
         return boost::math::pow<19>(constants::pi<T, Policy>(), pol) * tools::evaluate_even_polynomial(P, c) / boost::math::pow<20>(s, pol);
      }
      case 20:
      {
-        long long P[] = { 4951498053124096LL, 118071834535526400LL, 603968063567560704LL, 990081991141490688LL, 584901762421358592LL, 122829335169859584LL, 7984436548730880LL, 112949304754176LL, 137433710592LL, 524288 };
+        constexpr long long P[] = { 4951498053124096LL, 118071834535526400LL, 603968063567560704LL, 990081991141490688LL, 584901762421358592LL, 122829335169859584LL, 7984436548730880LL, 112949304754176LL, 137433710592LL, 524288 };
         return boost::math::pow<20>(constants::pi<T, Policy>(), pol) * c * tools::evaluate_even_polynomial(P, c) / boost::math::pow<21>(s, pol);
      }
 #endif


### PR DESCRIPTION
Continued work on issue #621. The call to `std::mutex` and `std::lock_guard` were already wrapped so only the header inclusion needed changed. Also make the arrays `constexpr`