### PR TITLE
constexpr scalbn and scalbln

### DIFF
--- a/doc/sf/ccmath.qbk
+++ b/doc/sf/ccmath.qbk
@@ -79,6 +79,18 @@ All of the following functions require C++17 or greater.
         template <typename T>
         inline constexpr int ilogb(T arg);
 
+        template <typename Real>
+        inline constexpr Real scalbn(Real x, int exp) noexcept
+
+        template <typename Integer>
+        inline constexpr double scalbn(Integer x, int exp) noexcept
+
+        template <typename Real>
+        inline constexpr Real scalbln(Real x, long exp) noexcept
+
+        template <typename Integer>
+        inline constexpr double scalbln(Integer x, long exp) noexcept
+
     } // Namespaces
 
 [endsect] [/section:ccmath Constexpr CMath]

--- a/include/boost/math/ccmath/ccmath.hpp
+++ b/include/boost/math/ccmath/ccmath.hpp
@@ -19,5 +19,7 @@
 #include <boost/math/ccmath/div.hpp>
 #include <boost/math/ccmath/logb.hpp>
 #include <boost/math/ccmath/ilogb.hpp>
+#include <boost/math/ccmath/scalbn.hpp>
+#include <boost/math/ccmath/scalbln.hpp>
 
 #endif // BOOST_MATH_CCMATH_HPP

--- a/include/boost/math/ccmath/scalbln.hpp
+++ b/include/boost/math/ccmath/scalbln.hpp
@@ -1,0 +1,57 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_CCMATH_SCALBLN_HPP
+#define BOOST_MATH_CCMATH_SCALBLN_HPP
+
+#include <cmath>
+#include <cfloat>
+#include <type_traits>
+#include <boost/math/tools/is_constant_evaluated.hpp>
+#include <boost/math/ccmath/scalbn.hpp>
+#include <boost/math/ccmath/abs.hpp>
+#include <boost/math/ccmath/isinf.hpp>
+#include <boost/math/ccmath/isnan.hpp>
+
+namespace boost::math::ccmath {
+
+template <typename Real, std::enable_if_t<!std::is_integral_v<Real>, bool> = true>
+inline constexpr Real scalbln(Real arg, long exp) noexcept
+{
+    if(BOOST_MATH_IS_CONSTANT_EVALUATED(arg))
+    {
+        return boost::math::ccmath::abs(arg) == Real(0) ? arg :
+               boost::math::ccmath::isinf(arg) ? arg :
+               boost::math::ccmath::isnan(arg) ? arg :
+               boost::math::ccmath::detail::scalbn_impl(arg, exp);
+    }
+    else
+    {
+        using std::scalbln;
+        return scalbln(arg, exp);
+    }
+}
+
+template <typename Z, std::enable_if_t<std::is_integral_v<Z>, bool> = true>
+inline constexpr double scalbln(Z arg, long exp) noexcept
+{
+    return boost::math::ccmath::scalbln(static_cast<double>(arg), exp);
+}
+
+inline constexpr float scalblnf(float arg, long exp) noexcept
+{
+    return boost::math::ccmath::scalbln(arg, exp);
+}
+
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+inline constexpr long double scalblnl(long double arg, long exp) noexcept
+{
+    return boost::math::ccmath::scalbln(arg, exp);
+}
+#endif
+
+} // Namespaces
+
+#endif // BOOST_MATH_CCMATH_SCALBLN_HPP

