### PR TITLE
Fix cstdfloat_math_incl_test on ppc64le with ieee128

### DIFF
--- a/test/compile_test/cstdfloat_cmath_incl_test.cpp
+++ b/test/compile_test/cstdfloat_cmath_incl_test.cpp
@@ -53,7 +53,11 @@ void compile_and_link_test()
     check_result<boost::float128_t>(std::fmax(f128, f128));
     check_result<boost::float128_t>(std::fmin(f128, f128));
     check_result<boost::float128_t>(std::fdim(f128, f128));
-    check_result<boost::float128_t>(std::nanq(0));
+#if __LDBL_MANT_DIG__ == 113
+    check_result<boost::float128_t>(std::nanl(""));
+#else
+    check_result<boost::float128_t>(std::nanq(""));
+#endif
     check_result<boost::float128_t>(std::exp2(f128));
     check_result<boost::float128_t>(std::log2(f128));
     check_result<boost::float128_t>(std::log1p(f128));


### PR DESCRIPTION
When switching the default long double format on ppc64le to ieee128, this test
does not compile as nanq is not available. In such cases nanl should be used
instead.

Also, calling nanl with argument 0 raises warnings as it expects a char*. Change
the argument to an empty string, which keeps the purpose of the test and avoids
new warnings.

Related to #682 