### PR TITLE
Cygwin, FreeBSD: Do not define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS

### DIFF
--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -81,7 +81,7 @@
 
 #include <boost/math/tools/user.hpp>
 
-#if (defined(__CYGWIN__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__EMSCRIPTEN__)\
+#if (defined(__NetBSD__) || defined(__EMSCRIPTEN__)\
    || (defined(__hppa) && !defined(__OpenBSD__)) || (defined(__NO_LONG_DOUBLE_MATH) && (DBL_MANT_DIG != LDBL_MANT_DIG))) \
    && !defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS)
 #  define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS


### PR DESCRIPTION
Conditionals for these platforms in `include/boost/math/tools/config.hpp` appear to be outdated.

FreeBSD patches it out in its port of SciPy (which vendors boost headers) - https://cgit.freebsd.org/ports/tree/science/py-scipy/files/patch-scipy___lib_boost_boost_math_tools_config.hpp

In SageMath, we have adopted this patch and made the same update to Cygwin - https://trac.sagemath.org/ticket/33080

The Cygwin platform can be tested via #727.