### PR TITLE
Redeclaration of max_factorial value

### DIFF
--- a/include/boost/math/special_functions/detail/unchecked_factorial.hpp
+++ b/include/boost/math/special_functions/detail/unchecked_factorial.hpp
@@ -1009,7 +1009,7 @@ struct max_factorial
 
 #ifndef BOOST_NO_INCLASS_MEMBER_INITIALIZATION
 template <class T>
-const unsigned max_factorial<T>::value;
+constexpr unsigned max_factorial<T>::value;
 #endif
 
 } // namespace math


### PR DESCRIPTION
I found this one while snooping around with older compiler(s) and other projects. But it also influences Math/Multiprecision directly.

This minute change raises the question of exactly _how_ should we deal with `static` `constexpr` POD members of a class/struct? Even in the presence of `BOOST_NO_INCLASS_MEMBER_INITIALIZATION` do these really need out-of-class initialization for any of the compilers we are using?

That there is a mismatch between `const` and `constexpr` is truly wrong. But what is right or less wrong?

I addressed this question in my own developments about two years ago while modernizing and came to the conclusion that the extra out-of-class initialization is redundant, harmless and somehow is handled properly (or simply disregarded) by every old, new, embedded, etc. compiler that I use from 11, 14, 17, to 20 and beyond. So I synchronized the word `constexpr` and retained all such initializations in my projects.

So within the context of this minute change in this PR, maybe some dialog regarding our philosophy in Boost will ensue?

Cc: @jzmaddock and @mborland and @NAThompson.