### PR TITLE
Add threading sanity check to probe clang-9 failures.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ g++-9, g++-10, clang++-9, clang++-10 ]
+        compiler: [ g++-9, g++-10, clang++-10 ]
         standard: [ c++11, c++14, c++17, c++2a ]
         suite: [ float128_tests, special_fun, distribution_tests, misc, quadrature, mp, interpolators, autodiff, ../example//examples, ../tools ]
     steps:

--- a/reporting/accuracy/Jamfile.v2
+++ b/reporting/accuracy/Jamfile.v2
@@ -80,42 +80,42 @@ rule all-tests {
      local result ;
      for local source in [ glob test*.cpp ]
      {
-         result += [ run $(source) /boost/regex//boost_regex /boost/system /boost/filesystem /boost/test//boost_unit_test_framework 
+         result += [ run $(source) /boost/system /boost/filesystem /boost/test//boost_unit_test_framework 
          : : : 
           [ check-target-builds has_gsl : <define>ALWAYS_TEST_DOUBLE : ] 
           <target-os>linux:<linkflags>-lpthread
           <target-os>linux:<linkflags>-lrt
           <toolset>gcc:<linkflags>$(OTHERFLAGS) ]
          ;
-         result += [ run $(source) /boost/regex//boost_regex /boost/system /boost/filesystem /boost/test//boost_unit_test_framework 
+         result += [ run $(source) /boost/system /boost/filesystem /boost/test//boost_unit_test_framework 
          : : : [ check-target-builds has_cxx17_cmath : <define>TEST_CXX17_CMATH : <build>no ] 
           <target-os>linux:<linkflags>-lpthread
           <target-os>linux:<linkflags>-lrt
           <toolset>gcc:<linkflags>$(OTHERFLAGS)
           : $(source:B)_cxx17_cmath ] 
          ;
-         result += [ run $(source) /boost/regex//boost_regex /boost/system /boost/filesystem /boost/test//boost_unit_test_framework 
+         result += [ run $(source) /boost/system /boost/filesystem /boost/test//boost_unit_test_framework 
          : : : [ check-target-builds has_c99_cmath : <define>TEST_C99 : <build>no ] 
           <target-os>linux:<linkflags>-lpthread
           <target-os>linux:<linkflags>-lrt
           <toolset>gcc:<linkflags>$(OTHERFLAGS)
           : $(source:B)_c99 ] 
          ;
-         result += [ run $(source) /boost/regex//boost_regex /boost/system /boost/filesystem /boost/test//boost_unit_test_framework gsl gslcblas
+         result += [ run $(source) /boost/system /boost/filesystem /boost/test//boost_unit_test_framework gsl gslcblas
          : : : [ check-target-builds has_gsl : <define>TEST_GSL : <build>no ] 
           <target-os>linux:<linkflags>-lpthread
           <target-os>linux:<linkflags>-lrt
           <toolset>gcc:<linkflags>$(OTHERFLAGS)
           : $(source:B)_gsl ] 
          ;
-         result += [ run $(source) /boost/regex//boost_regex /boost/system /boost/filesystem /boost/test//boost_unit_test_framework Rmath
+         result += [ run $(source) /boost/system /boost/filesystem /boost/test//boost_unit_test_framework Rmath
          : : : [ check-target-builds has_rmath : <define>TEST_RMATH : <build>no ] 
           <target-os>linux:<linkflags>-lpthread
           <target-os>linux:<linkflags>-lrt
           <toolset>gcc:<linkflags>$(OTHERFLAGS)
           : $(source:B)_rmath ] 
          ;
-         result += [ run $(source) /boost/regex//boost_regex /boost/system /boost/filesystem /boost/test//boost_unit_test_framework cephes_double
+         result += [ run $(source) /boost/system /boost/filesystem /boost/test//boost_unit_test_framework cephes_double
          : : : [ check-target-builds $(here)/third_party/cephes_double/acosh.c : <define>TEST_CEPHES <source>cephes_double : <build>no ] 
           <target-os>linux:<linkflags>-lpthread
           <target-os>linux:<linkflags>-lrt

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -59,7 +59,6 @@ project
       # <toolset>msvc:<cxxflags>/wd4506 has no effect?
       # suppress xstring(237) : warning C4506: no definition for inline function
       <include>../../..
-      <source>../../regex/build//boost_regex
       <exception-handling>off:<source>no_eh
       <link>shared:<define>BOOST_REGEX_DYN_LINK=1
       # For simplicities sake, make everything a static lib:
@@ -1297,99 +1296,99 @@ test-suite quadrature :
    [ run adaptive_gauss_kronrod_quadrature_test.cpp : : : <define>TEST3 [ check-target-builds ../config//has_float128 "GCC libquadmath and __float128 support" : <linkflags>-lquadmath ]
      [ requires cxx11_auto_declarations cxx11_lambdas cxx11_smart_ptr cxx11_unified_initialization_syntax ] <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj release [ check-target-builds ../config//is_ci_sanitizer_run "Sanitizer CI run" : <build>no ] : adaptive_gauss_quadrature_test_3 ]
 
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=1  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_1
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=2  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_2
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=3  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_3
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=4  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_4
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=5  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_5
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=6  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_6
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=7  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_7
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=8  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_8
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=9  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_9
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=10  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_10
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=11  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_11
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=12  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_12
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=13  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_13
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=14  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_14
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=15  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_15
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=16  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_16
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=17  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_17
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=18  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_18
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=19  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_19
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=20  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_20
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=21  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_21
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=22  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_22
    ]
-   [ run naive_monte_carlo_test.cpp ../../atomic/build//boost_atomic : : :
+   [ run naive_monte_carlo_test.cpp : : :
      <toolset>msvc:<cxxflags>/bigobj <define>TEST=23  [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" : naive_monte_carlo_test_23
    ]
-   [ compile compile_test/quad_naive_monte_carlo_incl_test.cpp ../../atomic/build//boost_atomic :
+   [ compile compile_test/quad_naive_monte_carlo_incl_test.cpp :
      [ requires cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_thread cxx11_hdr_atomic cxx11_decltype cxx11_hdr_future cxx11_hdr_chrono cxx11_hdr_random cxx11_allocator ]
      <target-os>linux:<linkflags>"-pthread" [ check-target-builds ../config//is_ci_sanitizer_run "Sanitizer CI run" : <build>no ] 
    ]
@@ -1448,7 +1447,6 @@ rule get_float128_tests
      {
          result += [ run $(source)
             /boost/test//boost_unit_test_framework/<link>static
-            /boost/regex//boost_regex/<link>static
            : # command line
            : # input files
            : # requirements

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -871,6 +871,7 @@ test-suite mp :
 ;
 
 test-suite misc :
+   [ run threading_sanity_check.cpp ]
    [ run test_tr1.cpp
    ../build//boost_math_tr1
    ../build//boost_math_tr1f

--- a/test/threading_sanity_check.cpp
+++ b/test/threading_sanity_check.cpp
@@ -1,0 +1,51 @@
+// Copyright John Maddock, 2021
+// Use, modification and distribution are subject to the
+// Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <vector>
+#include <atomic>
+#include <thread>
+#include <random>
+#include <algorithm>
+#include <iostream>
+
+std::atomic<int> counter{ 0 };
+
+
+void thread_proc()
+{
+   static thread_local std::vector<double> list;
+
+   std::default_random_engine rnd;
+   std::uniform_real_distribution<> dist;
+
+   for (unsigned i = 0; i < 1000; ++i)
+   {
+      list.push_back(dist(rnd));
+      ++counter;
+   }
+   std::sort(list.begin(), list.end());
+}
+
+int main()
+{
+   std::thread f1(thread_proc);
+   std::thread f2(thread_proc);
+   std::thread f3(thread_proc);
+   std::thread f4(thread_proc);
+   std::thread f5(thread_proc);
+   std::thread f6(thread_proc);
+
+   f1.join();
+   f2.join();
+   f3.join();
+   f4.join();
+   f5.join();
+   f6.join();
+
+   std::cout << "Counter value was: " << counter << std::endl;
+
+   return counter - 6000;
+}

--- a/test/threading_sanity_check.cpp
+++ b/test/threading_sanity_check.cpp
@@ -10,6 +10,7 @@
 #include <random>
 #include <algorithm>
 #include <iostream>
+#include <boost/math/tools/config.hpp>
 
 std::atomic<int> counter{ 0 };
 

--- a/test/threading_sanity_check.cpp
+++ b/test/threading_sanity_check.cpp
@@ -4,20 +4,22 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/math/tools/config.hpp>
+
+#if !defined(BOOST_MATH_NO_THREAD_LOCAL_WITH_NON_TRIVIAL_TYPES) && defined(BOOST_HAS_THREADS)
+
 #include <vector>
 #include <atomic>
 #include <thread>
 #include <random>
 #include <algorithm>
 #include <iostream>
-#include <boost/math/tools/config.hpp>
 
 std::atomic<int> counter{ 0 };
 
 
 void thread_proc()
 {
-#ifndef BOOST_MATH_NO_THREAD_LOCAL_WITH_NON_TRIVIAL_TYPES
    static thread_local std::vector<double> list;
 
    std::default_random_engine rnd;
@@ -29,7 +31,6 @@ void thread_proc()
       ++counter;
    }
    std::sort(list.begin(), list.end());
-#endif
 }
 
 int main()
@@ -52,3 +53,9 @@ int main()
 
    return counter - 6000;
 }
+
+#else
+
+int main() { return 0; }
+
+#endif

--- a/test/threading_sanity_check.cpp
+++ b/test/threading_sanity_check.cpp
@@ -16,6 +16,7 @@ std::atomic<int> counter{ 0 };
 
 void thread_proc()
 {
+#ifndef BOOST_MATH_NO_THREAD_LOCAL_WITH_NON_TRIVIAL_TYPES
    static thread_local std::vector<double> list;
 
    std::default_random_engine rnd;
@@ -27,6 +28,7 @@ void thread_proc()
       ++counter;
    }
    std::sort(list.begin(), list.end());
+#endif
 }
 
 int main()

--- a/tools/Jamfile.v2
+++ b/tools/Jamfile.v2
@@ -222,6 +222,6 @@ install generate_rational_test_install : generate_rational_test : <location>bin 
 #}
 
 exe generate_rational_code : generate_rational_code.cpp ;
-exe process_perf_results : process_perf_results.cpp ../../regex/build//boost_regex ;
+exe process_perf_results : process_perf_results.cpp ;
 
 install bin : generate_rational_code process_perf_results ;


### PR DESCRIPTION
See: https://github.com/boostorg/math/pull/629.