### PR TITLE
constexpr floor and ceil

### DIFF
--- a/doc/sf/ccmath.qbk
+++ b/doc/sf/ccmath.qbk
@@ -91,6 +91,12 @@ All of the following functions require C++17 or greater.
         template <typename Integer>
         inline constexpr double scalbln(Integer x, long exp) noexcept
 
+        template <typename Real>
+        inline constexpr Real floor(Real arg) noexcept
+
+        template <typename Integer>
+        inline constexpr double floor(Integer arg) noexcept
+
     } // Namespaces
 
 [endsect] [/section:ccmath Constexpr CMath]

--- a/doc/sf/ccmath.qbk
+++ b/doc/sf/ccmath.qbk
@@ -97,6 +97,12 @@ All of the following functions require C++17 or greater.
         template <typename Integer>
         inline constexpr double floor(Integer arg) noexcept
 
+        template <typename Real>
+        inline constexpr Real ceil(Real arg) noexcept
+
+        template <typename Integer>
+        inline constexpr double ceil(Integer arg) noexcept
+
     } // Namespaces
 
 [endsect] [/section:ccmath Constexpr CMath]

--- a/include/boost/math/ccmath/ccmath.hpp
+++ b/include/boost/math/ccmath/ccmath.hpp
@@ -22,5 +22,6 @@
 #include <boost/math/ccmath/scalbn.hpp>
 #include <boost/math/ccmath/scalbln.hpp>
 #include <boost/math/ccmath/floor.hpp>
+#include <boost/math/ccmath/ceil.hpp>
 
 #endif // BOOST_MATH_CCMATH_HPP

--- a/include/boost/math/ccmath/ccmath.hpp
+++ b/include/boost/math/ccmath/ccmath.hpp
@@ -21,5 +21,6 @@
 #include <boost/math/ccmath/ilogb.hpp>
 #include <boost/math/ccmath/scalbn.hpp>
 #include <boost/math/ccmath/scalbln.hpp>
+#include <boost/math/ccmath/floor.hpp>
 
 #endif // BOOST_MATH_CCMATH_HPP

--- a/include/boost/math/ccmath/ceil.hpp
+++ b/include/boost/math/ccmath/ceil.hpp
@@ -1,0 +1,75 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_CCMATH_CEIL_HPP
+#define BOOST_MATH_CCMATH_CEIL_HPP
+
+#include <cmath>
+#include <type_traits>
+#include <boost/math/tools/is_constant_evaluated.hpp>
+#include <boost/math/ccmath/floor.hpp>
+#include <boost/math/ccmath/abs.hpp>
+#include <boost/math/ccmath/isinf.hpp>
+#include <boost/math/ccmath/isnan.hpp>
+
+namespace boost::math::ccmath {
+
+namespace detail {
+
+template <typename T>
+inline constexpr T ceil_impl(T arg) noexcept
+{
+    T result = boost::math::ccmath::floor(arg);
+
+    if(result == arg)
+    {
+        return result;
+    }
+    else
+    {
+        return result + 1;
+    }
+}
+
+} // Namespace detail
+
+template <typename Real, std::enable_if_t<!std::is_integral_v<Real>, bool> = true>
+inline constexpr Real ceil(Real arg) noexcept
+{
+    if(BOOST_MATH_IS_CONSTANT_EVALUATED(arg))
+    {
+        return boost::math::ccmath::abs(arg) == Real(0) ? arg :
+               boost::math::ccmath::isinf(arg) ? arg :
+               boost::math::ccmath::isnan(arg) ? arg :
+               boost::math::ccmath::detail::ceil_impl(arg);
+    }
+    else
+    {
+        using std::ceil;
+        return ceil(arg);
+    }
+}
+
+template <typename Z, std::enable_if_t<std::is_integral_v<Z>, bool> = true>
+inline constexpr double ceil(Z arg) noexcept
+{
+    return boost::math::ccmath::ceil(static_cast<double>(arg));
+}
+
+inline constexpr float ceilf(float arg) noexcept
+{
+    return boost::math::ccmath::ceil(arg);
+}
+
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+inline constexpr long double ceill(long double arg) noexcept
+{
+    return boost::math::ccmath::ceil(arg);
+}
+#endif
+
+} // Namespaces
+
+#endif // BOOST_MATH_CCMATH_CEIL_HPP

