### PR TITLE
solve.hpp: fabs -> std::abs in templated function

### DIFF
--- a/include_private/boost/math/tools/solve.hpp
+++ b/include_private/boost/math/tools/solve.hpp
@@ -62,7 +62,8 @@ boost::numeric::ublas::vector<T> solve(
 
       for(unsigned i = 0; i < delta.size(); ++i)
       {
-         T err = std::abs(delta[i] / b[i]);
+         using std::abs;
+         T err = abs(delta[i] / b[i]);
          if(err > max_error)
             max_error = err;
       }

--- a/include_private/boost/math/tools/solve.hpp
+++ b/include_private/boost/math/tools/solve.hpp
@@ -62,7 +62,7 @@ boost::numeric::ublas::vector<T> solve(
 
       for(unsigned i = 0; i < delta.size(); ++i)
       {
-         T err = fabs(delta[i] / b[i]);
+         T err = std::abs(delta[i] / b[i]);
          if(err > max_error)
             max_error = err;
       }


### PR DESCRIPTION
correction needed to make boost::math::tools::solve<T> work with T=long double