### PR TITLE
constexpr round

### DIFF
--- a/doc/sf/ccmath.qbk
+++ b/doc/sf/ccmath.qbk
@@ -111,6 +111,18 @@ All of the following functions require C++17 or greater.
 
         template <typename Real>
         inline constexpr Real modf(Real x, Real* iptr) noexcept
+
+        template <typename Real>
+        inline constexpr Real round(Real arg) noexcept
+
+        template <typename Integer>
+        inline constexpr double round(Integer arg) noexcept
+
+        template <typename T>
+        inline constexpr long lround(T arg)
+
+        template <typename T>
+        inline constexpr long long llround(T arg)
         
     } // Namespaces
 

--- a/include/boost/math/ccmath/ccmath.hpp
+++ b/include/boost/math/ccmath/ccmath.hpp
@@ -25,5 +25,6 @@
 #include <boost/math/ccmath/ceil.hpp>
 #include <boost/math/ccmath/trunc.hpp>
 #include <boost/math/ccmath/modf.hpp>
+#include <boost/math/ccmath/round.hpp>
 
 #endif // BOOST_MATH_CCMATH_HPP

--- a/include/boost/math/ccmath/round.hpp
+++ b/include/boost/math/ccmath/round.hpp
@@ -1,0 +1,176 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_CCMATH_ROUND_HPP
+#define BOOST_MATH_CCMATH_ROUND_HPP
+
+#include <cmath>
+#include <type_traits>
+#include <stdexcept>
+#include <boost/math/tools/is_constant_evaluated.hpp>
+#include <boost/math/ccmath/abs.hpp>
+#include <boost/math/ccmath/isinf.hpp>
+#include <boost/math/ccmath/isnan.hpp>
+#include <boost/math/ccmath/modf.hpp>
+
+namespace boost::math::ccmath {
+
+namespace detail {
+
+// Computes the nearest integer value to arg (in floating-point format), 
+// rounding halfway cases away from zero, regardless of the current rounding mode.
+template <typename T>
+inline constexpr T round_impl(T arg) noexcept
+{
+    T iptr = 0;
+    const T x = boost::math::ccmath::modf(arg, &iptr);
+    constexpr T half = T(1)/2;
+
+    if(x >= half && iptr > 0)
+    {
+        return iptr + 1;
+    }
+    else if(boost::math::ccmath::abs(x) >= half && iptr < 0)
+    {
+        return iptr - 1;
+    }
+    else
+    {
+        return iptr;
+    }
+}
+
+template <typename ReturnType, typename T>
+inline constexpr ReturnType int_round_impl(T arg)
+{
+    const T rounded_arg = round_impl(arg);
+
+    if(rounded_arg > static_cast<T>((std::numeric_limits<ReturnType>::max)()))
+    {
+        if constexpr (std::is_same_v<ReturnType, long long>)
+        {
+            throw std::domain_error("Rounded value cannot be represented by a long long type without overflow");
+        }
+        else
+        {
+            throw std::domain_error("Rounded value cannot be represented by a long type without overflow");
+        }
+    }
+    else
+    {
+        return static_cast<ReturnType>(rounded_arg);
+    }
+}
+
+} // Namespace detail
+
+template <typename Real, std::enable_if_t<!std::is_integral_v<Real>, bool> = true>
+inline constexpr Real round(Real arg) noexcept
+{
+    if(BOOST_MATH_IS_CONSTANT_EVALUATED(arg))
+    {
+        return boost::math::ccmath::abs(arg) == Real(0) ? arg :
+               boost::math::ccmath::isinf(arg) ? arg :
+               boost::math::ccmath::isnan(arg) ? arg :
+               boost::math::ccmath::detail::round_impl(arg);
+    }
+    else
+    {
+        using std::round;
+        return round(arg);
+    }
+}
+
+template <typename Z, std::enable_if_t<std::is_integral_v<Z>, bool> = true>
+inline constexpr double round(Z arg) noexcept
+{
+    return boost::math::ccmath::round(static_cast<double>(arg));
+}
+
+inline constexpr float roundf(float arg) noexcept
+{
+    return boost::math::ccmath::round(arg);
+}
+
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+inline constexpr long double roundl(long double arg) noexcept
+{
+    return boost::math::ccmath::round(arg);
+}
+#endif
+
+template <typename Real, std::enable_if_t<!std::is_integral_v<Real>, bool> = true>
+inline constexpr long lround(Real arg)
+{
+    if(BOOST_MATH_IS_CONSTANT_EVALUATED(arg))
+    {
+        return boost::math::ccmath::abs(arg) == Real(0) ? 0l :
+               boost::math::ccmath::isinf(arg) ? 0l :
+               boost::math::ccmath::isnan(arg) ? 0l :
+               boost::math::ccmath::detail::int_round_impl<long>(arg);
+    }
+    else
+    {
+        using std::lround;
+        return lround(arg);
+    }
+}
+
+template <typename Z, std::enable_if_t<std::is_integral_v<Z>, bool> = true>
+inline constexpr long lround(Z arg)
+{
+    return boost::math::ccmath::lround(static_cast<double>(arg));
+}
+
+inline constexpr long lroundf(float arg)
+{
+    return boost::math::ccmath::lround(arg);
+}
+
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+inline constexpr long lroundl(long double arg)
+{
+    return boost::math::ccmath::lround(arg);
+}
+#endif
+
+template <typename Real, std::enable_if_t<!std::is_integral_v<Real>, bool> = true>
+inline constexpr long long llround(Real arg)
+{
+    if(BOOST_MATH_IS_CONSTANT_EVALUATED(arg))
+    {
+        return boost::math::ccmath::abs(arg) == Real(0) ? 0ll :
+               boost::math::ccmath::isinf(arg) ? 0ll :
+               boost::math::ccmath::isnan(arg) ? 0ll :
+               boost::math::ccmath::detail::int_round_impl<long long>(arg);
+    }
+    else
+    {
+        using std::llround;
+        return llround(arg);
+    }
+}
+
+template <typename Z, std::enable_if_t<std::is_integral_v<Z>, bool> = true>
+inline constexpr long llround(Z arg)
+{
+    return boost::math::ccmath::llround(static_cast<double>(arg));
+}
+
+inline constexpr long long llroundf(float arg)
+{
+    return boost::math::ccmath::llround(arg);
+}
+
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+inline constexpr long long llroundl(long double arg)
+{
+    return boost::math::ccmath::llround(arg);
+}
+#endif
+
+} // Namespaces
+
+#endif // BOOST_MATH_CCMATH_ROUND_HPP

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -139,6 +139,7 @@ test-suite special_fun :
    [ run ccmath_ceil_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run ccmath_trunc_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run ccmath_modf_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
+   [ run ccmath_round_test.cpp ../../test/build//boost_unit_test_framework : : : [ requires cxx17_if_constexpr ] ]
    [ run log1p_expm1_test.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]
    [ run powm1_sqrtp1m1_test.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]
    [ run special_functions_test.cpp ../../test/build//boost_unit_test_framework  ]

--- a/test/ccmath_round_test.cpp
+++ b/test/ccmath_round_test.cpp
@@ -1,0 +1,86 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <cmath>
+#include <cfloat>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <iostream>
+#include <type_traits>
+#include <boost/math/ccmath/round.hpp>
+#include <boost/math/ccmath/isnan.hpp>
+#include <boost/math/ccmath/isinf.hpp>
+
+#ifdef BOOST_HAS_FLOAT128
+#include <boost/multiprecision/float128.hpp>
+#endif
+
+template <typename T>
+constexpr void test()
+{
+    if constexpr (std::numeric_limits<T>::has_quiet_NaN)
+    {
+        static_assert(boost::math::ccmath::isnan(boost::math::ccmath::round(std::numeric_limits<T>::quiet_NaN())), "If x is NaN, NaN is returned");
+        static_assert(boost::math::ccmath::lround(std::numeric_limits<T>::quiet_NaN()) == T(0), "If x is NaN, 0 is returned");
+        static_assert(boost::math::ccmath::llround(std::numeric_limits<T>::quiet_NaN()) == T(0), "If x is NaN, 0 is returned");
+    }
+
+    static_assert(boost::math::ccmath::round(T(0)) == T(0));
+    static_assert(boost::math::ccmath::lround(T(0)) == 0l);
+    static_assert(boost::math::ccmath::llround(T(0)) == 0ll);
+
+    static_assert(boost::math::ccmath::round(T(-0)) == T(-0));
+    static_assert(boost::math::ccmath::lround(T(-0)) == -0l);
+    static_assert(boost::math::ccmath::llround(T(-0)) == -0ll);
+
+    static_assert(boost::math::ccmath::isinf(boost::math::ccmath::round(std::numeric_limits<T>::infinity())));
+    static_assert(boost::math::ccmath::lround(std::numeric_limits<T>::infinity()) == 0l);
+    static_assert(boost::math::ccmath::llround(std::numeric_limits<T>::infinity()) == 0ll);
+
+    static_assert(boost::math::ccmath::round(T(2.3)) == T(2));
+    static_assert(boost::math::ccmath::round(T(2.5)) == T(3));
+    static_assert(boost::math::ccmath::round(T(2.7)) == T(3));
+    static_assert(boost::math::ccmath::round(T(-2.3)) == T(-2));
+    static_assert(boost::math::ccmath::round(T(-2.5)) == T(-3));
+    static_assert(boost::math::ccmath::round(T(-2.7)) == T(-3));
+
+    static_assert(boost::math::ccmath::lround(T(2.3)) == 2l);
+    static_assert(boost::math::ccmath::lround(T(2.5)) == 3l);
+    static_assert(boost::math::ccmath::lround(T(2.7)) == 3l);
+    static_assert(boost::math::ccmath::lround(T(-2.3)) == -2l);
+    static_assert(boost::math::ccmath::lround(T(-2.5)) == -3l);
+    static_assert(boost::math::ccmath::lround(T(-2.7)) == -3l);
+
+    static_assert(boost::math::ccmath::llround(T(2.3)) == 2ll);
+    static_assert(boost::math::ccmath::llround(T(2.5)) == 3ll);
+    static_assert(boost::math::ccmath::llround(T(2.7)) == 3ll);
+    static_assert(boost::math::ccmath::llround(T(-2.3)) == -2ll);
+    static_assert(boost::math::ccmath::llround(T(-2.5)) == -3ll);
+    static_assert(boost::math::ccmath::llround(T(-2.7)) == -3ll);
+}
+
+#if !defined(BOOST_MATH_NO_CONSTEXPR_DETECTION) && !defined(BOOST_MATH_USING_BUILTIN_CONSTANT_P)
+int main()
+{
+    test<float>();
+    test<double>();
+
+    #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+    test<long double>();
+    #endif
+    
+    #ifdef BOOST_HAS_FLOAT128
+    test<boost::multiprecision::float128>();
+    #endif
+
+    return 0;
+}
+#else
+int main()
+{
+    return 0;
+}
+#endif

--- a/test/compile_test/ccmath_round_incl_test.cpp
+++ b/test/compile_test/ccmath_round_incl_test.cpp
@@ -1,0 +1,31 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/math/ccmath/round.hpp>
+#include "test_compile_result.hpp"
+
+void compile_and_link_test()
+{
+   // round
+   check_result<float>(boost::math::ccmath::round(1.0f));
+   check_result<double>(boost::math::ccmath::round(1.0));
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+   check_result<long double>(boost::math::ccmath::round(1.0l));
+#endif
+
+    // lround
+    check_result<long>(boost::math::ccmath::lround(1.0f));
+    check_result<long>(boost::math::ccmath::lround(1.0));
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+    check_result<long>(boost::math::ccmath::lround(1.0l));
+#endif
+
+    // llround
+    check_result<long long>(boost::math::ccmath::llround(1.0f));
+    check_result<long long>(boost::math::ccmath::llround(1.0));
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+    check_result<long long>(boost::math::ccmath::llround(1.0l));
+#endif
+}


### PR DESCRIPTION
Implements: `round`, `roundf`, `roundl`, `lround`, `lroundf`, `lroundl`, `llround`, `llroundf`, and `llroundl`.