### PR TITLE
Fix tests for Apple M1

### DIFF
--- a/test/test_bessel_i_prime.cpp
+++ b/test/test_bessel_i_prime.cpp
@@ -62,6 +62,7 @@ void expected_results()
       ".*", 4000, 1500);               // test function
 #else
       ".*", 3500, 1500);               // test function
+#endif
    //
    // G++ on Linux, results vary a bit by processor type,
    // on Itanium results are *much* better than listed here,

--- a/test/test_bessel_i_prime.cpp
+++ b/test/test_bessel_i_prime.cpp
@@ -58,6 +58,9 @@ void expected_results()
       "Mac OS",                      // platform
       largest_type,                  // test type(s)
       ".*",                          // test data group
+#ifdef __aarch64__
+      ".*", 4000, 1500);               // test function
+#else
       ".*", 3500, 1500);               // test function
    //
    // G++ on Linux, results vary a bit by processor type,

--- a/test/test_bessel_j.cpp
+++ b/test/test_bessel_j.cpp
@@ -143,6 +143,9 @@ void expected_results()
       "Mac OS",                          // platform
       largest_type,                  // test type(s)
       ".*J1.*Tricky.*",              // test data group
+#ifdef __aarch64__
+      ".*", 4000000, 2000000);       // test function
+#else
       ".*", 3000000, 2000000);       // test function
    add_expected_result(
       ".*",                          // compiler

--- a/test/test_bessel_j.cpp
+++ b/test/test_bessel_j.cpp
@@ -147,6 +147,7 @@ void expected_results()
       ".*", 4000000, 2000000);       // test function
 #else
       ".*", 3000000, 2000000);       // test function
+#endif
    add_expected_result(
       ".*",                          // compiler
       ".*",                          // stdlib

--- a/test/test_root_iterations.cpp
+++ b/test/test_root_iterations.cpp
@@ -299,7 +299,7 @@ BOOST_AUTO_TEST_CASE( test_main )
          result = ibeta_small_data[i][2];
          dr = boost::math::tools::halley_iterate(ibeta_roots_3<double, boost::math::policies::policy<> >(ibeta_small_data[i][0], ibeta_small_data[i][1], ibeta_small_data[i][5]), 0.5, 0.0, 1.0, 53, iters);
          BOOST_CHECK_CLOSE_FRACTION(dr, result, std::numeric_limits<double>::epsilon() * 200);
-#ifdef __PPC__
+#if defined(__PPC__) || defined(__aarch64__)
          BOOST_CHECK_LE(iters, 55);
 #else
          BOOST_CHECK_LE(iters, 40);


### PR DESCRIPTION
From #724

@jzmaddock M1 does not define `__arm__`, but does define `__aarch64__`. The tests now pass locally.