### PR TITLE
constexpr frexp

### DIFF
--- a/doc/sf/ccmath.qbk
+++ b/doc/sf/ccmath.qbk
@@ -12,6 +12,7 @@ LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 `Constexpr` implementations of the functionality found in `<cmath>`.
 In a `constexpr` context the functions will use an implementation defined in boost.
 If the context is not `constexpr` the functionality will be directly from the STL implementation of `<cmath>` used by the compiler.
+All functions that take an `Integer` type and return a `double` simply cast the `Integer` argument to a `double`.
 All of the following functions require C++17 or greater.
 
 [heading Synopsis]
@@ -30,8 +31,8 @@ All of the following functions require C++17 or greater.
         template <typename Real>
         inline constexpr Real sqrt(Real x);
 
-        template <typename Z>
-        inline constexpr double sqrt(Z x);
+        template <typename Integer>
+        inline constexpr double sqrt(Integer x);
 
         template <typename T>
         inline constexpr T abs(T x);
@@ -54,8 +55,8 @@ All of the following functions require C++17 or greater.
         template <typename Real>
         inline constexpr Real frexp(Real arg, int* exp);
 
-        template <typename Z>
-        inline constexpr double frexp(Z arg, int* exp);
+        template <typename Integer>
+        inline constexpr double frexp(Integer arg, int* exp);
 
     } // Namespaces
 

--- a/doc/sf/ccmath.qbk
+++ b/doc/sf/ccmath.qbk
@@ -51,6 +51,12 @@ All of the following functions require C++17 or greater.
         template <typename T>
         inline constexpr int fpclassify(T x);
 
+        template <typename Real>
+        inline constexpr Real frexp(Real arg, int* exp);
+
+        template <typename Z>
+        inline constexpr double frexp(Z arg, int* exp);
+
     } // Namespaces
 
 [endsect] [/section:ccmath Constexpr CMath]

--- a/include/boost/math/ccmath/ccmath.hpp
+++ b/include/boost/math/ccmath/ccmath.hpp
@@ -15,5 +15,6 @@
 #include <boost/math/ccmath/isfinite.hpp>
 #include <boost/math/ccmath/isnormal.hpp>
 #include <boost/math/ccmath/fpclassify.hpp>
+#include <boost/math/ccmath/frexp.hpp>
 
 #endif // BOOST_MATH_CCMATH

--- a/include/boost/math/ccmath/frexp.hpp
+++ b/include/boost/math/ccmath/frexp.hpp
@@ -29,7 +29,7 @@ inline constexpr Real frexp_zero_impl(Real arg, int* exp)
 template <typename Real>
 inline constexpr Real frexp_impl(Real arg, int* exp)
 {
-    constexpr bool negative_arg = arg < Real(0);
+    const bool negative_arg = (arg < 0);
     
     Real f = negative_arg ? -arg : arg;
     int e2 = 0;
@@ -57,39 +57,39 @@ inline constexpr Real frexp_impl(Real arg, int* exp)
 
 } // namespace detail
 
-template <typename Real, std::enable_if_t<!std::is_integral_v<Real>, bool> == true>
+template <typename Real, std::enable_if_t<!std::is_integral_v<Real>, bool> = true>
 inline constexpr Real frexp(Real arg, int* exp)
 {
     if(BOOST_MATH_IS_CONSTANT_EVALUATED(arg))
     {
-        return arg == T(0)  ? detail::frexp_zero_impl(arg, &exp) : 
-               arg == T(-0) ? detail::frexp_zero_impl(arg, &exp) :
-               boost::math::ccmath::isinf(arg) ? detail::frexp_zero_impl(arg, &exp) : 
-               boost::math::ccmath::isnan(arg) ? detail::frexp_zero_impl(arg, &exp) :
-               boost::math::ccmath::detail::frexp_impl(arg, &exp);
+        return arg == Real(0)  ? detail::frexp_zero_impl(arg, exp) : 
+               arg == Real(-0) ? detail::frexp_zero_impl(arg, exp) :
+               boost::math::ccmath::isinf(arg) ? detail::frexp_zero_impl(arg, exp) : 
+               boost::math::ccmath::isnan(arg) ? detail::frexp_zero_impl(arg, exp) :
+               boost::math::ccmath::detail::frexp_impl(arg, exp);
     }
     else
     {
         using std::frexp;
-        return frexp(arg, &exp);
+        return frexp(arg, exp);
     }
 }
 
