### PR TITLE
Fix build on platforms with "double-double" long double type

### DIFF
--- a/include/boost/math/tools/precision.hpp
+++ b/include/boost/math/tools/precision.hpp
@@ -145,7 +145,7 @@ inline constexpr T epsilon(const std::true_type& BOOST_MATH_APPEND_EXPLICIT_TEMP
 
 #if defined(__GNUC__) && ((LDBL_MANT_DIG == 106) || (__LDBL_MANT_DIG__ == 106))
 template <>
-inline constexpr long double epsilon<long double>(const std::true_type& BOOST_MATH_APPEND_EXPLICIT_TEMPLATE_TYPE(long double)) noexcept(long double)
+inline constexpr long double epsilon<long double>(const std::true_type& BOOST_MATH_APPEND_EXPLICIT_TEMPLATE_TYPE(long double)) noexcept(std::is_floating_point<long double>::value)
 {
    // numeric_limits on Darwin (and elsewhere) tells lies here:
    // the issue is that long double on a few platforms is


### PR DESCRIPTION
Since commit 01f3b7d7721fd most tests started to fail on platforms that use a
"double-double" for long double, like powerpc64le:

```
../../../boost/math/tools/precision.hpp:148:137: error: expected primary-expression before ‘long’
  148 | inline constexpr long double epsilon<long double>(const std::true_type&
  BOOST_MATH_APPEND_EXPLICIT_TEMPLATE_TYPE(long double)) noexcept(long double)

../../../boost/math/tools/precision.hpp:148:137: error: expected ‘)’ before ‘long’
  148 | inline constexpr long double epsilon<long double>(const std::true_type&
  BOOST_MATH_APPEND_EXPLICIT_TEMPLATE_TYPE(long double)) noexcept(long double)

../../../boost/math/tools/precision.hpp:148:137: error: expected initializer before ‘long’
  148 | inline constexpr long double epsilon<long double>(const std::true_type&
  BOOST_MATH_APPEND_EXPLICIT_TEMPLATE_TYPE(long double)) noexcept(long double)
```

Fix this by replacing the noexcept expression with the contents of
`BOOST_MATH_NOEXCEPT`, which was the intention of commit 01f3b7d7721fd.
