### PR TITLE
Fix #include inside boost namespace

### DIFF
--- a/include/boost/math/tools/mp.hpp
+++ b/include/boost/math/tools/mp.hpp
@@ -13,6 +13,7 @@
 
 #include <type_traits>
 #include <cstddef>
+#include <utility>
 
 namespace boost { namespace math { namespace tools { namespace meta_programming {
 
@@ -338,7 +339,6 @@ using mp_remove_if_q = mp_remove_if<L, Q::template fn>;
 // Index sequence
 // Use C++14 index sequence if available
 #if defined(__cpp_lib_integer_sequence) && (__cpp_lib_integer_sequence >= 201304)
-#include <utility>
 template<std::size_t... I>
 using index_sequence = std::index_sequence<I...>;
 


### PR DESCRIPTION
The existing code fails to build if <utility> was not already included.