### PR TITLE
nonfinite_num_get facet fix: honor "legacy" flag to enable "nanq"+"nans"

### DIFF
--- a/include/boost/math/special_functions/nonfinite_num_facets.hpp
+++ b/include/boost/math/special_functions/nonfinite_num_facets.hpp
@@ -414,7 +414,7 @@ namespace boost {
         switch(peek_char(it, end, ct)) {
         case 'q':
         case 's':
-          if(flags_)
+          if(flags_ & legacy)
             ++it;
           break;  // "nanq", "nans"
 


### PR DESCRIPTION
A hopefully obvious one-line fix to "Facets for Floating-Point Infinities and NaNs".

The documentation states that the "legacy" flag enables support for "nanq" and "nans", but any other flag is not supposed to do so.

The "legacy" flag got lost in 16c57be3 "Fixes for compile tests", but the affected code was broken from the very beginning.