### PR TITLE
Add abs specializations to ccmath

### DIFF
--- a/include/boost/math/ccmath/abs.hpp
+++ b/include/boost/math/ccmath/abs.hpp
@@ -20,7 +20,7 @@ namespace boost::math::ccmath {
 namespace detail {
 
 template <typename T> 
-inline constexpr T abs_impl(T x)
+inline constexpr T abs_impl(T x) noexcept
 {
     return boost::math::ccmath::isnan(x) ? std::numeric_limits<T>::quiet_NaN() : 
            boost::math::ccmath::isinf(x) ? std::numeric_limits<T>::infinity() : 
@@ -32,7 +32,7 @@ inline constexpr T abs_impl(T x)
 } // Namespace detail
 
 template <typename T, std::enable_if_t<!std::is_unsigned_v<T>, bool> = true>
-inline constexpr T abs(T x)
+inline constexpr T abs(T x) noexcept
 {
     if(BOOST_MATH_IS_CONSTANT_EVALUATED(x))
     {
@@ -48,7 +48,7 @@ inline constexpr T abs(T x)
 // If abs() is called with an argument of type X for which is_unsigned_v<X> is true and if X
 // cannot be converted to int by integral promotion (7.3.7), the program is ill-formed.
 template <typename T, std::enable_if_t<std::is_unsigned_v<T>, bool> = true>
-inline constexpr T abs(T x)
+inline constexpr T abs(T x) noexcept
 {
     if constexpr (std::is_convertible_v<T, int>)
     {
@@ -59,6 +59,16 @@ inline constexpr T abs(T x)
         static_assert(sizeof(T) == 0, "Taking the absolute value of an unsigned value not covertible to int is UB.");
         return T(0); // Unreachable, but suppresses warnings
     }
+}
+
+inline constexpr long int labs(long int j) noexcept
+{
+    return boost::math::ccmath::abs(j);
+}
+
+inline constexpr long long int llabs(long long int j) noexcept
+{
+    return boost::math::ccmath::abs(j);
 }
 
 } // Namespaces

--- a/include/boost/math/ccmath/fabs.hpp
+++ b/include/boost/math/ccmath/fabs.hpp
@@ -13,10 +13,22 @@
 namespace boost::math::ccmath {
 
 template <typename T>
-inline constexpr auto fabs(T x)
+inline constexpr auto fabs(T x) noexcept
 {
     return boost::math::ccmath::abs(x);
 }
+
+inline constexpr float fabsf(float x) noexcept
+{
+    return boost::math::ccmath::abs(x);
+}
+
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+inline constexpr long double fabsl(long double x) noexcept
+{
+    return boost::math::ccmath::abs(x);
+}
+#endif
 
 }
 

--- a/test/ccmath_abs_test.cpp
+++ b/test/ccmath_abs_test.cpp
@@ -70,6 +70,7 @@ int main()
 
     test<int>();
     test<long>();
+    test<long long>();
     test<std::int32_t>();
     test<std::int64_t>();
 


### PR DESCRIPTION
Adds `labs`, `llabs`, `fabsf`, and `fabsl`