### PR TITLE
Expand the catmull-rom spline doc

### DIFF
--- a/doc/interpolators/catmull_rom.qbk
+++ b/doc/interpolators/catmull_rom.qbk
@@ -65,8 +65,7 @@ The basic usage is shown here:
     // Interpolate at s = 0.1:
     auto point = cr(0.1);
 
-Here, /s/ varies between 0 and /cr.max_parameter()/. The latter's value depends on the choice of /alpha/. In order to interpolate the curve between /points[i]/ and /points[i+1]/, 
-/s/ should go from  /cr.parameter_at_point(i)/ and /cr.parameter_at_point(i+1)/.
+Here, /s/ varies between 0 and /cr.max_parameter()/. The latter's value depends on the choice of /alpha/. In order to interpolate the curve between /points[i]/ and /points[i+1]/, /s/ should go from  /cr.parameter_at_point(i)/ and /cr.parameter_at_point(i+1)/.
 
 The spline can be either open or /closed/, closed meaning that there is some /s > 0/ such that /P(s) = P(0)/.
 The default is open, but this can be easily changed:

--- a/doc/interpolators/catmull_rom.qbk
+++ b/doc/interpolators/catmull_rom.qbk
@@ -65,6 +65,9 @@ The basic usage is shown here:
     // Interpolate at s = 0.1:
     auto point = cr(0.1);
 
+Here, /s/ varies between 0 and /cr.max_parameter()/. The latter's value depends on the choice of /alpha/. In order to interpolate the curve between /points[i]/ and /points[i+1]/, 
+/s/ should go from  /cr.parameter_at_point(i)/ and /cr.parameter_at_point(i+1)/.
+
 The spline can be either open or /closed/, closed meaning that there is some /s > 0/ such that /P(s) = P(0)/.
 The default is open, but this can be easily changed:
 


### PR DESCRIPTION
It is not clear from the current documentation how the curve parameter is relates to how to interpolate between any two of the input points, which is one reason for using spline interpolation. Here a blurb is added to the doc, following https://github.com/boostorg/math/issues/211. 