### PR TITLE
improve mode of the non central chi squared algorithm

### DIFF
--- a/include/boost/math/distributions/non_central_chi_squared.hpp
+++ b/include/boost/math/distributions/non_central_chi_squared.hpp
@@ -839,7 +839,7 @@ namespace boost
             Policy()))
                return (RealType)r;
          bool asymptotic_mode = k < l/4;
-         RealType starting_point = asymptotic_mode ? k + l - 3 : 1 + k;
+         RealType starting_point = asymptotic_mode ? k + l - RealType(3) : RealType(1) + k;
          return detail::generic_find_mode(dist, starting_point, function);
       }
 

--- a/include/boost/math/distributions/non_central_chi_squared.hpp
+++ b/include/boost/math/distributions/non_central_chi_squared.hpp
@@ -838,7 +838,9 @@ namespace boost
             &r,
             Policy()))
                return (RealType)r;
-         return detail::generic_find_mode(dist, 1 + k, function);
+         bool asymptotic_mode = k < l/4;
+         RealType starting_point = asymptotic_mode ? k + l - 3 : 1 + k;
+         return detail::generic_find_mode(dist, starting_point, function);
       }
 
       template <class RealType, class Policy>
@@ -994,6 +996,3 @@ namespace boost
 #include <boost/math/distributions/detail/derived_accessors.hpp>
 
 #endif // BOOST_MATH_SPECIAL_NON_CENTRAL_CHI_SQUARE_HPP
-
-
-

--- a/reporting/performance/test_distributions_mode.cpp
+++ b/reporting/performance/test_distributions_mode.cpp
@@ -53,7 +53,7 @@ BENCHMARK_TEMPLATE(test_mode_2param, long double, non_central_chi_squared_distri
 
 BENCHMARK_TEMPLATE(test_mode_2param, long double, non_central_chi_squared_distribution)->ArgsProduct({
     benchmark::CreateRange(4, 4096, /*multi=*/2),
-    {0, 30, 100, 500}
+    {1, 30, 100, 500}
 })->Name("fixed_nc");
 
 BENCHMARK_TEMPLATE(test_mode_2param, long double, non_central_chi_squared_distribution)

--- a/reporting/performance/test_distributions_mode.cpp
+++ b/reporting/performance/test_distributions_mode.cpp
@@ -36,9 +36,8 @@ void test_mode_2param(benchmark::State& state)
 }
 
 
