### PR TITLE
Fix for issue 675

### DIFF
--- a/include/boost/math/tools/header_deprecated.hpp
+++ b/include/boost/math/tools/header_deprecated.hpp
@@ -6,12 +6,22 @@
 #ifndef BOOST_MATH_TOOLS_HEADER_DEPRECATED
 #define BOOST_MATH_TOOLS_HEADER_DEPRECATED
 
-#ifdef _MSC_VER
+#ifndef BOOST_MATH_STANDALONE
+
+#   include <boost/config/header_deprecated.hpp>
+#   define BOOST_MATH_HEADER_DEPRECATED(expr) BOOST_HEADER_DEPRECATED(expr)
+
+#else
+
+#   ifdef _MSC_VER
 // Expands to "This header is deprecated; use expr instead."
-#define BOOST_MATH_HEADER_DEPRECATED(expr) __pragma("This header is deprecated; use " expr " instead.")
-#else // GNU, Clang, Intel, IBM, etc.
-// Expands to "This header is deprecated; use expr instead."
-#define BOOST_MATH_HEADER_DEPRECATED(expr) _Pragma("This header is deprecated; use " expr " instead.")
-#endif
+#       define BOOST_MATH_HEADER_DEPRECATED(expr) __pragma("This header is deprecated; use " expr " instead.")
+#   else // GNU, Clang, Intel, IBM, etc.
+// Expands to "This header is deprecated use expr instead"
+#       define BOOST_MATH_HEADER_DEPRECATED_MESSAGE(expr) _Pragma(#expr)
+#       define BOOST_MATH_HEADER_DEPRECATED(expr) BOOST_MATH_HEADER_DEPRECATED_MESSAGE(message "This header is deprecated use " expr " instead")
+#   endif
+
+#endif // BOOST_MATH_STANDALONE
 
 #endif // BOOST_MATH_TOOLS_HEADER_DEPRECATED

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -874,6 +874,7 @@ test-suite mp :
 ;
 
 test-suite misc :
+   [ run header_deprecated_test.cpp ]
    [ run threading_sanity_check.cpp ]
    [ run test_tr1.cpp
    ../build//boost_math_tr1

--- a/test/header_deprecated_test.cpp
+++ b/test/header_deprecated_test.cpp
@@ -1,0 +1,12 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/math/tools/header_deprecated.hpp>
+
+int main()
+{
+    BOOST_MATH_HEADER_DEPRECATED("<boost/integer/common_factor_rt.hpp>");
+    return 0;
+}


### PR DESCRIPTION
Fixes for #675. Allows for switching of `BOOST_MATH_HEADER_DEPRECATED` based on standalone context. Fixes behavior of standalone implementation. 