### PR TITLE
Thread guards in stats

### DIFF
--- a/include/boost/math/statistics/bivariate_statistics.hpp
+++ b/include/boost/math/statistics/bivariate_statistics.hpp
@@ -11,8 +11,6 @@
 #include <tuple>
 #include <type_traits>
 #include <stdexcept>
-#include <future>
-#include <thread>
 #include <vector>
 #include <algorithm>
 #include <cmath>
@@ -22,8 +20,10 @@
 
 // Support compilers with P0024R2 implemented without linking TBB
 // https://en.cppreference.com/w/cpp/compiler_support
-#ifndef BOOST_NO_CXX17_HDR_EXECUTION
+#if !defined(BOOST_NO_CXX17_HDR_EXECUTION) && defined(BOOST_HAS_THREADS)
 #include <execution>
+#include <future>
+#include <thread>
 #define EXEC_COMPATIBLE
 #endif
 
@@ -59,6 +59,8 @@ ReturnType means_and_covariance_seq_impl(ForwardIterator u_begin, ForwardIterato
 
     return std::make_tuple(mu_u, mu_v, cov/i, i);
 }
+
+#ifdef EXEC_COMPATIBLE
 
 // Numerically stable parallel computation of (co-)variance
 // https://dl.acm.org/doi/10.1145/3221269.3223036
@@ -152,6 +154,8 @@ ReturnType means_and_covariance_parallel_impl(ForwardIterator u_begin, ForwardIt
     return std::make_tuple(mu_u_a, mu_v_a, cov_a, n_a);
 }
 
+#endif // EXEC_COMPATIBLE
+
 template<typename ReturnType, typename ForwardIterator>
 ReturnType correlation_coefficient_seq_impl(ForwardIterator u_begin, ForwardIterator u_end, ForwardIterator v_begin, ForwardIterator v_end)
 {
@@ -201,6 +205,8 @@ ReturnType correlation_coefficient_seq_impl(ForwardIterator u_begin, ForwardIter
 
     return std::make_tuple(mu_u, Qu, mu_v, Qv, cov, rho, i);
 }
+
+#ifdef EXEC_COMPATIBLE
 
 // Numerically stable parallel computation of (co-)variance:
 // https://dl.acm.org/doi/10.1145/3221269.3223036
@@ -323,6 +329,8 @@ ReturnType correlation_coefficient_parallel_impl(ForwardIterator u_begin, Forwar
     return std::make_tuple(mu_u_a, Qu_a, mu_v_a, Qv_a, cov_a, rho, n_a);
 }
 
+#endif // EXEC_COMPATIBLE
+
 } // namespace detail
 
 #ifdef EXEC_COMPATIBLE
@@ -417,7 +425,7 @@ inline auto correlation_coefficient(Container const & u, Container const & v)
     return correlation_coefficient(std::execution::seq, u, v);
 }
 
-#else // C++11 bindings
+#else // C++11 and single threaded bindings
 
 template<typename Container, typename Real = typename Container::value_type, typename std::enable_if<std::is_integral<Real>::value, bool>::type = true>
 inline auto means_and_covariance(Container const & u, Container const & v) -> std::tuple<double, double, double>

--- a/include/boost/math/statistics/detail/single_pass.hpp
+++ b/include/boost/math/statistics/detail/single_pass.hpp
@@ -7,19 +7,22 @@
 #ifndef BOOST_MATH_STATISTICS_UNIVARIATE_STATISTICS_DETAIL_SINGLE_PASS_HPP
 #define BOOST_MATH_STATISTICS_UNIVARIATE_STATISTICS_DETAIL_SINGLE_PASS_HPP
 
+#include <boost/math/tools/config.hpp>
 #include <boost/math/tools/assert.hpp>
 #include <tuple>
 #include <iterator>
-#include <atomic>
-#include <thread>
 #include <type_traits>
-#include <future>
 #include <cmath>
 #include <algorithm>
 #include <valarray>
 #include <stdexcept>
 #include <functional>
 #include <vector>
+
+#ifdef BOOST_HAS_THREADS
+#include <future>
+#include <thread>
+#endif
 
 namespace boost { namespace math { namespace statistics { namespace detail {
 
@@ -109,6 +112,8 @@ ReturnType first_four_moments_sequential_impl(ForwardIterator first, ForwardIter
     return std::make_tuple(M1, M2, M3, M4, n-1);
 }
 
+#ifdef BOOST_HAS_THREADS
+
 // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Higher-order_statistics
 // EQN 3.1: https://www.osti.gov/servlets/purl/1426900
 template<typename ReturnType, typename ForwardIterator>
@@ -195,6 +200,7 @@ ReturnType first_four_moments_parallel_impl(ForwardIterator first, ForwardIterat
     return std::make_tuple(M1_a, M2_a, M3_a, M4_a, elements);
 }
 
+#endif // BOOST_HAS_THREADS
 
 // Follows equation 1.5 of:
 // https://prod.sandia.gov/techlib-noauth/access-control.cgi/2008/086212.pdf
@@ -276,6 +282,8 @@ ReturnType gini_range_fraction(ForwardIterator first, ForwardIterator last, std:
     return std::make_tuple(num, denom, i);
 }
 
+#ifdef BOOST_HAS_THREADS
+
 template<typename ReturnType, typename ExecutionPolicy, typename ForwardIterator>
 ReturnType gini_coefficient_parallel_impl(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last)
 {
@@ -348,6 +356,8 @@ ReturnType gini_coefficient_parallel_impl(ExecutionPolicy&& exec, ForwardIterato
         return ((2*num)/denom - elements)/(elements-1);
     }
 }
+
+#endif // BOOST_HAS_THREADS
 
 template<typename ForwardIterator, typename OutputIterator>
 OutputIterator mode_impl(ForwardIterator first, ForwardIterator last, OutputIterator output)

--- a/include/boost/math/statistics/univariate_statistics.hpp
+++ b/include/boost/math/statistics/univariate_statistics.hpp
@@ -22,7 +22,7 @@
 
 // Support compilers with P0024R2 implemented without linking TBB
 // https://en.cppreference.com/w/cpp/compiler_support
-#ifndef BOOST_NO_CXX17_HDR_EXECUTION
+#if !defined(BOOST_NO_CXX17_HDR_EXECUTION) && defined(BOOST_HAS_THREADS)
 #include <execution>
 
 namespace boost::math::statistics {


### PR DESCRIPTION
Allows for use of stats functions in single threaded environments. See issue #621 