--- a/include/boost/math/ccmath/scalbn.hpp
+++ b/include/boost/math/ccmath/scalbn.hpp
@@ -1,0 +1,79 @@
+//  (C) Copyright Matt Borland 2021.
+//  (C) Copyright John Maddock 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_CCMATH_SCALBN_HPP
+#define BOOST_MATH_CCMATH_SCALBN_HPP
+
+#include <cmath>
+#include <cfloat>
+#include <limits>
+#include <type_traits>
+#include <boost/math/tools/is_constant_evaluated.hpp>
+#include <boost/math/ccmath/abs.hpp>
+#include <boost/math/ccmath/isinf.hpp>
+#include <boost/math/ccmath/isnan.hpp>
+
+namespace boost::math::ccmath {
+
+namespace detail {
+
+template <typename Real, typename Z>
+inline constexpr Real scalbn_impl(Real arg, Z exp) noexcept
+{
+    while(exp > 0)
+    {
+        arg *= FLT_RADIX;
+        --exp;
+    }
+    while(exp < 0)
+    {
+        arg /= FLT_RADIX;
+        ++exp;
+    }
+
+    return arg;
+}
+
+} // Namespace detail
+
+template <typename Real, std::enable_if_t<!std::is_integral_v<Real>, bool> = true>
+inline constexpr Real scalbn(Real arg, int exp) noexcept
+{
+    if(BOOST_MATH_IS_CONSTANT_EVALUATED(arg))
+    {
+        return boost::math::ccmath::abs(arg) == Real(0) ? arg :
+               boost::math::ccmath::isinf(arg) ? arg :
+               boost::math::ccmath::isnan(arg) ? arg :
+               boost::math::ccmath::detail::scalbn_impl(arg, exp);
+    }
+    else
+    {
+        using std::scalbn;
+        return scalbn(arg, exp);
+    }
+}
+
+template <typename Z, std::enable_if_t<std::is_integral_v<Z>, bool> = true>
+inline constexpr double scalbn(Z arg, int exp) noexcept
+{
+    return boost::math::ccmath::scalbn(static_cast<double>(arg), exp);
+}
+
+inline constexpr float scalbnf(float arg, int exp) noexcept
+{
+    return boost::math::ccmath::scalbn(arg, exp);
+}
+
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+inline constexpr long double scalbnl(long double arg, int exp) noexcept
+{
+    return boost::math::ccmath::scalbn(arg, exp);
+}
+#endif
+
+} // Namespaces
+
+#endif // BOOST_MATH_CCMATH_SCALBN_HPP

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -133,6 +133,8 @@ test-suite special_fun :
    [ run ccmath_div_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run ccmath_logb_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run ccmath_ilogb_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
+   [ run ccmath_scalbn_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
+   [ run ccmath_scalbln_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run log1p_expm1_test.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]
    [ run powm1_sqrtp1m1_test.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]
    [ run special_functions_test.cpp ../../test/build//boost_unit_test_framework  ]

--- a/test/ccmath_scalbln_test.cpp
+++ b/test/ccmath_scalbln_test.cpp
@@ -1,0 +1,72 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <cmath>
+#include <cfloat>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <boost/math/ccmath/scalbln.hpp>
+#include <boost/math/ccmath/isnan.hpp>
+#include <boost/math/ccmath/isinf.hpp>
+
+#ifdef BOOST_HAS_FLOAT128
+#include <boost/multiprecision/float128.hpp>
+#endif
+
+template <typename T>
+constexpr void test()
+{
+    // Tests are only valid on binary systems
+    if constexpr (FLT_RADIX == 2)
+    {
+        if constexpr (std::numeric_limits<T>::has_quiet_NaN)
+        {
+            static_assert(boost::math::ccmath::isnan(boost::math::ccmath::scalbln(std::numeric_limits<T>::quiet_NaN(), 1l)), "If x is NaN, NaN is returned");
+        }
+
+        static_assert(!boost::math::ccmath::scalbln(T(0), 1l), "If x is +- 0, it is returned, unmodified");
+        static_assert(!boost::math::ccmath::scalbln(T(-0), 1l), "If x is +- 0, it is returned, unmodified");
+
+        static_assert(boost::math::ccmath::isinf(boost::math::ccmath::scalbln(std::numeric_limits<T>::infinity(), 1l)), 
+                        "If x is +- inf, it is returned, unmodified");
+        static_assert(boost::math::ccmath::isinf(boost::math::ccmath::scalbln(-std::numeric_limits<T>::infinity(), 1l)), 
+                        "If x is +- inf, it is returned, unmodified");
+
+        static_assert(boost::math::ccmath::scalbln(T(2), 0l) == T(2), "If exp is 0, then x is returned, unmodified");
+
+        // 1 * 2^2 = 4
+        static_assert(boost::math::ccmath::scalbln(T(1), 2l) == T(4));
+
+        // 1.2 * 2^10 = 1228.8
+        static_assert(boost::math::ccmath::scalbln(T(1.2), 10l) == T(1228.8));
+
+        // 500 * 2^-2 = 125
+        static_assert(boost::math::ccmath::scalbln(T(500), -2l) == T(125));
+    }
+}
+
+#if !defined(BOOST_MATH_NO_CONSTEXPR_DETECTION) && !defined(BOOST_MATH_USING_BUILTIN_CONSTANT_P)
+int main()
+{
+    test<float>();
+    test<double>();
+
+    #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+    test<long double>();
+    #endif
+    
+    #ifdef BOOST_HAS_FLOAT128
+    test<boost::multiprecision::float128>();
+    #endif
+
+    return 0;
+}
+#else
+int main()
+{
+    return 0;
+}
+#endif

--- a/test/ccmath_scalbn_test.cpp
+++ b/test/ccmath_scalbn_test.cpp
@@ -1,0 +1,72 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <cmath>
+#include <cfloat>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <boost/math/ccmath/scalbn.hpp>
+#include <boost/math/ccmath/isnan.hpp>
+#include <boost/math/ccmath/isinf.hpp>
+
+#ifdef BOOST_HAS_FLOAT128
+#include <boost/multiprecision/float128.hpp>
+#endif
+
+template <typename T>
+constexpr void test()
+{
+    // Tests are only valid on binary systems
+    if constexpr (FLT_RADIX == 2)
+    {
+        if constexpr (std::numeric_limits<T>::has_quiet_NaN)
+        {
+            static_assert(boost::math::ccmath::isnan(boost::math::ccmath::scalbn(std::numeric_limits<T>::quiet_NaN(), 1)), "If x is NaN, NaN is returned");
+        }
+
+        static_assert(!boost::math::ccmath::scalbn(T(0), 1), "If x is +- 0, it is returned, unmodified");
+        static_assert(!boost::math::ccmath::scalbn(T(-0), 1), "If x is +- 0, it is returned, unmodified");
+
+        static_assert(boost::math::ccmath::isinf(boost::math::ccmath::scalbn(std::numeric_limits<T>::infinity(), 1)), 
+                        "If x is +- inf, it is returned, unmodified");
+        static_assert(boost::math::ccmath::isinf(boost::math::ccmath::scalbn(-std::numeric_limits<T>::infinity(), 1)), 
+                        "If x is +- inf, it is returned, unmodified");
+
+        static_assert(boost::math::ccmath::scalbn(T(2), 0) == T(2), "If exp is 0, then x is returned, unmodified");
+
+        // 1 * 2^2 = 4
+        static_assert(boost::math::ccmath::scalbn(T(1), 2) == T(4));
+
+        // 1.2 * 2^10 = 1228.8
+        static_assert(boost::math::ccmath::scalbn(T(1.2), 10) == T(1228.8));
+
+        // 500 * 2^-2 = 125
+        static_assert(boost::math::ccmath::scalbn(T(500), -2) == T(125));
+    }
+}
+
+#if !defined(BOOST_MATH_NO_CONSTEXPR_DETECTION) && !defined(BOOST_MATH_USING_BUILTIN_CONSTANT_P)
+int main()
+{
+    test<float>();
+    test<double>();
+
+    #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+    test<long double>();
+    #endif
+    
+    #ifdef BOOST_HAS_FLOAT128
+    test<boost::multiprecision::float128>();
+    #endif
+
+    return 0;
+}
+#else
+int main()
+{
+    return 0;
+}
+#endif

--- a/test/compile_test/ccmath_scalbln_incl_test.cpp
+++ b/test/compile_test/ccmath_scalbln_incl_test.cpp
@@ -1,0 +1,16 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/math/ccmath/scalbln.hpp>
+#include "test_compile_result.hpp"
+
+void compile_and_link_test()
+{
+   check_result<float>(boost::math::ccmath::scalbln(1.0f, 1l));
+   check_result<double>(boost::math::ccmath::scalbln(1.0, 1l));
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+   check_result<long double>(boost::math::ccmath::scalbln(1.0l, 1l));
+#endif
+}

--- a/test/compile_test/ccmath_scalbn_incl_test.cpp
+++ b/test/compile_test/ccmath_scalbn_incl_test.cpp
@@ -1,0 +1,16 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/math/ccmath/scalbn.hpp>
+#include "test_compile_result.hpp"
+
+void compile_and_link_test()
+{
+   check_result<float>(boost::math::ccmath::scalbn(1.0f, 1));
+   check_result<double>(boost::math::ccmath::scalbn(1.0, 1));
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+   check_result<long double>(boost::math::ccmath::scalbn(1.0l, 1));
+#endif
+}


### PR DESCRIPTION
Implements: `scalbn`, `scalbnf`, `scalbnl`, `scalbln`, `scalblnf`, and `scalblnl`