-template <typename Z, std::enable_if_t<std::is_integral_v<Z>, bool> == true>
+template <typename Z, std::enable_if_t<std::is_integral_v<Z>, bool> = true>
 inline constexpr double frexp(Z arg, int* exp)
 {
-    return boost::math::ccmath::frexp(static_cast<double>(arg), &exp);
+    return boost::math::ccmath::frexp(static_cast<double>(arg), exp);
 }
 
 inline constexpr float frexpf(float arg, int* exp)
 {
-    return boost::math::ccmath::frexp(arg, &exp);
+    return boost::math::ccmath::frexp(arg, exp);
 }
 
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
 inline constexpr float frexpl(long double arg, int* exp)
 {
-    return boost::math::ccmath::frexp(arg, &exp);
+    return boost::math::ccmath::frexp(arg, exp);
 }
 #endif
 

--- a/include/boost/math/ccmath/frexp.hpp
+++ b/include/boost/math/ccmath/frexp.hpp
@@ -29,7 +29,7 @@ inline constexpr Real frexp_zero_impl(Real arg, int* exp)
 template <typename Real>
 inline constexpr Real frexp_impl(Real arg, int* exp)
 {
-    const bool negative_arg = (arg < 0);
+    const bool negative_arg = (arg < Real(0));
     
     Real f = negative_arg ? -arg : arg;
     int e2 = 0;

--- a/include/boost/math/ccmath/frexp.hpp
+++ b/include/boost/math/ccmath/frexp.hpp
@@ -1,0 +1,98 @@
+//  (C) Copyright Christopher Kormanyos 1999 - 2021.
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_CCMATH_FREXP_HPP
+#define BOOST_MATH_CCMATH_FREXP_HPP
+
+#include <cmath>
+#include <limits>
+#include <type_traits>
+#include <boost/math/ccmath/isinf.hpp>
+#include <boost/math/ccmath/isnan.hpp>
+#include <boost/math/ccmath/isfinite.hpp>
+
+namespace boost::math::ccmath {
+
+namespace detail
+{
+
+template <typename Real>
+inline constexpr Real frexp_zero_impl(Real arg, int* exp)
+{
+    *exp = 0;
+    return arg;
+}
+
+template <typename Real>
+inline constexpr Real frexp_impl(Real arg, int* exp)
+{
+    constexpr bool negative_arg = arg < Real(0);
+    
+    Real f = negative_arg ? -arg : arg;
+    int e2 = 0;
+    constexpr Real two_pow_32 = Real(4294967296);
+
+    while (f >= two_pow_32)
+    {
+        f = f / two_pow_32;
+        e2 += 32;
+    }
+
+    while(f >= Real(1))
+    {
+        f = f / Real(2);
+        ++e2;
+    }
+    
+    if(exp != nullptr)
+    {
+        *exp = e2;
+    }
+
+    return !negative_arg ? f : -f;
+}
+
+} // namespace detail
+
+template <typename Real, std::enable_if_t<!std::is_integral_v<Real>, bool> == true>
+inline constexpr Real frexp(Real arg, int* exp)
+{
+    if(BOOST_MATH_IS_CONSTANT_EVALUATED(arg))
+    {
+        return arg == T(0)  ? detail::frexp_zero_impl(arg, &exp) : 
+               arg == T(-0) ? detail::frexp_zero_impl(arg, &exp) :
+               boost::math::ccmath::isinf(arg) ? detail::frexp_zero_impl(arg, &exp) : 
+               boost::math::ccmath::isnan(arg) ? detail::frexp_zero_impl(arg, &exp) :
+               boost::math::ccmath::detail::frexp_impl(arg, &exp);
+    }
+    else
+    {
+        using std::frexp;
+        return frexp(arg, &exp);
+    }
+}
+
+template <typename Z, std::enable_if_t<std::is_integral_v<Z>, bool> == true>
+inline constexpr double frexp(Z arg, int* exp)
+{
+    return boost::math::ccmath::frexp(static_cast<double>(arg), &exp);
+}
+
+inline constexpr float frexpf(float arg, int* exp)
+{
+    return boost::math::ccmath::frexp(arg, &exp);
+}
+
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+inline constexpr float frexpl(long double arg, int* exp)
+{
+    return boost::math::ccmath::frexp(arg, &exp);
+}
+#endif
+
+}
+
+#endif // BOOST_MATH_CCMATH_FREXP_HPP

--- a/include/boost/math/ccmath/frexp.hpp
+++ b/include/boost/math/ccmath/frexp.hpp
@@ -87,7 +87,7 @@ inline constexpr float frexpf(float arg, int* exp)
 }
 
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-inline constexpr float frexpl(long double arg, int* exp)
+inline constexpr long double frexpl(long double arg, int* exp)
 {
     return boost::math::ccmath::frexp(arg, exp);
 }

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -128,6 +128,7 @@ test-suite special_fun :
    [ run ccmath_isfinite_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run ccmath_isnormal_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run ccmath_fpclassify_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
+   [ run ccmath_frexp_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run log1p_expm1_test.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]
    [ run powm1_sqrtp1m1_test.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]
    [ run special_functions_test.cpp ../../test/build//boost_unit_test_framework  ]

--- a/test/ccmath_frexp_test.cpp
+++ b/test/ccmath_frexp_test.cpp
@@ -1,0 +1,54 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <cmath>
+#include <cfloat>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <boost/math/ccmath/frexp.hpp>
+#include <boost/math/ccmath/isnan.hpp>
+#include <boost/math/ccmath/isinf.hpp>
+
+#ifdef BOOST_HAS_FLOAT128
+#include <boost/multiprecision/float128.hpp>
+#endif
+
+template <typename T>
+void test()
+{
+    static int i;
+    if constexpr (std::numeric_limits<T>::has_quiet_NaN)
+    {
+        static_assert(boost::math::ccmath::isnan(boost::math::ccmath::frexp(std::numeric_limits<T>::quiet_NaN(), &i)));
+    }
+
+    static_assert(boost::math::ccmath::frexp(0, &i) == 0);
+    static_assert(boost::math::ccmath::isinf(boost::math::ccmath::frexp(std::numeric_limits<T>::infinity(), &i)));
+    static_assert(boost::math::ccmath::frexp(T(1024), &i) == T(0.5));
+}
+
+#ifndef BOOST_MATH_NO_CONSTEXPR_DETECTION
+int main()
+{
+    test<float>();
+    test<double>();
+
+    #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+    test<long double>();
+    #endif
+    
+    #if defined(BOOST_HAS_FLOAT128) && !defined(BOOST_MATH_USING_BUILTIN_CONSTANT_P)
+    test<boost::multiprecision::float128>();
+    #endif
+
+    return 0;
+}
+#else
+int main()
+{
+    return 0;
+}
+#endif

--- a/test/ccmath_frexp_test.cpp
+++ b/test/ccmath_frexp_test.cpp
@@ -56,7 +56,7 @@ constexpr void test()
     static_assert(test_exp == 2);
 }
 
-#ifndef BOOST_MATH_NO_CONSTEXPR_DETECTION
+#if !defined(BOOST_MATH_NO_CONSTEXPR_DETECTION) && !defined(BOOST_MATH_USING_BUILTIN_CONSTANT_P)
 int main()
 {
     test<float>();
@@ -66,7 +66,7 @@ int main()
     test<long double>();
     #endif
     
-    #if defined(BOOST_HAS_FLOAT128) && !defined(BOOST_MATH_USING_BUILTIN_CONSTANT_P)
+    #ifdef BOOST_HAS_FLOAT128
     test<boost::multiprecision::float128>();
     #endif
 

--- a/test/compile_test/ccmath_frexp_incl_test.cpp
+++ b/test/compile_test/ccmath_frexp_incl_test.cpp
@@ -1,0 +1,17 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/math/ccmath/frexp.hpp>
+#include "test_compile_result.hpp"
+
+void compile_and_link_test()
+{
+   int i;
+   check_result<float>(boost::math::ccmath::frexp(1.0f, &i));
+   check_result<double>(boost::math::ccmath::frexp(1.0, &i));
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+   check_result<long double>(boost::math::ccmath::frexp(1.0l, &i));
+#endif
+}


### PR DESCRIPTION
@ckormanyos This was borrowed heavily from your wide integer implementation with some added handling described in the standard (e.g. NaN). Do you have a sample `constexpr` test you use?  I am not sure how to get around `exp` having external visibility in a `constexpr` context. I could change to something like `frexp(T arg, void)`, but then the behavior would be different from the standard. 