-template<class T>
-static void fixed_ratio_2args(benchmark::internal::Benchmark* b, T left_div_right, std::vector<int64_t> lefts) {
-    for (const T &left: lefts) {
+static void fixed_ratio_2args(benchmark::internal::Benchmark* b, long double left_div_right, std::vector<int64_t> lefts) {
+    for (const long double &left: lefts) {
         b->Args({(int64_t)left, (int64_t)(left/left_div_right)});
     }
 }
@@ -58,17 +57,17 @@ BENCHMARK_TEMPLATE(test_mode_2param, long double, non_central_chi_squared_distri
 
 BENCHMARK_TEMPLATE(test_mode_2param, long double, non_central_chi_squared_distribution)
     -> Apply([](benchmark::internal::Benchmark*b) {
-                fixed_ratio_2args<long double>(b, 0.05L, benchmark::CreateRange(4, 4096, /*multi=*/2));
+                fixed_ratio_2args(b, 0.05, benchmark::CreateRange(4, 4096, /*multi=*/2));
     }) -> Name("fixed_scale_0_05");
 
 BENCHMARK_TEMPLATE(test_mode_2param, long double, non_central_chi_squared_distribution)
     -> Apply([](benchmark::internal::Benchmark*b) {
-                fixed_ratio_2args<long double>(b, 0.15L, benchmark::CreateRange(4, 4096, /*multi=*/2));
+                fixed_ratio_2args(b, 0.15, benchmark::CreateRange(4, 4096, /*multi=*/2));
     }) -> Name("fixed_scale_0_15");
 
 BENCHMARK_TEMPLATE(test_mode_2param, long double, non_central_chi_squared_distribution)
     -> Apply([](benchmark::internal::Benchmark*b) {
-                fixed_ratio_2args<long double>(b, 0.25L, benchmark::CreateRange(4, 4096, /*multi=*/2));
+                fixed_ratio_2args(b, 0.25, benchmark::CreateRange(4, 4096, /*multi=*/2));
     }) -> Name("fixed_scale_0_25");
 
 BENCHMARK_MAIN();

--- a/reporting/performance/test_distributions_mode.cpp
+++ b/reporting/performance/test_distributions_mode.cpp
@@ -1,0 +1,74 @@
+//  (C) Copyright Victor Ananyev 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <random>
+#include <vector>
+#include <boost/math/distributions.hpp>
+#include <benchmark/benchmark.h>
+
+
+template <class Z, template<typename> class dist >
+void test_mode_2param(benchmark::State& state)
+{
+    using boost::math::normal_distribution;
+
+    std::random_device rd;
+    std::mt19937_64 mt(rd());
+    std::normal_distribution<Z> noise(0., 1E-6);
+
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        Z p1 = state.range(0) + noise(mt);
+        Z p2 = state.range(1) + noise(mt);
+        dist<Z> the_dist(p1, p2);
+        state.ResumeTiming();
+        try {
+            benchmark::DoNotOptimize(mode(the_dist));
+        }
+        catch (boost::wrapexcept<boost::math::evaluation_error>& e) {
+            state.SkipWithError(e.what());
+            break;
+        }
+    }
+}
+
+
+template<class T>
+static void fixed_ratio_2args(benchmark::internal::Benchmark* b, T left_div_right, std::vector<int64_t> lefts) {
+    for (const T &left: lefts) {
+        b->Args({(int64_t)left, (int64_t)(left/left_div_right)});
+    }
+}
+
+
+using boost::math::non_central_chi_squared_distribution;
+
+BENCHMARK_TEMPLATE(test_mode_2param, long double, non_central_chi_squared_distribution)->ArgsProduct({
+    {2, 15, 50},
+    benchmark::CreateRange(4, 1024, /*multi=*/2)
+})->Name("fixed_k");
+
+BENCHMARK_TEMPLATE(test_mode_2param, long double, non_central_chi_squared_distribution)->ArgsProduct({
+    benchmark::CreateRange(4, 4096, /*multi=*/2),
+    {0, 30, 100, 500}
+})->Name("fixed_nc");
+
+BENCHMARK_TEMPLATE(test_mode_2param, long double, non_central_chi_squared_distribution)
+    -> Apply([](benchmark::internal::Benchmark*b) {
+                fixed_ratio_2args<long double>(b, 0.05L, benchmark::CreateRange(4, 4096, /*multi=*/2));
+    }) -> Name("fixed_scale_0_05");
+
+BENCHMARK_TEMPLATE(test_mode_2param, long double, non_central_chi_squared_distribution)
+    -> Apply([](benchmark::internal::Benchmark*b) {
+                fixed_ratio_2args<long double>(b, 0.15L, benchmark::CreateRange(4, 4096, /*multi=*/2));
+    }) -> Name("fixed_scale_0_15");
+
+BENCHMARK_TEMPLATE(test_mode_2param, long double, non_central_chi_squared_distribution)
+    -> Apply([](benchmark::internal::Benchmark*b) {
+                fixed_ratio_2args<long double>(b, 0.25L, benchmark::CreateRange(4, 4096, /*multi=*/2));
+    }) -> Name("fixed_scale_0_25");
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Hello! I made a little research on the mode of the non-central chi2, and it turned out that the boost library could benefit from it. The main change is aimed at tuning the starting point of the iterative scheme that searches for the mode. Please have a look at the theoretical bases of the change and also at some benchmarking plots in the preprint: https://arxiv.org/abs/2106.12276

The corresponding code that I used for benchmarking you can find on the github repo here:
https://github.com/vindex10/ncxmax/tree/master/boost-test