--- a/include/boost/math/ccmath/floor.hpp
+++ b/include/boost/math/ccmath/floor.hpp
@@ -1,0 +1,121 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_CCMATH_FLOOR_HPP
+#define BOOST_MATH_CCMATH_FLOOR_HPP
+
+#include <cmath>
+#include <limits>
+#include <type_traits>
+#include <boost/math/tools/is_constant_evaluated.hpp>
+#include <boost/math/ccmath/abs.hpp>
+#include <boost/math/ccmath/isinf.hpp>
+#include <boost/math/ccmath/isnan.hpp>
+
+namespace boost::math::ccmath {
+
+namespace detail {
+
+template <typename T>
+inline constexpr T floor_pos_impl(T arg) noexcept
+{
+    T result = 1;
+
+    if(result < arg)
+    {
+        while(result < arg)
+        {
+            result *= 2;
+        }
+        while(result > arg)
+        {
+            --result;
+        }
+
+        return result;
+    }
+    else
+    {
+        return T(0);
+    }
+}
+
+template <typename T>
+inline constexpr T floor_neg_impl(T arg) noexcept
+{
+    T result = -1;
+
+    if(result > arg)
+    {
+        while(result > arg)
+        {
+            result *= 2;
+        }
+        while(result < arg)
+        {
+            ++result;
+        }
+        if(result != arg)
+        {
+            --result;
+        }
+    }
+
+    return result;
+}
+
+template <typename T>
+inline constexpr T floor_impl(T arg) noexcept
+{
+    if(arg > 0)
+    {
+        return floor_pos_impl(arg);
+    }
+    else
+    {
+        return floor_neg_impl(arg);
+    }
+}
+
+} // Namespace detail
+
+template <typename Real, std::enable_if_t<!std::is_integral_v<Real>, bool> = true>
+inline constexpr Real floor(Real arg) noexcept
+{
+    if(BOOST_MATH_IS_CONSTANT_EVALUATED(arg))
+    {
+        return boost::math::ccmath::abs(arg) == Real(0) ? arg :
+               boost::math::ccmath::isinf(arg) ? arg :
+               boost::math::ccmath::isnan(arg) ? arg :
+               boost::math::ccmath::detail::floor_impl(arg);
+    }
+    else
+    {
+        using std::floor;
+        return floor(arg);
+    }
+}
+
+template <typename Z, std::enable_if_t<std::is_integral_v<Z>, bool> = true>
+inline constexpr double floor(Z arg) noexcept
+{
+    return boost::math::ccmath::floor(static_cast<double>(arg));
+}
+
+inline constexpr float floorf(float arg) noexcept
+{
+    return boost::math::ccmath::floor(arg);
+}
+
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+inline constexpr long double floorl(long double arg) noexcept
+{
+    return boost::math::ccmath::floor(arg);
+}
+#endif
+
+} // Namespaces
+
+#endif // BOOST_MATH_CCMATH_FLOOR_HPP

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -136,6 +136,7 @@ test-suite special_fun :
    [ run ccmath_scalbn_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run ccmath_scalbln_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run ccmath_floor_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
+   [ run ccmath_ceil_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run log1p_expm1_test.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]
    [ run powm1_sqrtp1m1_test.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]
    [ run special_functions_test.cpp ../../test/build//boost_unit_test_framework  ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -135,6 +135,7 @@ test-suite special_fun :
    [ run ccmath_ilogb_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run ccmath_scalbn_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run ccmath_scalbln_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
+   [ run ccmath_floor_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run log1p_expm1_test.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]
    [ run powm1_sqrtp1m1_test.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]
    [ run special_functions_test.cpp ../../test/build//boost_unit_test_framework  ]

--- a/test/ccmath_ceil_test.cpp
+++ b/test/ccmath_ceil_test.cpp
@@ -1,0 +1,63 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <cmath>
+#include <cfloat>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <boost/math/ccmath/ceil.hpp>
+#include <boost/math/ccmath/isnan.hpp>
+#include <boost/math/ccmath/isinf.hpp>
+
+#ifdef BOOST_HAS_FLOAT128
+#include <boost/multiprecision/float128.hpp>
+#endif
+
+template <typename T>
+constexpr void test()
+{
+    if constexpr (std::numeric_limits<T>::has_quiet_NaN)
+    {
+        static_assert(boost::math::ccmath::isnan(boost::math::ccmath::ceil(std::numeric_limits<T>::quiet_NaN())), "If x is NaN, NaN is returned");
+    }
+
+    static_assert(!boost::math::ccmath::ceil(T(0)), "If x is +- 0, it is returned, unmodified");
+    static_assert(!boost::math::ccmath::ceil(T(-0)), "If x is +- 0, it is returned, unmodified");
+    
+    static_assert(boost::math::ccmath::isinf(boost::math::ccmath::ceil(std::numeric_limits<T>::infinity())), 
+                  "If x is +- inf, it is returned, unmodified");
+    static_assert(boost::math::ccmath::isinf(boost::math::ccmath::ceil(-std::numeric_limits<T>::infinity())), 
+                  "If x is +- inf, it is returned, unmodified");
+
+    static_assert(boost::math::ccmath::ceil(T(2)) == T(2));
+    static_assert(boost::math::ccmath::ceil(T(2.4)) == T(3));
+    static_assert(boost::math::ccmath::ceil(T(2.9)) == T(3));
+    static_assert(boost::math::ccmath::ceil(T(-2.7)) == T(-2));
+    static_assert(boost::math::ccmath::ceil(T(-2)) == T(-2));
+}
+
+#if !defined(BOOST_MATH_NO_CONSTEXPR_DETECTION) && !defined(BOOST_MATH_USING_BUILTIN_CONSTANT_P)
+int main()
+{
+    test<float>();
+    test<double>();
+
+    #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+    test<long double>();
+    #endif
+    
+    #ifdef BOOST_HAS_FLOAT128
+    test<boost::multiprecision::float128>();
+    #endif
+
+    return 0;
+}
+#else
+int main()
+{
+    return 0;
+}
+#endif

--- a/test/ccmath_floor_test.cpp
+++ b/test/ccmath_floor_test.cpp
@@ -1,0 +1,63 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <cmath>
+#include <cfloat>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <boost/math/ccmath/floor.hpp>
+#include <boost/math/ccmath/isnan.hpp>
+#include <boost/math/ccmath/isinf.hpp>
+
+#ifdef BOOST_HAS_FLOAT128
+#include <boost/multiprecision/float128.hpp>
+#endif
+
+template <typename T>
+constexpr void test()
+{
+    if constexpr (std::numeric_limits<T>::has_quiet_NaN)
+    {
+        static_assert(boost::math::ccmath::isnan(boost::math::ccmath::floor(std::numeric_limits<T>::quiet_NaN())), "If x is NaN, NaN is returned");
+    }
+
+    static_assert(!boost::math::ccmath::floor(T(0)), "If x is +- 0, it is returned, unmodified");
+    static_assert(!boost::math::ccmath::floor(T(-0)), "If x is +- 0, it is returned, unmodified");
+    
+    static_assert(boost::math::ccmath::isinf(boost::math::ccmath::floor(std::numeric_limits<T>::infinity())), 
+                  "If x is +- inf, it is returned, unmodified");
+    static_assert(boost::math::ccmath::isinf(boost::math::ccmath::floor(-std::numeric_limits<T>::infinity())), 
+                  "If x is +- inf, it is returned, unmodified");
+
+    static_assert(boost::math::ccmath::floor(T(2)) == T(2));
+    static_assert(boost::math::ccmath::floor(T(2.4)) == T(2));
+    static_assert(boost::math::ccmath::floor(T(2.9)) == T(2));
+    static_assert(boost::math::ccmath::floor(T(-2.7)) == T(-3));
+    static_assert(boost::math::ccmath::floor(T(-2)) == T(-2));
+}
+
+#if !defined(BOOST_MATH_NO_CONSTEXPR_DETECTION) && !defined(BOOST_MATH_USING_BUILTIN_CONSTANT_P)
+int main()
+{
+    test<float>();
+    test<double>();
+
+    #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+    test<long double>();
+    #endif
+    
+    #ifdef BOOST_HAS_FLOAT128
+    test<boost::multiprecision::float128>();
+    #endif
+
+    return 0;
+}
+#else
+int main()
+{
+    return 0;
+}
+#endif

--- a/test/compile_test/ccmath_ceil_incl_test.cpp
+++ b/test/compile_test/ccmath_ceil_incl_test.cpp
@@ -1,0 +1,16 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/math/ccmath/ceil.hpp>
+#include "test_compile_result.hpp"
+
+void compile_and_link_test()
+{
+   check_result<float>(boost::math::ccmath::ceil(1.0f));
+   check_result<double>(boost::math::ccmath::ceil(1.0));
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+   check_result<long double>(boost::math::ccmath::ceil(1.0l));
+#endif
+}

--- a/test/compile_test/ccmath_floor_incl_test.cpp
+++ b/test/compile_test/ccmath_floor_incl_test.cpp
@@ -1,0 +1,16 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/math/ccmath/floor.hpp>
+#include "test_compile_result.hpp"
+
+void compile_and_link_test()
+{
+   check_result<float>(boost::math::ccmath::floor(1.0f));
+   check_result<double>(boost::math::ccmath::floor(1.0));
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+   check_result<long double>(boost::math::ccmath::floor(1.0l));
+#endif
+}


### PR DESCRIPTION
Implements: `floor`, `floorf`, `floorl`, `ceil`, `ceilf`, and `ceill`