### PR TITLE
Cleanup Warnings

### DIFF
--- a/include/boost/math/concepts/real_type_concept.hpp
+++ b/include/boost/math/concepts/real_type_concept.hpp
@@ -26,7 +26,7 @@ template <class RealType>
 struct RealTypeConcept
 {
    template <class Other>
-   void check_binary_ops(Other o)
+   void check_binary_ops(Other o) const
    {
       RealType r(o);
       r = o;
@@ -100,7 +100,7 @@ struct RealTypeConcept
       r2 = asin(r);
       r2 = acos(r);
       r2 = atan(r);
-      int i;
+      int i {};
       r2 = ldexp(r, i);
       r2 = frexp(r, &i);
       i = boost::math::tools::digits<RealType>();

--- a/include/boost/math/octonion.hpp
+++ b/include/boost/math/octonion.hpp
@@ -19,7 +19,7 @@ namespace boost
 {
     namespace math
     {
-    
+
 #define    BOOST_OCTONION_ACCESSOR_GENERATOR(type)                      \
             type                        real() const                    \
             {                                                           \
@@ -100,8 +100,8 @@ namespace boost
             {                                                           \
                 return(::boost::math::quaternion<type>(e,f,g,h));       \
             }
-        
-    
+
+
 #define    BOOST_OCTONION_MEMBER_ASSIGNMENT_GENERATOR(type)                                         \
             template<typename X>                                                                    \
             octonion<type> &        operator = (octonion<X> const & a_affecter)                     \
@@ -162,8 +162,8 @@ namespace boost
                                                                                                     \
                 return(*this);                                                                      \
             }
-        
-        
+
+
 #define    BOOST_OCTONION_MEMBER_DATA_GENERATOR(type) \
             type    a;                                \
             type    b;                                \
@@ -173,18 +173,18 @@ namespace boost
             type    f;                                \
             type    g;                                \
             type    h;                                \
-        
-        
+
+
         template<typename T>
         class octonion
         {
         public:
-            
-            typedef T value_type;
-            
+
+            using value_type = T;
+
             // constructor for O seen as R^8
             // (also default constructor)
-            
+
             explicit                octonion(   T const & requested_a = T(),
                                                 T const & requested_b = T(),
                                                 T const & requested_c = T(),
@@ -204,10 +204,10 @@ namespace boost
             {
                 // nothing to do!
             }
-            
-            
+
+
             // constructor for H seen as C^4
-                
+
             explicit                octonion(   ::std::complex<T> const & z0,
                                                 ::std::complex<T> const & z1 = ::std::complex<T>(),
                                                 ::std::complex<T> const & z2 = ::std::complex<T>(),
@@ -223,10 +223,10 @@ namespace boost
             {
                 // nothing to do!
             }
-            
-            
+
+
             // constructor for O seen as H^2
-                
+
             explicit                octonion(   ::boost::math::quaternion<T> const & q0,
                                                 ::boost::math::quaternion<T> const & q1 = ::boost::math::quaternion<T>())
             :   a(q0.R_component_1()),
@@ -240,14 +240,14 @@ namespace boost
             {
                 // nothing to do!
             }
-            
-            
+
+
             // UNtemplated copy constructor
-            // (this is taken care of by the compiler itself)
-            
-            
+            octonion(const octonion&) = default;
+
+
             // templated copy constructor
-            
+
             template<typename X>
             explicit                octonion(octonion<X> const & a_recopier)
             :   a(static_cast<T>(a_recopier.R_component_1())),
@@ -261,12 +261,12 @@ namespace boost
             {
                 // nothing to do!
             }
-            
-            
+
+
             // destructor
-            // (this is taken care of by the compiler itself)
-            
-            
+            ~octonion() = default;
+
+
             // accessors
             //
             // Note:    Like complex number, octonions do have a meaningful notion of "real part",
@@ -275,58 +275,58 @@ namespace boost
             //            nothing simpler (as opposed to the complex number case).
             //            However, for practicality, there are accessors for the other components
             //            (these are necessary for the templated copy constructor, for instance).
-            
+
             BOOST_OCTONION_ACCESSOR_GENERATOR(T)
-            
+
             // assignment operators
-            
+
             BOOST_OCTONION_MEMBER_ASSIGNMENT_GENERATOR(T)
-            
+
             // other assignment-related operators
             //
             // NOTE:    Octonion multiplication is *NOT* commutative;
             //            symbolically, "q *= rhs;" means "q = q * rhs;"
             //            and "q /= rhs;" means "q = q * inverse_of(rhs);";
             //            octonion multiplication is also *NOT* associative
-            
+
             octonion<T> &            operator += (T const & rhs)
             {
                 T    at = a + rhs;    // exception guard
-                
+
                 a = at;
-                
+
                 return(*this);
             }
-            
-            
+
+
             octonion<T> &            operator += (::std::complex<T> const & rhs)
             {
                 T    at = a + rhs.real();    // exception guard
                 T    bt = b + rhs.imag();    // exception guard
-                
-                a = at; 
+
+                a = at;
                 b = bt;
-                
+
                 return(*this);
             }
-            
-            
+
+
             octonion<T> &            operator += (::boost::math::quaternion<T> const & rhs)
             {
                 T    at = a + rhs.R_component_1();    // exception guard
                 T    bt = b + rhs.R_component_2();    // exception guard
                 T    ct = c + rhs.R_component_3();    // exception guard
                 T    dt = d + rhs.R_component_4();    // exception guard
-                
-                a = at; 
+
+                a = at;
                 b = bt;
                 c = ct;
                 d = dt;
-                
+
                 return(*this);
             }
-            
-            
+
+
             template<typename X>
             octonion<T> &            operator += (octonion<X> const & rhs)
             {
@@ -338,7 +338,7 @@ namespace boost
                 T    ft = f + static_cast<T>(rhs.R_component_6());    // exception guard
                 T    gt = g + static_cast<T>(rhs.R_component_7());    // exception guard
                 T    ht = h + static_cast<T>(rhs.R_component_8());    // exception guard
-                
+
                 a = at;
                 b = bt;
                 c = ct;
@@ -347,50 +347,50 @@ namespace boost
                 f = ft;
                 g = gt;
                 h = ht;
-                
+
                 return(*this);
             }
-            
-            
-            
+
+
+
             octonion<T> &            operator -= (T const & rhs)
             {
                 T    at = a - rhs;    // exception guard
-                
+
                 a = at;
-                
+
                 return(*this);
             }
-            
-            
+
+
             octonion<T> &            operator -= (::std::complex<T> const & rhs)
             {
                 T    at = a - rhs.real();    // exception guard
                 T    bt = b - rhs.imag();    // exception guard
-                
-                a = at; 
+
+                a = at;
                 b = bt;
-                
+
                 return(*this);
             }
-            
-            
+
+
             octonion<T> &            operator -= (::boost::math::quaternion<T> const & rhs)
             {
                 T    at = a - rhs.R_component_1();    // exception guard
                 T    bt = b - rhs.R_component_2();    // exception guard
                 T    ct = c - rhs.R_component_3();    // exception guard
                 T    dt = d - rhs.R_component_4();    // exception guard
-                
-                a = at; 
+
+                a = at;
                 b = bt;
                 c = ct;
                 d = dt;
-                
+
                 return(*this);
             }
-            
-            
+
+
             template<typename X>
             octonion<T> &            operator -= (octonion<X> const & rhs)
             {
@@ -402,7 +402,7 @@ namespace boost
                 T    ft = f - static_cast<T>(rhs.R_component_6());    // exception guard
                 T    gt = g - static_cast<T>(rhs.R_component_7());    // exception guard
                 T    ht = h - static_cast<T>(rhs.R_component_8());    // exception guard
-                
+
                 a = at;
                 b = bt;
                 c = ct;
@@ -411,11 +411,11 @@ namespace boost
                 f = ft;
                 g = gt;
                 h = ht;
-                
+
                 return(*this);
             }
-            
-            
+
+
             octonion<T> &            operator *= (T const & rhs)
             {
                 T    at = a * rhs;    // exception guard
@@ -426,7 +426,7 @@ namespace boost
                 T    ft = f * rhs;    // exception guard
                 T    gt = g * rhs;    // exception guard
                 T    ht = h * rhs;    // exception guard
-                
+
                 a = at;
                 b = bt;
                 c = ct;
@@ -435,16 +435,16 @@ namespace boost
                 f = ft;
                 g = gt;
                 h = ht;
-                
+
                 return(*this);
             }
-            
-            
+
+
             octonion<T> &            operator *= (::std::complex<T> const & rhs)
             {
                 T    ar = rhs.real();
                 T    br = rhs.imag();
-                
+
                 T    at = +a*ar-b*br;
                 T    bt = +a*br+b*ar;
                 T    ct = +c*ar+d*br;
@@ -453,7 +453,7 @@ namespace boost
                 T    ft = -e*br+f*ar;
                 T    gt = +g*ar-h*br;
                 T    ht = +g*br+h*ar;
-                
+
                 a = at;
                 b = bt;
                 c = ct;
@@ -462,18 +462,18 @@ namespace boost
                 f = ft;
                 g = gt;
                 h = ht;
-                
+
                 return(*this);
             }
-            
-            
+
+
             octonion<T> &            operator *= (::boost::math::quaternion<T> const & rhs)
             {
                 T    ar = rhs.R_component_1();
                 T    br = rhs.R_component_2();
                 T    cr = rhs.R_component_2();
                 T    dr = rhs.R_component_2();
-                
+
                 T    at = +a*ar-b*br-c*cr-d*dr;
                 T    bt = +a*br+b*ar+c*dr-d*cr;
                 T    ct = +a*cr-b*dr+c*ar+d*br;
@@ -482,7 +482,7 @@ namespace boost
                 T    ft = -e*br+f*ar-g*dr+h*cr;
                 T    gt = -e*cr+f*dr+g*ar-h*br;
                 T    ht = -e*dr-f*cr+g*br+h*ar;
-                
+
                 a = at;
                 b = bt;
                 c = ct;
@@ -491,11 +491,11 @@ namespace boost
                 f = ft;
                 g = gt;
                 h = ht;
-                
+
                 return(*this);
             }
-            
-            
+
+
             template<typename X>
             octonion<T> &            operator *= (octonion<X> const & rhs)
             {
@@ -507,7 +507,7 @@ namespace boost
                 T    fr = static_cast<T>(rhs.R_component_6());
                 T    gr = static_cast<T>(rhs.R_component_7());
                 T    hr = static_cast<T>(rhs.R_component_8());
-                
+
                 T    at = +a*ar-b*br-c*cr-d*dr-e*er-f*fr-g*gr-h*hr;
                 T    bt = +a*br+b*ar+c*dr-d*cr+e*fr-f*er-g*hr+h*gr;
                 T    ct = +a*cr-b*dr+c*ar+d*br+e*gr+f*hr-g*er-h*fr;
@@ -516,7 +516,7 @@ namespace boost
                 T    ft = +a*fr+b*er-c*hr+d*gr-e*br+f*ar-g*dr+h*cr;
                 T    gt = +a*gr+b*hr+c*er-d*fr-e*cr+f*dr+g*ar-h*br;
                 T    ht = +a*hr-b*gr+c*fr+d*er-e*dr-f*cr+g*br+h*ar;
-                
+
                 a = at;
                 b = bt;
                 c = ct;
@@ -525,11 +525,11 @@ namespace boost
                 f = ft;
                 g = gt;
                 h = ht;
-                
+
                 return(*this);
             }
-            
-            
+
+
             octonion<T> &            operator /= (T const & rhs)
             {
                 T    at = a / rhs;    // exception guard
@@ -540,7 +540,7 @@ namespace boost
                 T    ft = f / rhs;    // exception guard
                 T    gt = g / rhs;    // exception guard
                 T    ht = h / rhs;    // exception guard
-                
+
                 a = at;
                 b = bt;
                 c = ct;
@@ -549,18 +549,18 @@ namespace boost
                 f = ft;
                 g = gt;
                 h = ht;
-                
+
                 return(*this);
             }
-            
-            
+
+
             octonion<T> &            operator /= (::std::complex<T> const & rhs)
             {
                 T    ar = rhs.real();
                 T    br = rhs.imag();
-                
+
                 T    denominator = ar*ar+br*br;
-                
+
                 T    at = (+a*ar-b*br)/denominator;
                 T    bt = (-a*br+b*ar)/denominator;
                 T    ct = (+c*ar-d*br)/denominator;
@@ -569,7 +569,7 @@ namespace boost
                 T    ft = (+e*br+f*ar)/denominator;
                 T    gt = (+g*ar+h*br)/denominator;
                 T    ht = (+g*br+h*ar)/denominator;
-                
+
                 a = at;
                 b = bt;
                 c = ct;
@@ -578,20 +578,20 @@ namespace boost
                 f = ft;
                 g = gt;
                 h = ht;
-                
+
                 return(*this);
             }
-            
-            
+
+
             octonion<T> &            operator /= (::boost::math::quaternion<T> const & rhs)
             {
                 T    ar = rhs.R_component_1();
                 T    br = rhs.R_component_2();
                 T    cr = rhs.R_component_2();
                 T    dr = rhs.R_component_2();
-                
+
                 T    denominator = ar*ar+br*br+cr*cr+dr*dr;
-                
+
                 T    at = (+a*ar+b*br+c*cr+d*dr)/denominator;
                 T    bt = (-a*br+b*ar-c*dr+d*cr)/denominator;
                 T    ct = (-a*cr+b*dr+c*ar-d*br)/denominator;
@@ -600,7 +600,7 @@ namespace boost
                 T    ft = (+e*br+f*ar+g*dr-h*cr)/denominator;
                 T    gt = (+e*cr-f*dr+g*ar+h*br)/denominator;
                 T    ht = (+e*dr+f*cr-g*br+h*ar)/denominator;
-                
+
                 a = at;
                 b = bt;
                 c = ct;
@@ -609,11 +609,11 @@ namespace boost
                 f = ft;
                 g = gt;
                 h = ht;
-                
+
                 return(*this);
             }
-            
-            
+
+
             template<typename X>
             octonion<T> &            operator /= (octonion<X> const & rhs)
             {
@@ -625,9 +625,9 @@ namespace boost
                 T    fr = static_cast<T>(rhs.R_component_6());
                 T    gr = static_cast<T>(rhs.R_component_7());
                 T    hr = static_cast<T>(rhs.R_component_8());
-                
+
                 T    denominator = ar*ar+br*br+cr*cr+dr*dr+er*er+fr*fr+gr*gr+hr*hr;
-                
+
                 T    at = (+a*ar+b*br+c*cr+d*dr+e*er+f*fr+g*gr+h*hr)/denominator;
                 T    bt = (-a*br+b*ar-c*dr+d*cr-e*fr+f*er+g*hr-h*gr)/denominator;
                 T    ct = (-a*cr+b*dr+c*ar-d*br-e*gr-f*hr+g*er+h*fr)/denominator;
@@ -636,7 +636,7 @@ namespace boost
                 T    ft = (-a*fr-b*er+c*hr-d*gr+e*br+f*ar+g*dr-h*cr)/denominator;
                 T    gt = (-a*gr-b*hr-c*er+d*fr+e*cr-f*dr+g*ar+h*br)/denominator;
                 T    ht = (-a*hr+b*gr-c*fr-d*er+e*dr+f*cr-g*br+h*ar)/denominator;
-                
+
                 a = at;
                 b = bt;
                 c = ct;
@@ -645,43 +645,43 @@ namespace boost
                 f = ft;
                 g = gt;
                 h = ht;
-                
+
                 return(*this);
             }
-            
-            
+
+
         protected:
-            
+
             BOOST_OCTONION_MEMBER_DATA_GENERATOR(T)
-            
-            
+
+
         private:
-            
+
         };
-        
-        
+
+
         // declaration of octonion specialization
-        
+
         template<>    class octonion<float>;
         template<>    class octonion<double>;
         template<>    class octonion<long double>;
-        
-        
+
+
         // helper templates for converting copy constructors (declaration)
-        
+
         namespace detail
         {
-            
+
             template<   typename T,
                         typename U
                     >
             octonion<T>    octonion_type_converter(octonion<U> const & rhs);
         }
-        
-        
+
+
         // implementation of octonion specialization
-        
-        
+
+
 #define    BOOST_OCTONION_CONSTRUCTOR_GENERATOR(type)                                                                               \
             explicit                    octonion(   type const & requested_a = static_cast<type>(0),                                \
                                                     type const & requested_b = static_cast<type>(0),                                \
@@ -729,8 +729,8 @@ namespace boost
                 h(q1.R_component_4())                                                                                               \
             {                                                                                                                       \
             }
-        
-    
+
+
 #define    BOOST_OCTONION_MEMBER_ADD_GENERATOR_1(type)                  \
             octonion<type> &            operator += (type const & rhs)  \
             {                                                           \
@@ -738,7 +738,7 @@ namespace boost
                                                                         \
                 return(*this);                                          \
             }
-    
+
 #define    BOOST_OCTONION_MEMBER_ADD_GENERATOR_2(type)                                  \
             octonion<type> &            operator += (::std::complex<type> const & rhs)  \
             {                                                                           \
@@ -747,7 +747,7 @@ namespace boost
                                                                                         \
                 return(*this);                                                          \
             }
-    
+
 #define    BOOST_OCTONION_MEMBER_ADD_GENERATOR_3(type)                                              \
             octonion<type> &            operator += (::boost::math::quaternion<type> const & rhs)   \
             {                                                                                       \
@@ -758,7 +758,7 @@ namespace boost
                                                                                                     \
                 return(*this);                                                                      \
             }
-    
+
 #define    BOOST_OCTONION_MEMBER_ADD_GENERATOR_4(type)                          \
             template<typename X>                                                \
             octonion<type> &            operator += (octonion<X> const & rhs)   \
@@ -774,7 +774,7 @@ namespace boost
                                                                                 \
                 return(*this);                                                  \
             }
-    
+
 #define    BOOST_OCTONION_MEMBER_SUB_GENERATOR_1(type)                  \
             octonion<type> &            operator -= (type const & rhs)  \
             {                                                           \
@@ -782,7 +782,7 @@ namespace boost
                                                                         \
                 return(*this);                                          \
             }
-    
+
 #define    BOOST_OCTONION_MEMBER_SUB_GENERATOR_2(type)                                  \
             octonion<type> &            operator -= (::std::complex<type> const & rhs)  \
             {                                                                           \
@@ -791,7 +791,7 @@ namespace boost
                                                                                         \
                 return(*this);                                                          \
             }
-    
+
 #define    BOOST_OCTONION_MEMBER_SUB_GENERATOR_3(type)                                              \
             octonion<type> &            operator -= (::boost::math::quaternion<type> const & rhs)   \
             {                                                                                       \
@@ -802,7 +802,7 @@ namespace boost
                                                                                                     \
                 return(*this);                                                                      \
             }
-    
+
 #define    BOOST_OCTONION_MEMBER_SUB_GENERATOR_4(type)                        \
             template<typename X>                                              \
             octonion<type> &            operator -= (octonion<X> const & rhs) \
@@ -818,7 +818,7 @@ namespace boost
                                                                               \
                 return(*this);                                                \
             }
-    
+
 #define    BOOST_OCTONION_MEMBER_MUL_GENERATOR_1(type)                   \
             octonion<type> &            operator *= (type const & rhs)   \
             {                                                            \
@@ -833,7 +833,7 @@ namespace boost
                                                                          \
                 return(*this);                                           \
             }
-    
+
 #define    BOOST_OCTONION_MEMBER_MUL_GENERATOR_2(type)                                  \
             octonion<type> &            operator *= (::std::complex<type> const & rhs)  \
             {                                                                           \
@@ -860,7 +860,7 @@ namespace boost
                                                                                         \
                 return(*this);                                                          \
             }
-    
+
 #define    BOOST_OCTONION_MEMBER_MUL_GENERATOR_3(type)                                                    \
             octonion<type> &            operator *= (::boost::math::quaternion<type> const & rhs)   \
             {                                                                                       \
@@ -889,7 +889,7 @@ namespace boost
                                                                                                     \
                 return(*this);                                                                      \
             }
-    
+
 #define    BOOST_OCTONION_MEMBER_MUL_GENERATOR_4(type)                          \
             template<typename X>                                                \
             octonion<type> &            operator *= (octonion<X> const & rhs)   \
@@ -923,14 +923,14 @@ namespace boost
                                                                                 \
                 return(*this);                                                  \
             }
-    
+
 // There is quite a lot of repetition in the code below. This is intentional.
 // The last conditional block is the normal form, and the others merely
 // consist of workarounds for various compiler deficiencies. Hopefully, when
 // more compilers are conformant and we can retire support for those that are
 // not, we will be able to remove the clutter. This is makes the situation
 // (painfully) explicit.
-    
+
 #define    BOOST_OCTONION_MEMBER_DIV_GENERATOR_1(type)                  \
             octonion<type> &            operator /= (type const & rhs)  \
             {                                                           \
@@ -941,7 +941,7 @@ namespace boost
                                                                         \
                 return(*this);                                          \
             }
-    
+
 #if defined(BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP)
     #define    BOOST_OCTONION_MEMBER_DIV_GENERATOR_2(type)                              \
             octonion<type> &            operator /= (::std::complex<type> const & rhs)  \
@@ -1026,7 +1026,7 @@ namespace boost
                 return(*this);                                                          \
             }
 #endif /* BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP */
-    
+
 #if defined(BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP)
     #define    BOOST_OCTONION_MEMBER_DIV_GENERATOR_3(type)                                           \
             octonion<type> &            operator /= (::boost::math::quaternion<type> const & rhs)    \
@@ -1115,7 +1115,7 @@ namespace boost
                 return(*this);                                                                       \
             }
 #endif /* BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP */
-    
+
 #if defined(BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP)
     #define    BOOST_OCTONION_MEMBER_DIV_GENERATOR_4(type)                                           \
             template<typename X>                                                                     \
@@ -1214,66 +1214,66 @@ namespace boost
                 return(*this);                                                                       \
             }
 #endif /* BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP */
-    
-    
+
+
 #define    BOOST_OCTONION_MEMBER_ADD_GENERATOR(type)       \
         BOOST_OCTONION_MEMBER_ADD_GENERATOR_1(type)        \
         BOOST_OCTONION_MEMBER_ADD_GENERATOR_2(type)        \
         BOOST_OCTONION_MEMBER_ADD_GENERATOR_3(type)        \
         BOOST_OCTONION_MEMBER_ADD_GENERATOR_4(type)
-        
+
 #define    BOOST_OCTONION_MEMBER_SUB_GENERATOR(type)       \
         BOOST_OCTONION_MEMBER_SUB_GENERATOR_1(type)        \
         BOOST_OCTONION_MEMBER_SUB_GENERATOR_2(type)        \
         BOOST_OCTONION_MEMBER_SUB_GENERATOR_3(type)        \
         BOOST_OCTONION_MEMBER_SUB_GENERATOR_4(type)
-        
+
 #define    BOOST_OCTONION_MEMBER_MUL_GENERATOR(type)       \
         BOOST_OCTONION_MEMBER_MUL_GENERATOR_1(type)        \
         BOOST_OCTONION_MEMBER_MUL_GENERATOR_2(type)        \
         BOOST_OCTONION_MEMBER_MUL_GENERATOR_3(type)        \
         BOOST_OCTONION_MEMBER_MUL_GENERATOR_4(type)
-        
+
 #define    BOOST_OCTONION_MEMBER_DIV_GENERATOR(type)       \
         BOOST_OCTONION_MEMBER_DIV_GENERATOR_1(type)        \
         BOOST_OCTONION_MEMBER_DIV_GENERATOR_2(type)        \
         BOOST_OCTONION_MEMBER_DIV_GENERATOR_3(type)        \
         BOOST_OCTONION_MEMBER_DIV_GENERATOR_4(type)
-        
+
 #define    BOOST_OCTONION_MEMBER_ALGEBRAIC_GENERATOR(type) \
         BOOST_OCTONION_MEMBER_ADD_GENERATOR(type)          \
         BOOST_OCTONION_MEMBER_SUB_GENERATOR(type)          \
         BOOST_OCTONION_MEMBER_MUL_GENERATOR(type)          \
         BOOST_OCTONION_MEMBER_DIV_GENERATOR(type)
-        
-        
+
+
         template<>
         class octonion<float>
         {
         public:
-            
-            typedef float value_type;
-            
+
+            using value_type = float;
+
             BOOST_OCTONION_CONSTRUCTOR_GENERATOR(float)
-            
+
             // UNtemplated copy constructor
-            // (this is taken care of by the compiler itself)
-            
+            octonion(const octonion&) = default;
+
             // explicit copy constructors (precision-losing converters)
-            
+
             explicit                    octonion(octonion<double> const & a_recopier)
             {
                 *this = detail::octonion_type_converter<float, double>(a_recopier);
             }
-            
+
             explicit                    octonion(octonion<long double> const & a_recopier)
             {
                 *this = detail::octonion_type_converter<float, long double>(a_recopier);
             }
-            
+
             // destructor
-            // (this is taken care of by the compiler itself)
-            
+            ~octonion() = default;
+
             // accessors
             //
             // Note:    Like complex number, octonions do have a meaningful notion of "real part",
@@ -1282,62 +1282,58 @@ namespace boost
             //            nothing simpler (as opposed to the complex number case).
             //            However, for practicality, there are accessors for the other components
             //            (these are necessary for the templated copy constructor, for instance).
-            
+
             BOOST_OCTONION_ACCESSOR_GENERATOR(float)
-            
+
             // assignment operators
-            
+
             BOOST_OCTONION_MEMBER_ASSIGNMENT_GENERATOR(float)
-            
+
             // other assignment-related operators
             //
             // NOTE:    Octonion multiplication is *NOT* commutative;
             //            symbolically, "q *= rhs;" means "q = q * rhs;"
             //            and "q /= rhs;" means "q = q * inverse_of(rhs);";
             //            octonion multiplication is also *NOT* associative
-            
+
             BOOST_OCTONION_MEMBER_ALGEBRAIC_GENERATOR(float)
-            
-            
+
+
         protected:
-            
+
             BOOST_OCTONION_MEMBER_DATA_GENERATOR(float)
-            
-            
-        private:
-            
         };
-        
-        
+
+
         template<>
         class octonion<double>
         {
         public:
-            
-            typedef double value_type;
-            
+
+            using value_type = double;
+
             BOOST_OCTONION_CONSTRUCTOR_GENERATOR(double)
-            
-            // UNtemplated copy constructor
-            // (this is taken care of by the compiler itself)
-            
+
+            // Untemplated copy constructor
+            octonion(const octonion&) = default;
+
             // converting copy constructor
-            
+
             explicit                    octonion(octonion<float> const & a_recopier)
             {
                 *this = detail::octonion_type_converter<double, float>(a_recopier);
             }
-            
+
             // explicit copy constructors (precision-losing converters)
-            
+
             explicit                    octonion(octonion<long double> const & a_recopier)
             {
                 *this = detail::octonion_type_converter<double, long double>(a_recopier);
             }
-            
+
             // destructor
             // (this is taken care of by the compiler itself)
-            
+
             // accessors
             //
             // Note:    Like complex number, octonions do have a meaningful notion of "real part",
@@ -1346,62 +1342,58 @@ namespace boost
             //            nothing simpler (as opposed to the complex number case).
             //            However, for practicality, there are accessors for the other components
             //            (these are necessary for the templated copy constructor, for instance).
-            
+
             BOOST_OCTONION_ACCESSOR_GENERATOR(double)
-            
+
             // assignment operators
-            
+
             BOOST_OCTONION_MEMBER_ASSIGNMENT_GENERATOR(double)
-            
+
             // other assignment-related operators
             //
             // NOTE:    Octonion multiplication is *NOT* commutative;
             //            symbolically, "q *= rhs;" means "q = q * rhs;"
             //            and "q /= rhs;" means "q = q * inverse_of(rhs);";
             //            octonion multiplication is also *NOT* associative
-            
+
             BOOST_OCTONION_MEMBER_ALGEBRAIC_GENERATOR(double)
-            
-            
+
+
         protected:
-            
+
             BOOST_OCTONION_MEMBER_DATA_GENERATOR(double)
-            
-            
-        private:
-            
         };
-        
-        
+
+
         template<>
         class octonion<long double>
         {
         public:
-            
-            typedef long double value_type;
-            
+
+            using value_type = long double;
+
             BOOST_OCTONION_CONSTRUCTOR_GENERATOR(long double)
-            
+
             // UNtemplated copy constructor
-            // (this is taken care of by the compiler itself)
-            
+            octonion(const octonion&) = default;
+
             // converting copy constructor
-            
+
             explicit                            octonion(octonion<float> const & a_recopier)
             {
                 *this = detail::octonion_type_converter<long double, float>(a_recopier);
             }
-            
-            
+
+
             explicit                            octonion(octonion<double> const & a_recopier)
             {
                 *this = detail::octonion_type_converter<long double, double>(a_recopier);
             }
-            
-            
+
+
             // destructor
             // (this is taken care of by the compiler itself)
-            
+
             // accessors
             //
             // Note:    Like complex number, octonions do have a meaningful notion of "real part",
@@ -1410,42 +1402,42 @@ namespace boost
             //            nothing simpler (as opposed to the complex number case).
             //            However, for practicality, there are accessors for the other components
             //            (these are necessary for the templated copy constructor, for instance).
-            
+
             BOOST_OCTONION_ACCESSOR_GENERATOR(long double)
-            
+
             // assignment operators
-            
+
             BOOST_OCTONION_MEMBER_ASSIGNMENT_GENERATOR(long double)
-            
+
             // other assignment-related operators
             //
             // NOTE:    Octonion multiplication is *NOT* commutative;
             //            symbolically, "q *= rhs;" means "q = q * rhs;"
             //            and "q /= rhs;" means "q = q * inverse_of(rhs);";
             //            octonion multiplication is also *NOT* associative
-            
+
             BOOST_OCTONION_MEMBER_ALGEBRAIC_GENERATOR(long double)
-            
-            
+
+
         protected:
-            
+
             BOOST_OCTONION_MEMBER_DATA_GENERATOR(long double)
-            
-            
+
+
         private:
-            
+
         };
-        
-        
+
+
 #undef    BOOST_OCTONION_CONSTRUCTOR_GENERATOR
-        
+
 #undef    BOOST_OCTONION_MEMBER_ALGEBRAIC_GENERATOR
-    
+
 #undef    BOOST_OCTONION_MEMBER_ADD_GENERATOR
 #undef    BOOST_OCTONION_MEMBER_SUB_GENERATOR
 #undef    BOOST_OCTONION_MEMBER_MUL_GENERATOR
 #undef    BOOST_OCTONION_MEMBER_DIV_GENERATOR
-    
+
 #undef    BOOST_OCTONION_MEMBER_ADD_GENERATOR_1
 #undef    BOOST_OCTONION_MEMBER_ADD_GENERATOR_2
 #undef    BOOST_OCTONION_MEMBER_ADD_GENERATOR_3
@@ -1462,59 +1454,59 @@ namespace boost
 #undef    BOOST_OCTONION_MEMBER_DIV_GENERATOR_2
 #undef    BOOST_OCTONION_MEMBER_DIV_GENERATOR_3
 #undef    BOOST_OCTONION_MEMBER_DIV_GENERATOR_4
-    
-    
+
+
 #undef    BOOST_OCTONION_MEMBER_DATA_GENERATOR
-    
+
 #undef    BOOST_OCTONION_MEMBER_ASSIGNMENT_GENERATOR
-    
+
 #undef    BOOST_OCTONION_ACCESSOR_GENERATOR
-        
-        
+
+
         // operators
-        
+
 #define    BOOST_OCTONION_OPERATOR_GENERATOR_BODY(op) \
         {                                             \
             octonion<T>    res(lhs);                  \
             res op##= rhs;                            \
             return(res);                              \
         }
-        
+
 #define    BOOST_OCTONION_OPERATOR_GENERATOR_1_L(op)                                                                              \
         template<typename T>                                                                                                      \
         inline octonion<T>                        operator op (T const & lhs, octonion<T> const & rhs)                            \
         BOOST_OCTONION_OPERATOR_GENERATOR_BODY(op)
-        
+
 #define    BOOST_OCTONION_OPERATOR_GENERATOR_1_R(op)                                                                              \
         template<typename T>                                                                                                      \
         inline octonion<T>                        operator op (octonion<T> const & lhs, T const & rhs)                            \
         BOOST_OCTONION_OPERATOR_GENERATOR_BODY(op)
-        
+
 #define    BOOST_OCTONION_OPERATOR_GENERATOR_2_L(op)                                                                              \
         template<typename T>                                                                                                      \
         inline octonion<T>                        operator op (::std::complex<T> const & lhs, octonion<T> const & rhs)            \
         BOOST_OCTONION_OPERATOR_GENERATOR_BODY(op)
-        
+
 #define    BOOST_OCTONION_OPERATOR_GENERATOR_2_R(op)                                                                              \
         template<typename T>                                                                                                      \
         inline octonion<T>                        operator op (octonion<T> const & lhs, ::std::complex<T> const & rhs)            \
         BOOST_OCTONION_OPERATOR_GENERATOR_BODY(op)
-        
+
 #define    BOOST_OCTONION_OPERATOR_GENERATOR_3_L(op)                                                                              \
         template<typename T>                                                                                                      \
         inline octonion<T>                        operator op (::boost::math::quaternion<T> const & lhs, octonion<T> const & rhs) \
         BOOST_OCTONION_OPERATOR_GENERATOR_BODY(op)
-        
+
 #define    BOOST_OCTONION_OPERATOR_GENERATOR_3_R(op)                                                                              \
         template<typename T>                                                                                                      \
         inline octonion<T>                        operator op (octonion<T> const & lhs, ::boost::math::quaternion<T> const & rhs) \
         BOOST_OCTONION_OPERATOR_GENERATOR_BODY(op)
-        
+
 #define    BOOST_OCTONION_OPERATOR_GENERATOR_4(op)                                                                                \
         template<typename T>                                                                                                      \
         inline octonion<T>                        operator op (octonion<T> const & lhs, octonion<T> const & rhs)                  \
         BOOST_OCTONION_OPERATOR_GENERATOR_BODY(op)
-        
+
 #define    BOOST_OCTONION_OPERATOR_GENERATOR(op)     \
         BOOST_OCTONION_OPERATOR_GENERATOR_1_L(op)    \
         BOOST_OCTONION_OPERATOR_GENERATOR_1_R(op)    \
@@ -1523,16 +1515,16 @@ namespace boost
         BOOST_OCTONION_OPERATOR_GENERATOR_3_L(op)    \
         BOOST_OCTONION_OPERATOR_GENERATOR_3_R(op)    \
         BOOST_OCTONION_OPERATOR_GENERATOR_4(op)
-        
-        
+
+
         BOOST_OCTONION_OPERATOR_GENERATOR(+)
         BOOST_OCTONION_OPERATOR_GENERATOR(-)
         BOOST_OCTONION_OPERATOR_GENERATOR(*)
         BOOST_OCTONION_OPERATOR_GENERATOR(/)
-        
-        
+
+
 #undef    BOOST_OCTONION_OPERATOR_GENERATOR
-        
+
 #undef    BOOST_OCTONION_OPERATOR_GENERATOR_1_L
 #undef    BOOST_OCTONION_OPERATOR_GENERATOR_1_R
 #undef    BOOST_OCTONION_OPERATOR_GENERATOR_2_L
@@ -1540,24 +1532,24 @@ namespace boost
 #undef    BOOST_OCTONION_OPERATOR_GENERATOR_3_L
 #undef    BOOST_OCTONION_OPERATOR_GENERATOR_3_R
 #undef    BOOST_OCTONION_OPERATOR_GENERATOR_4
-    
+
 #undef    BOOST_OCTONION_OPERATOR_GENERATOR_BODY
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        operator + (octonion<T> const & o)
         {
             return(o);
         }
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        operator - (octonion<T> const & o)
         {
             return(octonion<T>(-o.R_component_1(),-o.R_component_2(),-o.R_component_3(),-o.R_component_4(),-o.R_component_5(),-o.R_component_6(),-o.R_component_7(),-o.R_component_8()));
         }
-        
-        
+
+
         template<typename T>
         inline bool                                operator == (T const & lhs, octonion<T> const & rhs)
         {
@@ -1572,8 +1564,8 @@ namespace boost
                         (rhs.R_component_8() == static_cast<T>(0))
                     );
         }
-        
-        
+
+
         template<typename T>
         inline bool                                operator == (octonion<T> const & lhs, T const & rhs)
         {
@@ -1588,8 +1580,8 @@ namespace boost
                         (lhs.R_component_8() == static_cast<T>(0))
                     );
         }
-        
-        
+
+
         template<typename T>
         inline bool                                operator == (::std::complex<T> const & lhs, octonion<T> const & rhs)
         {
@@ -1604,8 +1596,8 @@ namespace boost
                         (rhs.R_component_8() == static_cast<T>(0))
                     );
         }
-        
-        
+
+
         template<typename T>
         inline bool                                operator == (octonion<T> const & lhs, ::std::complex<T> const & rhs)
         {
@@ -1620,8 +1612,8 @@ namespace boost
                         (lhs.R_component_8() == static_cast<T>(0))
                     );
         }
-        
-        
+
+
         template<typename T>
         inline bool                                operator == (::boost::math::quaternion<T> const & lhs, octonion<T> const & rhs)
         {
@@ -1636,8 +1628,8 @@ namespace boost
                         (rhs.R_component_8() == static_cast<T>(0))
                     );
         }
-        
-        
+
+
         template<typename T>
         inline bool                                operator == (octonion<T> const & lhs, ::boost::math::quaternion<T> const & rhs)
         {
@@ -1652,8 +1644,8 @@ namespace boost
                         (lhs.R_component_8() == static_cast<T>(0))
                     );
         }
-        
-        
+
+
         template<typename T>
         inline bool                                operator == (octonion<T> const & lhs, octonion<T> const & rhs)
         {
@@ -1668,44 +1660,44 @@ namespace boost
                         (rhs.R_component_8() == lhs.R_component_8())
                     );
         }
-        
-        
+
+
 #define    BOOST_OCTONION_NOT_EQUAL_GENERATOR \
         {                                     \
             return(!(lhs == rhs));            \
         }
-        
+
         template<typename T>
         inline bool                                operator != (T const & lhs, octonion<T> const & rhs)
         BOOST_OCTONION_NOT_EQUAL_GENERATOR
-        
+
         template<typename T>
         inline bool                                operator != (octonion<T> const & lhs, T const & rhs)
         BOOST_OCTONION_NOT_EQUAL_GENERATOR
-        
+
         template<typename T>
         inline bool                                operator != (::std::complex<T> const & lhs, octonion<T> const & rhs)
         BOOST_OCTONION_NOT_EQUAL_GENERATOR
-        
+
         template<typename T>
         inline bool                                operator != (octonion<T> const & lhs, ::std::complex<T> const & rhs)
         BOOST_OCTONION_NOT_EQUAL_GENERATOR
-        
+
         template<typename T>
         inline bool                                operator != (::boost::math::quaternion<T> const & lhs, octonion<T> const & rhs)
         BOOST_OCTONION_NOT_EQUAL_GENERATOR
-        
+
         template<typename T>
         inline bool                                operator != (octonion<T> const & lhs, ::boost::math::quaternion<T> const & rhs)
         BOOST_OCTONION_NOT_EQUAL_GENERATOR
-        
+
         template<typename T>
         inline bool                                operator != (octonion<T> const & lhs, octonion<T> const & rhs)
         BOOST_OCTONION_NOT_EQUAL_GENERATOR
-        
+
     #undef    BOOST_OCTONION_NOT_EQUAL_GENERATOR
-        
-        
+
+
         // Note:    the default values in the constructors of the complex and quaternions make for
         //            a very complex and ambiguous situation; we have made choices to disambiguate.
         template<typename T, typename charT, class traits>
@@ -1716,7 +1708,7 @@ namespace boost
 #else
             const ::std::ctype<charT> & ct = ::std::use_facet< ::std::ctype<charT> >(is.getloc());
 #endif /* BOOST_NO_STD_LOCALE */
-            
+
             T    a = T();
             T    b = T();
             T    c = T();
@@ -1725,82 +1717,82 @@ namespace boost
             T    f = T();
             T    g = T();
             T    h = T();
-            
+
             ::std::complex<T>    u = ::std::complex<T>();
             ::std::complex<T>    v = ::std::complex<T>();
             ::std::complex<T>    x = ::std::complex<T>();
             ::std::complex<T>    y = ::std::complex<T>();
-            
+
             ::boost::math::quaternion<T>    p = ::boost::math::quaternion<T>();
             ::boost::math::quaternion<T>    q = ::boost::math::quaternion<T>();
-            
+
             charT    ch = charT();
             char    cc;
-            
+
             is >> ch;                                        // get the first lexeme
-            
+
             if    (!is.good())    goto finish;
-            
+
 #ifdef    BOOST_NO_STD_LOCALE
             cc = ch;
 #else
             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-            
+
             if    (cc == '(')                            // read "("
             {
                 is >> ch;                                    // get the second lexeme
-                
+
                 if    (!is.good())    goto finish;
-                
+
 #ifdef    BOOST_NO_STD_LOCALE
                 cc = ch;
 #else
                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                
+
                 if    (cc == '(')                                // read "(("
                 {
                     is >> ch;                                    // get the third lexeme
-                    
+
                     if    (!is.good())    goto finish;
-                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                     cc = ch;
 #else
                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                        
+
                     if    (cc == '(')                                // read "((("
                     {
                         is.putback(ch);
-                        
+
                         is >> u;                                // read "((u"
-                        
+
                         if    (!is.good())    goto finish;
-                        
+
                         is >> ch;                                // get the next lexeme
-                        
+
                         if    (!is.good())    goto finish;
-                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                         cc = ch;
 #else
                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                        
+
                         if        (cc == ')')                        // read "((u)"
                         {
                             is >> ch;                                // get the next lexeme
-                            
+
                             if    (!is.good())    goto finish;
-                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                             cc = ch;
 #else
                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                            
+
                             if        (cc == ')')                        // format: (((a))), (((a,b)))
                             {
                                 o = octonion<T>(u);
@@ -1808,21 +1800,21 @@ namespace boost
                             else if    (cc == ',')                        // read "((u),"
                             {
                                 p = ::boost::math::quaternion<T>(u);
-                                
+
                                 is >> q;                                // read "((u),q"
-                                
+
                                 if    (!is.good())    goto finish;
-                                
+
                                 is >> ch;                                // get the next lexeme
-                                
+
                                 if    (!is.good())    goto finish;
-                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                 cc = ch;
 #else
                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                
+
                                 if        (cc == ')')                        // format: (((a)),q), (((a,b)),q)
                                 {
                                     o = octonion<T>(p,q);
@@ -1840,11 +1832,11 @@ namespace boost
                         else if    (cc ==',')                        // read "((u,"
                         {
                             is >> v;                                // read "((u,v"
-                            
+
                             if    (!is.good())    goto finish;
-                            
+
                             is >> ch;                                // get the next lexeme
-                            
+
                             if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -1852,13 +1844,13 @@ namespace boost
 #else
                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                            
+
                             if        (cc == ')')                        // read "((u,v)"
                             {
                                 p = ::boost::math::quaternion<T>(u,v);
-                                
+
                                 is >> ch;                                // get the next lexeme
-                                
+
                                 if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -1866,7 +1858,7 @@ namespace boost
 #else
                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                
+
                                 if        (cc == ')')                        // format: (((a),v)), (((a,b),v))
                                 {
                                     o = octonion<T>(p);
@@ -1874,11 +1866,11 @@ namespace boost
                                 else if    (cc == ',')                        // read "((u,v),"
                                 {
                                     is >> q;                                // read "(p,q"
-                                    
+
                                     if    (!is.good())    goto finish;
-                                    
+
                                     is >> ch;                                // get the next lexeme
-                                    
+
                                     if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -1886,7 +1878,7 @@ namespace boost
 #else
                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                    
+
                                     if        (cc == ')')                        // format: (((a),v),q), (((a,b),v),q)
                                     {
                                         o = octonion<T>(p,q);
@@ -1914,13 +1906,13 @@ namespace boost
                     else                                        // read "((a"
                     {
                         is.putback(ch);
-                        
+
                         is >> a;                                    // we extract the first component
-                        
+
                         if    (!is.good())    goto finish;
-                        
+
                         is >> ch;                                    // get the next lexeme
-                        
+
                         if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -1928,11 +1920,11 @@ namespace boost
 #else
                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                        
+
                         if        (cc == ')')                            // read "((a)"
                         {
                             is >> ch;                                    // get the next lexeme
-                            
+
                             if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -1940,7 +1932,7 @@ namespace boost
 #else
                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                            
+
                             if        (cc == ')')                            // read "((a))"
                             {
                                 o = octonion<T>(a);
@@ -1948,19 +1940,19 @@ namespace boost
                             else if    (cc == ',')                            // read "((a),"
                             {
                                 is >> ch;                                    // get the next lexeme
-                                
+
                                 if    (!is.good())    goto finish;
-                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                 cc = ch;
 #else
                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                
+
                                 if        (cc == '(')                            // read "((a),("
                                 {
                                     is >> ch;                                    // get the next lexeme
-                                    
+
                                     if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -1968,19 +1960,19 @@ namespace boost
 #else
                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                    
+
                                     if        (cc == '(')                            // read "((a),(("
                                     {
                                         is.putback(ch);
-                                        
+
                                         is.putback(ch);                                // we backtrack twice, with the same value!
-                                        
+
                                         is >> q;                                    // read "((a),q"
-                                        
+
                                         if    (!is.good())    goto finish;
-                                        
+
                                         is >> ch;                                    // get the next lexeme
-                                        
+
                                         if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -1988,11 +1980,11 @@ namespace boost
 #else
                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                        
+
                                         if        (cc == ')')                            // read "((a),q)"
                                         {
                                             p = ::boost::math::quaternion<T>(a);
-                                            
+
                                             o = octonion<T>(p,q);
                                         }
                                         else                                        // error
@@ -2003,33 +1995,33 @@ namespace boost
                                     else                                        // read "((a),(c" or "((a),(e"
                                     {
                                         is.putback(ch);
-                                        
+
                                         is >> c;
-                                        
+
                                         if    (!is.good())    goto finish;
-                                        
+
                                         is >> ch;                                    // get the next lexeme
-                                        
+
                                         if    (!is.good())    goto finish;
-                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                         cc = ch;
 #else
                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                        
+
                                         if        (cc == ')')                            // read "((a),(c)" (ambiguity resolution)
                                         {
                                             is >> ch;                                    // get the next lexeme
-                                            
+
                                             if    (!is.good())    goto finish;
-                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                             cc = ch;
 #else
                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                            
+
                                             if        (cc == ')')                        // read "((a),(c))"
                                             {
                                                 o = octonion<T>(a,b,c);
@@ -2037,23 +2029,23 @@ namespace boost
                                             else if    (cc == ',')                        // read "((a),(c),"
                                             {
                                                 u = ::std::complex<T>(a);
-                                                
+
                                                 v = ::std::complex<T>(c);
-                                                
+
                                                 is >> x;                            // read "((a),(c),x"
-                                                
+
                                                 if    (!is.good())    goto finish;
-                                                
+
                                                 is >> ch;                                // get the next lexeme
-                                                
+
                                                 if    (!is.good())    goto finish;
-                                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                 cc = ch;
 #else
                                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                
+
                                                 if        (cc == ')')                        // read "((a),(c),x)"
                                                 {
                                                     o = octonion<T>(u,v,x);
@@ -2061,19 +2053,19 @@ namespace boost
                                                 else if    (cc == ',')                        // read "((a),(c),x,"
                                                 {
                                                     is >> y;                                // read "((a),(c),x,y"
-                                                    
+
                                                     if    (!is.good())    goto finish;
-                                                    
+
                                                     is >> ch;                                // get the next lexeme
-                                                    
+
                                                     if    (!is.good())    goto finish;
-                                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                     cc = ch;
 #else
                                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                    
+
                                                     if        (cc == ')')                        // read "((a),(c),x,y)"
                                                     {
                                                         o = octonion<T>(u,v,x,y);
@@ -2096,7 +2088,7 @@ namespace boost
                                         else if    (cc == ',')                            // read "((a),(c," or "((a),(e,"
                                         {
                                             is >> ch;                                // get the next lexeme
-                                            
+
                                             if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -2104,31 +2096,31 @@ namespace boost
 #else
                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                            
+
                                             if        (cc == '(')                        // read "((a),(e,(" (ambiguity resolution)
                                             {
                                                 p = ::boost::math::quaternion<T>(a);
-                                                
+
                                                 x = ::std::complex<T>(c);                // "c" was actually "e"
-                                                
+
                                                 is.putback(ch);                            // we can only backtrace once
-                                                
+
                                                 is >> y;                                // read "((a),(e,y"
-                                                
+
                                                 if    (!is.good())    goto finish;
-                                                
+
                                                 is >> ch;                                // get the next lexeme
-                                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                 cc = ch;
 #else
                                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                
+
                                                 if        (cc == ')')                        // read "((a),(e,y)"
                                                 {
                                                     q = ::boost::math::quaternion<T>(x,y);
-                                                    
+
                                                     is >> ch;                                // get the next lexeme
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -2136,7 +2128,7 @@ namespace boost
 #else
                                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                    
+
                                                     if        (cc == ')')                        // read "((a),(e,y))"
                                                     {
                                                         o = octonion<T>(p,q);
@@ -2154,25 +2146,25 @@ namespace boost
                                             else                                    // read "((a),(c,d" or "((a),(e,f"
                                             {
                                                 is.putback(ch);
-                                                
+
                                                 is >> d;
-                                                
+
                                                 if    (!is.good())    goto finish;
-                                                
+
                                                 is >> ch;                                // get the next lexeme
-                                                
+
                                                 if    (!is.good())    goto finish;
-                                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                 cc = ch;
 #else
                                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                
+
                                                 if        (cc == ')')                        // read "((a),(c,d)" (ambiguity resolution)
                                                 {
                                                     is >> ch;                                // get the next lexeme
-                                                    
+
                                                     if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -2180,7 +2172,7 @@ namespace boost
 #else
                                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                    
+
                                                     if        (cc == ')')                        // read "((a),(c,d))"
                                                     {
                                                         o = octonion<T>(a,b,c,d);
@@ -2188,23 +2180,23 @@ namespace boost
                                                     else if    (cc == ',')                        // read "((a),(c,d),"
                                                     {
                                                         u = ::std::complex<T>(a);
-                                                        
+
                                                         v = ::std::complex<T>(c,d);
-                                                        
+
                                                         is >> x;                                // read "((a),(c,d),x"
-                                                        
+
                                                         if    (!is.good())    goto finish;
-                                                        
+
                                                         is >> ch;                                // get the next lexeme
-                                                        
+
                                                         if    (!is.good())    goto finish;
-                                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                         cc = ch;
 #else
                                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                        
+
                                                         if        (cc == ')')                        // read "((a),(c,d),x)"
                                                         {
                                                             o = octonion<T>(u,v,x);
@@ -2212,19 +2204,19 @@ namespace boost
                                                         else if    (cc == ',')                        // read "((a),(c,d),x,"
                                                         {
                                                             is >> y;                                // read "((a),(c,d),x,y"
-                                                            
+
                                                             if    (!is.good())    goto finish;
-                                                            
+
                                                             is >> ch;                                // get the next lexeme
-                                                            
+
                                                             if    (!is.good())    goto finish;
-                                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                             cc = ch;
 #else
                                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                            
+
                                                             if        (cc == ')')                        // read "((a),(c,d),x,y)"
                                                             {
                                                                 o = octonion<T>(u,v,x,y);
@@ -2247,35 +2239,35 @@ namespace boost
                                                 else if    (cc == ',')                        // read "((a),(e,f," (ambiguity resolution)
                                                 {
                                                     p = ::boost::math::quaternion<T>(a);
-                                                    
+
                                                     is >> g;                                // read "((a),(e,f,g" (too late to backtrack)
-                                                    
+
                                                     if    (!is.good())    goto finish;
-                                                    
+
                                                     is >> ch;                                // get the next lexeme
-                                                    
+
                                                     if    (!is.good())    goto finish;
-                                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                     cc = ch;
 #else
                                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                    
+
                                                     if        (cc == ')')                        // read "((a),(e,f,g)"
                                                     {
                                                         q = ::boost::math::quaternion<T>(c,d,g);        // "c" was actually "e", and "d" was actually "f"
-                                                        
+
                                                         is >> ch;                                // get the next lexeme
-                                                        
+
                                                         if    (!is.good())    goto finish;
-                                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                         cc = ch;
 #else
                                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                        
+
                                                         if        (cc == ')')                        // read "((a),(e,f,g))"
                                                         {
                                                             o = octonion<T>(p,q);
@@ -2288,33 +2280,33 @@ namespace boost
                                                     else if    (cc == ',')                        // read "((a),(e,f,g,"
                                                     {
                                                         is >> h;                                // read "((a),(e,f,g,h"
-                                                        
+
                                                         if    (!is.good())    goto finish;
-                                                        
+
                                                         is >> ch;                                // get the next lexeme
-                                                        
+
                                                         if    (!is.good())    goto finish;
-                                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                         cc = ch;
 #else
                                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                        
+
                                                         if        (cc == ')')                        // read "((a),(e,f,g,h)"
                                                         {
                                                             q = ::boost::math::quaternion<T>(c,d,g,h);    // "c" was actually "e", and "d" was actually "f"
-                                                            
+
                                                             is >> ch;                                // get the next lexeme
-                                                            
+
                                                             if    (!is.good())    goto finish;
-                                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                             cc = ch;
 #else
                                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                            
+
                                                             if        (cc == ')')                        // read "((a),(e,f,g,h))"
                                                             {
                                                                 o = octonion<T>(p,q);
@@ -2349,21 +2341,21 @@ namespace boost
                                 else                                        // read "((a),c" (ambiguity resolution)
                                 {
                                     is.putback(ch);
-                                    
+
                                     is >> c;                                    // we extract the third component
-                                    
+
                                     if    (!is.good())    goto finish;
-                                    
+
                                     is >> ch;                                    // get the next lexeme
-                                    
+
                                     if    (!is.good())    goto finish;
-                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                     cc = ch;
 #else
                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                    
+
                                     if        (cc == ')')                            // read "((a),c)"
                                     {
                                         o = octonion<T>(a,b,c);
@@ -2371,19 +2363,19 @@ namespace boost
                                     else if    (cc == ',')                            // read "((a),c,"
                                     {
                                         is >> x;                                    // read "((a),c,x"
-                                        
+
                                         if    (!is.good())    goto finish;
-                                        
+
                                         is >> ch;                                    // get the next lexeme
-                                        
+
                                         if    (!is.good())    goto finish;
-                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                         cc = ch;
 #else
                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                        
+
                                         if        (cc == ')')                            // read "((a),c,x)"
                                         {
                                             o = octonion<T>(a,b,c,d,x.real(),x.imag());
@@ -2391,17 +2383,17 @@ namespace boost
                                         else if    (cc == ',')                            // read "((a),c,x,"
                                         {
                                             is >> y;if    (!is.good())    goto finish;        // read "((a),c,x,y"
-                                            
+
                                             is >> ch;                                    // get the next lexeme
-                                            
+
                                             if    (!is.good())    goto finish;
-                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                             cc = ch;
 #else
                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                            
+
                                             if        (cc == ')')                            // read "((a),c,x,y)"
                                             {
                                                 o = octonion<T>(a,b,c,d,x.real(),x.imag(),y.real(),y.imag());
@@ -2430,39 +2422,39 @@ namespace boost
                         else if    (cc ==',')                            // read "((a,"
                         {
                             is >> ch;                                    // get the next lexeme
-                            
+
                             if    (!is.good())    goto finish;
-                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                             cc = ch;
 #else
                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                            
+
                             if        (cc == '(')                            // read "((a,("
                             {
                                 u = ::std::complex<T>(a);
-                                
+
                                 is.putback(ch);                                // can only backtrack so much
-                                
+
                                 is >> v;                                    // read "((a,v"
-                                
+
                                 if    (!is.good())    goto finish;
-                                
+
                                 is >> ch;                                    // get the next lexeme
-                                
+
                                 if    (!is.good())    goto finish;
-                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                 cc = ch;
 #else
                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                
+
                                 if        (cc == ')')                            // read "((a,v)"
                                 {
                                     is >> ch;                                    // get the next lexeme
-                                    
+
                                     if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -2470,7 +2462,7 @@ namespace boost
 #else
                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                    
+
                                     if        (cc == ')')                            // read "((a,v))"
                                     {
                                         o = octonion<T>(u,v);
@@ -2478,21 +2470,21 @@ namespace boost
                                     else if    (cc == ',')                            // read "((a,v),"
                                     {
                                         p = ::boost::math::quaternion<T>(u,v);
-                                        
+
                                         is >> q;                                    // read "((a,v),q"
-                                        
+
                                         if    (!is.good())    goto finish;
-                                        
+
                                         is >> ch;                                    // get the next lexeme
-                                        
+
                                         if    (!is.good())    goto finish;
-                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                         cc = ch;
 #else
                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                        
+
                                         if        (cc == ')')                            // read "((a,v),q)"
                                         {
                                             o = octonion<T>(p,q);
@@ -2515,33 +2507,33 @@ namespace boost
                             else
                             {
                                 is.putback(ch);
-                                
+
                                 is >> b;                                    // read "((a,b"
-                                
+
                                 if    (!is.good())    goto finish;
-                                
+
                                 is >> ch;                                    // get the next lexeme
-                                
+
                                 if    (!is.good())    goto finish;
-                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                 cc = ch;
 #else
                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                
+
                                 if        (cc == ')')                            // read "((a,b)"
                                 {
                                     is >> ch;                                    // get the next lexeme
-                                    
+
                                     if    (!is.good())    goto finish;
-                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                     cc = ch;
 #else
                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                    
+
                                     if        (cc == ')')                            // read "((a,b))"
                                     {
                                         o = octonion<T>(a,b);
@@ -2549,7 +2541,7 @@ namespace boost
                                     else if    (cc == ',')                            // read "((a,b),"
                                     {
                                         is >> ch;                                    // get the next lexeme
-                                        
+
                                         if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -2557,41 +2549,41 @@ namespace boost
 #else
                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                        
+
                                         if        (cc == '(')                            // read "((a,b),("
                                         {
                                             is >> ch;                                    // get the next lexeme
-                                            
+
                                             if    (!is.good())    goto finish;
-                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                             cc = ch;
 #else
                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                            
+
                                             if        (cc == '(')                            // read "((a,b),(("
                                             {
                                                 p = ::boost::math::quaternion<T>(a,b);
-                                                
+
                                                 is.putback(ch);
-                                                
+
                                                 is.putback(ch);                            // we backtrack twice, with the same value
-                                                
+
                                                 is >> q;                                // read "((a,b),q"
-                                                
+
                                                 if    (!is.good())    goto finish;
-                                                
+
                                                 is >> ch;                                    // get the next lexeme
-                                                
+
                                                 if    (!is.good())    goto finish;
-                                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                 cc = ch;
 #else
                                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                
+
                                                 if        (cc == ')')                            // read "((a,b),q)"
                                                 {
                                                     o = octonion<T>(p,q);
@@ -2604,33 +2596,33 @@ namespace boost
                                             else                                        // read "((a,b),(c" or "((a,b),(e"
                                             {
                                                 is.putback(ch);
-                                                
+
                                                 is >> c;
-                                                
+
                                                 if    (!is.good())    goto finish;
-                                                
+
                                                 is >> ch;                                    // get the next lexeme
-                                                
+
                                                 if    (!is.good())    goto finish;
-                                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                 cc = ch;
 #else
                                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                
+
                                                 if        (cc == ')')                            // read "((a,b),(c)" (ambiguity resolution)
                                                 {
                                                     is >> ch;                                    // get the next lexeme
-                                                    
+
                                                     if    (!is.good())    goto finish;
-                                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                     cc = ch;
 #else
                                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                    
+
                                                     if        (cc == ')')                            // read "((a,b),(c))"
                                                     {
                                                         o = octonion<T>(a,b,c);
@@ -2638,23 +2630,23 @@ namespace boost
                                                     else if    (cc == ',')                            // read "((a,b),(c),"
                                                     {
                                                         u = ::std::complex<T>(a,b);
-                                                        
+
                                                         v = ::std::complex<T>(c);
-                                                        
+
                                                         is >> x;                                    // read "((a,b),(c),x"
-                                                        
+
                                                         if    (!is.good())    goto finish;
-                                                        
+
                                                         is >> ch;                                    // get the next lexeme
-                                                        
+
                                                         if    (!is.good())    goto finish;
-                                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                         cc = ch;
 #else
                                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                        
+
                                                         if        (cc == ')')                            // read "((a,b),(c),x)"
                                                         {
                                                             o = octonion<T>(u,v,x);
@@ -2662,19 +2654,19 @@ namespace boost
                                                         else if    (cc == ',')                            // read "((a,b),(c),x,"
                                                         {
                                                             is >> y;                                    // read "((a,b),(c),x,y"
-                                                            
+
                                                             if    (!is.good())    goto finish;
-                                                            
+
                                                             is >> ch;                                    // get the next lexeme
-                                                            
+
                                                             if    (!is.good())    goto finish;
-                                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                             cc = ch;
 #else
                                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                            
+
                                                             if        (cc == ')')                            // read "((a,b),(c),x,y)"
                                                             {
                                                                 o = octonion<T>(u,v,x,y);
@@ -2697,41 +2689,41 @@ namespace boost
                                                 else if    (cc == ',')                            // read "((a,b),(c," or "((a,b),(e,"
                                                 {
                                                     is >> ch;                                    // get the next lexeme
-                                                    
+
                                                     if    (!is.good())    goto finish;
-                                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                     cc = ch;
 #else
                                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                    
+
                                                     if        (cc == '(')                            // read "((a,b),(e,(" (ambiguity resolution)
                                                     {
                                                         u = ::std::complex<T>(a,b);
-                                                        
+
                                                         x = ::std::complex<T>(c);                    // "c" is actually "e"
-                                                        
+
                                                         is.putback(ch);
-                                                        
+
                                                         is >> y;                                    // read "((a,b),(e,y"
-                                                        
+
                                                         if    (!is.good())    goto finish;
-                                                        
+
                                                         is >> ch;                                    // get the next lexeme
-                                                        
+
                                                         if    (!is.good())    goto finish;
-                                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                         cc = ch;
 #else
                                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                        
+
                                                         if        (cc == ')')                            // read "((a,b),(e,y)"
                                                         {
                                                             is >> ch;                                    // get the next lexeme
-                                                            
+
                                                             if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -2739,7 +2731,7 @@ namespace boost
 #else
                                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                            
+
                                                             if        (cc == ')')                            // read "((a,b),(e,y))"
                                                             {
                                                                 o = octonion<T>(u,v,x,y);
@@ -2757,37 +2749,37 @@ namespace boost
                                                     else                                        // read "((a,b),(c,d" or "((a,b),(e,f"
                                                     {
                                                         is.putback(ch);
-                                                        
+
                                                         is >> d;
-                                                        
+
                                                         if    (!is.good())    goto finish;
-                                                        
+
                                                         is >> ch;                                    // get the next lexeme
-                                                        
+
                                                         if    (!is.good())    goto finish;
-                                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                         cc = ch;
 #else
                                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                        
+
                                                         if        (cc == ')')                            // read "((a,b),(c,d)" (ambiguity resolution)
                                                         {
                                                             u = ::std::complex<T>(a,b);
-                                                            
+
                                                             v = ::std::complex<T>(c,d);
-                                                            
+
                                                             is >> ch;                                    // get the next lexeme
-                                                            
+
                                                             if    (!is.good())    goto finish;
-                                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                             cc = ch;
 #else
                                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                            
+
                                                             if        (cc == ')')                            // read "((a,b),(c,d))"
                                                             {
                                                                 o = octonion<T>(u,v);
@@ -2795,19 +2787,19 @@ namespace boost
                                                             else if    (cc == ',')                            // read "((a,b),(c,d),"
                                                             {
                                                                 is >> x;                                    // read "((a,b),(c,d),x
-                                                                
+
                                                                 if    (!is.good())    goto finish;
-                                                                
+
                                                                 is >> ch;                                    // get the next lexeme
-                                                                
+
                                                                 if    (!is.good())    goto finish;
-                                                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                                 cc = ch;
 #else
                                                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                                
+
                                                                 if        (cc == ')')                            // read "((a,b),(c,d),x)"
                                                                 {
                                                                     o = octonion<T>(u,v,x);
@@ -2815,19 +2807,19 @@ namespace boost
                                                                 else if    (cc == ',')                            // read "((a,b),(c,d),x,"
                                                                 {
                                                                     is >> y;                                    // read "((a,b),(c,d),x,y"
-                                                                    
+
                                                                     if    (!is.good())    goto finish;
-                                                                    
+
                                                                     is >> ch;                                    // get the next lexeme
-                                                                    
+
                                                                     if    (!is.good())    goto finish;
-                                                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                                     cc = ch;
 #else
                                                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                                    
+
                                                                     if        (cc == ')')                            // read "((a,b),(c,d),x,y)"
                                                                     {
                                                                         o = octonion<T>(u,v,x,y);
@@ -2850,37 +2842,37 @@ namespace boost
                                                         else if    (cc == ',')                            // read "((a,b),(e,f," (ambiguity resolution)
                                                         {
                                                             p = ::boost::math::quaternion<T>(a,b);                // too late to backtrack
-                                                            
+
                                                             is >> g;                                    // read "((a,b),(e,f,g"
-                                                            
+
                                                             if    (!is.good())    goto finish;
-                                                            
+
                                                             is >> ch;                                    // get the next lexeme
-                                                            
+
                                                             if    (!is.good())    goto finish;
-                                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                             cc = ch;
 #else
                                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                            
+
                                                             if        (cc == ')')                            // read "((a,b),(e,f,g)"
                                                             {
                                                                 is >> ch;                                    // get the next lexeme
-                                                                
+
                                                                 if    (!is.good())    goto finish;
-                                                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                                 cc = ch;
 #else
                                                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                                
+
                                                                 if        (cc == ')')                            // read "((a,b),(e,f,g))"
                                                                 {
                                                                     q = ::boost::math::quaternion<T>(c,d,g);            // "c" is actually "e" and "d" is actually "f"
-                                                                    
+
                                                                     o = octonion<T>(p,q);
                                                                 }
                                                                 else                                        // error
@@ -2891,35 +2883,35 @@ namespace boost
                                                             else if    (cc == ',')                            // read "((a,b),(e,f,g,"
                                                             {
                                                                 is >> h;                                    // read "((a,b),(e,f,g,h"
-                                                                
+
                                                                 if    (!is.good())    goto finish;
-                                                                
+
                                                                 is >> ch;                                    // get the next lexeme
-                                                                
+
                                                                 if    (!is.good())    goto finish;
-                                                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                                 cc = ch;
 #else
                                                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                                
+
                                                                 if        (cc == ')')                            // read "((a,b),(e,f,g,h)"
                                                                 {
                                                                     is >> ch;                                    // get the next lexeme
-                                                                    
+
                                                                     if    (!is.good())    goto finish;
-                                                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                                     cc = ch;
 #else
                                                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                                    
+
                                                                     if        (cc == ')')                            // read ((a,b),(e,f,g,h))"
                                                                     {
                                                                         q = ::boost::math::quaternion<T>(c,d,g,h);            // "c" is actually "e" and "d" is actually "f"
-                                                                        
+
                                                                         o = octonion<T>(p,q);
                                                                     }
                                                                     else                                        // error
@@ -2962,31 +2954,31 @@ namespace boost
                                 else if    (cc == ',')                            // read "((a,b,"
                                 {
                                     is >> c;                                    // read "((a,b,c"
-                                    
+
                                     if    (!is.good())    goto finish;
-                                    
+
                                     is >> ch;                                    // get the next lexeme
-                                                                
+
                                     if    (!is.good())    goto finish;
-                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                     cc = ch;
 #else
                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                    
+
                                     if        (cc == ')')                            // read "((a,b,c)"
                                     {
                                         is >> ch;                                    // get the next lexeme
-                                                                    
+
                                         if    (!is.good())    goto finish;
-                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                         cc = ch;
 #else
                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                        
+
                                         if        (cc == ')')                            // read "((a,b,c))"
                                         {
                                             o = octonion<T>(a,b,c);
@@ -2994,21 +2986,21 @@ namespace boost
                                         else if    (cc == ',')                            // read "((a,b,c),"
                                         {
                                             p = ::boost::math::quaternion<T>(a,b,c);
-                                            
+
                                             is >> q;                                    // read "((a,b,c),q"
-                                            
+
                                             if    (!is.good())    goto finish;
-                                            
+
                                             is >> ch;                                    // get the next lexeme
-                                                                        
+
                                             if    (!is.good())    goto finish;
-                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                             cc = ch;
 #else
                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                            
+
                                             if        (cc == ')')                            // read "((a,b,c),q)"
                                             {
                                                 o = octonion<T>(p,q);
@@ -3026,31 +3018,31 @@ namespace boost
                                     else if    (cc == ',')                            // read "((a,b,c,"
                                     {
                                         is >> d;                                    // read "((a,b,c,d"
-                                        
+
                                         if    (!is.good())    goto finish;
-                                        
+
                                         is >> ch;                                    // get the next lexeme
-                                                                    
+
                                         if    (!is.good())    goto finish;
-                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                         cc = ch;
 #else
                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                        
+
                                         if        (cc == ')')                            // read "((a,b,c,d)"
                                         {
                                             is >> ch;                                    // get the next lexeme
-                                                                        
+
                                             if    (!is.good())    goto finish;
-                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                             cc = ch;
 #else
                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                            
+
                                             if        (cc == ')')                            // read "((a,b,c,d))"
                                             {
                                                 o = octonion<T>(a,b,c,d);
@@ -3058,21 +3050,21 @@ namespace boost
                                             else if    (cc == ',')                            // read "((a,b,c,d),"
                                             {
                                                 p = ::boost::math::quaternion<T>(a,b,c,d);
-                                                
+
                                                 is >> q;                                    // read "((a,b,c,d),q"
-                                                
+
                                                 if    (!is.good())    goto finish;
-                                                
+
                                                 is >> ch;                                    // get the next lexeme
-                                                                            
+
                                                 if    (!is.good())    goto finish;
-                                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                 cc = ch;
 #else
                                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                
+
                                                 if        (cc == ')')                            // read "((a,b,c,d),q)"
                                                 {
                                                     o = octonion<T>(p,q);
@@ -3112,21 +3104,21 @@ namespace boost
                 else                                        // read "(a"
                 {
                     is.putback(ch);
-                    
+
                     is >> a;                                    // we extract the first component
-                    
+
                     if    (!is.good())    goto finish;
-                    
+
                     is >> ch;                                    // get the next lexeme
-                                                
+
                     if    (!is.good())    goto finish;
-                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                     cc = ch;
 #else
                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                    
+
                     if        (cc == ')')                            // read "(a)"
                     {
                         o = octonion<T>(a);
@@ -3134,19 +3126,19 @@ namespace boost
                     else if    (cc == ',')                            // read "(a,"
                     {
                         is >> ch;                                    // get the next lexeme
-                                                    
+
                         if    (!is.good())    goto finish;
-                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                         cc = ch;
 #else
                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                        
+
                         if        (cc == '(')                            // read "(a,("
                         {
                             is >> ch;                                    // get the next lexeme
-                                                        
+
                             if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -3154,29 +3146,29 @@ namespace boost
 #else
                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                            
+
                             if        (cc == '(')                            // read "(a,(("
                             {
                                 p = ::boost::math::quaternion<T>(a);
-                                
+
                                 is.putback(ch);
-                                
+
                                 is.putback(ch);                                // we backtrack twice, with the same value
-                                
+
                                 is >> q;                                    // read "(a,q"
-                                
+
                                 if    (!is.good())    goto finish;
-                                
+
                                 is >> ch;                                    // get the next lexeme
-                                                            
+
                                 if    (!is.good())    goto finish;
-                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                 cc = ch;
 #else
                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                
+
                                 if        (cc == ')')                            // read "(a,q)"
                                 {
                                     o = octonion<T>(p,q);
@@ -3189,33 +3181,33 @@ namespace boost
                             else                                        // read "(a,(c" or "(a,(e"
                             {
                                 is.putback(ch);
-                                
+
                                 is >> c;
-                                
+
                                 if    (!is.good())    goto finish;
-                                
+
                                 is >> ch;                                    // get the next lexeme
-                                                            
+
                                 if    (!is.good())    goto finish;
-                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                 cc = ch;
 #else
                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                
+
                                 if        (cc == ')')                            // read "(a,(c)" (ambiguity resolution)
                                 {
                                     is >> ch;                                    // get the next lexeme
-                                                                
+
                                     if    (!is.good())    goto finish;
-                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                     cc = ch;
 #else
                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                    
+
                                     if        (cc == ')')                            // read "(a,(c))"
                                     {
                                         o = octonion<T>(a,b,c);
@@ -3223,15 +3215,15 @@ namespace boost
                                     else if    (cc == ',')                            // read "(a,(c),"
                                     {
                                         u = ::std::complex<T>(a);
-                                        
+
                                         v = ::std::complex<T>(c);
-                                        
+
                                         is >> x;                                // read "(a,(c),x"
-                                        
+
                                         if    (!is.good())    goto finish;
-                                        
+
                                         is >> ch;                                    // get the next lexeme
-                                                                    
+
                                         if    (!is.good())    goto finish;
 
 #ifdef    BOOST_NO_STD_LOCALE
@@ -3239,7 +3231,7 @@ namespace boost
 #else
                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                        
+
                                         if        (cc == ')')                            // read "(a,(c),x)"
                                         {
                                             o = octonion<T>(u,v,x);
@@ -3247,19 +3239,19 @@ namespace boost
                                         else if    (cc == ',')                            // read "(a,(c),x,"
                                         {
                                             is >> y;                                    // read "(a,(c),x,y"
-                                            
+
                                             if    (!is.good())    goto finish;
-                                            
+
                                             is >> ch;                                    // get the next lexeme
-                                                                        
+
                                             if    (!is.good())    goto finish;
-                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                             cc = ch;
 #else
                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                            
+
                                             if        (cc == ')')                            // read "(a,(c),x,y)"
                                             {
                                                 o = octonion<T>(u,v,x,y);
@@ -3282,49 +3274,49 @@ namespace boost
                                 else if    (cc == ',')                            // read "(a,(c," or "(a,(e,"
                                 {
                                     is >> ch;                                    // get the next lexeme
-                                                                
+
                                     if    (!is.good())    goto finish;
-                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                     cc = ch;
 #else
                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                    
+
                                     if        (cc == '(')                            // read "(a,(e,(" (ambiguity resolution)
                                     {
                                         u = ::std::complex<T>(a);
-                                        
+
                                         x = ::std::complex<T>(c);                // "c" is actually "e"
-                                        
+
                                         is.putback(ch);                            // we backtrack
-                                        
+
                                         is >> y;                                // read "(a,(e,y"
-                                        
+
                                         if    (!is.good())    goto finish;
-                                        
+
                                         is >> ch;                                    // get the next lexeme
-                                                                    
+
                                         if    (!is.good())    goto finish;
-                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                         cc = ch;
 #else
                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                        
+
                                         if        (cc == ')')                            // read "(a,(e,y)"
                                         {
                                             is >> ch;                                    // get the next lexeme
-                                                                        
+
                                             if    (!is.good())    goto finish;
-                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                             cc = ch;
 #else
                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                            
+
                                             if        (cc == ')')                            // read "(a,(e,y))"
                                             {
                                                 o = octonion<T>(u,v,x,y);
@@ -3342,33 +3334,33 @@ namespace boost
                                     else                                        // read "(a,(c,d" or "(a,(e,f"
                                     {
                                         is.putback(ch);
-                                        
+
                                         is >> d;
-                                        
+
                                         if    (!is.good())    goto finish;
-                                        
+
                                         is >> ch;                                    // get the next lexeme
-                                                                    
+
                                         if    (!is.good())    goto finish;
-                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                         cc = ch;
 #else
                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                        
+
                                         if        (cc == ')')                            // read "(a,(c,d)" (ambiguity resolution)
                                         {
                                             is >> ch;                                    // get the next lexeme
-                                                                        
+
                                             if    (!is.good())    goto finish;
-                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                             cc = ch;
 #else
                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                            
+
                                             if        (cc == ')')                            // read "(a,(c,d))"
                                             {
                                                 o = octonion<T>(a,b,c,d);
@@ -3376,23 +3368,23 @@ namespace boost
                                             else if    (cc == ',')                            // read "(a,(c,d),"
                                             {
                                                 u = ::std::complex<T>(a);
-                                                
+
                                                 v = ::std::complex<T>(c,d);
-                                                
+
                                                 is >> x;                                // read "(a,(c,d),x"
-                                                
+
                                                 if    (!is.good())    goto finish;
-                                                
+
                                                 is >> ch;                                    // get the next lexeme
-                                                                            
+
                                                 if    (!is.good())    goto finish;
-                                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                 cc = ch;
 #else
                                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                
+
                                                 if        (cc == ')')                            // read "(a,(c,d),x)"
                                                 {
                                                     o = octonion<T>(u,v,x);
@@ -3400,19 +3392,19 @@ namespace boost
                                                 else if    (cc == ',')                            // read "(a,(c,d),x,"
                                                 {
                                                     is >> y;                                    // read "(a,(c,d),x,y"
-                                                    
+
                                                     if    (!is.good())    goto finish;
-                                                    
+
                                                     is >> ch;                                    // get the next lexeme
-                                                                                
+
                                                     if    (!is.good())    goto finish;
-                                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                     cc = ch;
 #else
                                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                    
+
                                                     if        (cc == ')')                            // read "(a,(c,d),x,y)"
                                                     {
                                                         o = octonion<T>(u,v,x,y);
@@ -3435,37 +3427,37 @@ namespace boost
                                         else if    (cc == ',')                            // read "(a,(e,f," (ambiguity resolution)
                                         {
                                             p = ::boost::math::quaternion<T>(a);
-                                            
+
                                             is >> g;                                    // read "(a,(e,f,g"
-                                            
+
                                             if    (!is.good())    goto finish;
-                                            
+
                                             is >> ch;                                    // get the next lexeme
-                                                                        
+
                                             if    (!is.good())    goto finish;
-                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                             cc = ch;
 #else
                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                            
+
                                             if        (cc == ')')                            // read "(a,(e,f,g)"
                                             {
                                                 is >> ch;                                    // get the next lexeme
-                                                                            
+
                                                 if    (!is.good())    goto finish;
-                                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                 cc = ch;
 #else
                                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                
+
                                                 if        (cc == ')')                            // read "(a,(e,f,g))"
                                                 {
                                                     q = ::boost::math::quaternion<T>(c,d,g);            // "c" is actually "e" and "d" is actually "f"
-                                                    
+
                                                     o = octonion<T>(p,q);
                                                 }
                                                 else                                        // error
@@ -3476,35 +3468,35 @@ namespace boost
                                             else if    (cc == ',')                            // read "(a,(e,f,g,"
                                             {
                                                 is >> h;                                    // read "(a,(e,f,g,h"
-                                                
+
                                                 if    (!is.good())    goto finish;
-                                                
+
                                                 is >> ch;                                    // get the next lexeme
-                                                                            
+
                                                 if    (!is.good())    goto finish;
-                                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                 cc = ch;
 #else
                                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                
+
                                                 if        (cc == ')')                            // read "(a,(e,f,g,h)"
                                                 {
                                                     is >> ch;                                    // get the next lexeme
-                                                                                
+
                                                     if    (!is.good())    goto finish;
-                                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                     cc = ch;
 #else
                                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                    
+
                                                     if        (cc == ')')                            // read "(a,(e,f,g,h))"
                                                     {
                                                         q = ::boost::math::quaternion<T>(c,d,g,h);            // "c" is actually "e" and "d" is actually "f"
-                                                        
+
                                                         o = octonion<T>(p,q);
                                                     }
                                                     else                                        // error
@@ -3537,21 +3529,21 @@ namespace boost
                         else                                        // read "(a,b" or "(a,c" (ambiguity resolution)
                         {
                             is.putback(ch);
-                            
+
                             is >> b;
-                            
+
                             if    (!is.good())    goto finish;
-                            
+
                             is >> ch;                                    // get the next lexeme
-                                                        
+
                             if    (!is.good())    goto finish;
-                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                             cc = ch;
 #else
                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                            
+
                             if        (cc == ')')                            // read "(a,b)" (ambiguity resolution)
                             {
                                 o = octonion<T>(a,b);
@@ -3559,37 +3551,37 @@ namespace boost
                             else if    (cc == ',')                            // read "(a,b," or "(a,c,"
                             {
                                 is >> ch;                                    // get the next lexeme
-                                                            
+
                                 if    (!is.good())    goto finish;
-                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                 cc = ch;
 #else
                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                
+
                                 if        (cc == '(')                            // read "(a,c,(" (ambiguity resolution)
                                 {
                                     u = ::std::complex<T>(a);
-                                    
+
                                     v = ::std::complex<T>(b);                    // "b" is actually "c"
-                                    
+
                                     is.putback(ch);                                // we backtrack
-                                    
+
                                     is >> x;                                    // read "(a,c,x"
-                                    
+
                                     if    (!is.good())    goto finish;
-                                    
+
                                     is >> ch;                                    // get the next lexeme
-                                                                
+
                                     if    (!is.good())    goto finish;
-                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                     cc = ch;
 #else
                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                    
+
                                     if        (cc == ')')                            // read "(a,c,x)"
                                     {
                                         o = octonion<T>(u,v,x);
@@ -3597,19 +3589,19 @@ namespace boost
                                     else if    (cc == ',')                            // read "(a,c,x,"
                                     {
                                         is >> y;                                    // read "(a,c,x,y"                                    // read "(a,c,x"
-                                        
+
                                         if    (!is.good())    goto finish;
-                                        
+
                                         is >> ch;                                    // get the next lexeme
-                                                                    
+
                                         if    (!is.good())    goto finish;
-                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                         cc = ch;
 #else
                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                        
+
                                         if        (cc == ')')                            // read "(a,c,x,y)"
                                         {
                                             o = octonion<T>(u,v,x,y);
@@ -3627,21 +3619,21 @@ namespace boost
                                 else                                        // read "(a,b,c" or "(a,c,e"
                                 {
                                     is.putback(ch);
-                                    
+
                                     is >> c;
-                                    
+
                                     if    (!is.good())    goto finish;
-                                    
+
                                     is >> ch;                                    // get the next lexeme
-                                                                
+
                                     if    (!is.good())    goto finish;
-                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                     cc = ch;
 #else
                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                    
+
                                     if        (cc == ')')                            // read "(a,b,c)" (ambiguity resolution)
                                     {
                                         o = octonion<T>(a,b,c);
@@ -3649,39 +3641,39 @@ namespace boost
                                     else if    (cc == ',')                            // read "(a,b,c," or "(a,c,e,"
                                     {
                                         is >> ch;                                    // get the next lexeme
-                                                                    
+
                                         if    (!is.good())    goto finish;
-                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                         cc = ch;
 #else
                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                        
+
                                         if        (cc == '(')                            // read "(a,c,e,(") (ambiguity resolution)
                                         {
                                             u = ::std::complex<T>(a);
-                                            
+
                                             v = ::std::complex<T>(b);                    // "b" is actually "c"
-                                            
+
                                             x = ::std::complex<T>(c);                    // "c" is actually "e"
-                                            
+
                                             is.putback(ch);                                // we backtrack
-                                            
+
                                             is >> y;                                    // read "(a,c,e,y"
-                                            
+
                                             if    (!is.good())    goto finish;
-                                            
+
                                             is >> ch;                                    // get the next lexeme
-                                                                        
+
                                             if    (!is.good())    goto finish;
-                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                             cc = ch;
 #else
                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                            
+
                                             if        (cc == ')')                            // read "(a,c,e,y)"
                                             {
                                                 o = octonion<T>(u,v,x,y);
@@ -3694,21 +3686,21 @@ namespace boost
                                         else                                        // read "(a,b,c,d" (ambiguity resolution)
                                         {
                                             is.putback(ch);                                // we backtrack
-                                            
+
                                             is >> d;
-                                            
+
                                             if    (!is.good())    goto finish;
-                                            
+
                                             is >> ch;                                    // get the next lexeme
-                                                                        
+
                                             if    (!is.good())    goto finish;
-                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                             cc = ch;
 #else
                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                            
+
                                             if        (cc == ')')                            // read "(a,b,c,d)"
                                             {
                                                 o = octonion<T>(a,b,c,d);
@@ -3716,19 +3708,19 @@ namespace boost
                                             else if    (cc == ',')                            // read "(a,b,c,d,"
                                             {
                                                 is >> e;                                    // read "(a,b,c,d,e"
-                                                
+
                                                 if    (!is.good())    goto finish;
-                                                
+
                                                 is >> ch;                                    // get the next lexeme
-                                                                            
+
                                                 if    (!is.good())    goto finish;
-                                                
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                 cc = ch;
 #else
                                                 cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                
+
                                                 if        (cc == ')')                            // read "(a,b,c,d,e)"
                                                 {
                                                     o = octonion<T>(a,b,c,d,e);
@@ -3736,19 +3728,19 @@ namespace boost
                                                 else if    (cc == ',')                            // read "(a,b,c,d,e,"
                                                 {
                                                     is >> f;                                    // read "(a,b,c,d,e,f"
-                                                    
+
                                                     if    (!is.good())    goto finish;
-                                                    
+
                                                     is >> ch;                                    // get the next lexeme
-                                                                                
+
                                                     if    (!is.good())    goto finish;
-                                                    
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                     cc = ch;
 #else
                                                     cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                    
+
                                                     if        (cc == ')')                            // read "(a,b,c,d,e,f)"
                                                     {
                                                         o = octonion<T>(a,b,c,d,e,f);
@@ -3756,19 +3748,19 @@ namespace boost
                                                     else if    (cc == ',')                            // read "(a,b,c,d,e,f,"
                                                     {
                                                         is >> g;                                    // read "(a,b,c,d,e,f,g"                                    // read "(a,b,c,d,e,f"
-                                                        
+
                                                         if    (!is.good())    goto finish;
-                                                        
+
                                                         is >> ch;                                    // get the next lexeme
-                                                                                    
+
                                                         if    (!is.good())    goto finish;
-                                                        
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                         cc = ch;
 #else
                                                         cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                        
+
                                                         if        (cc == ')')                            // read "(a,b,c,d,e,f,g)"
                                                         {
                                                             o = octonion<T>(a,b,c,d,e,f,g);
@@ -3776,19 +3768,19 @@ namespace boost
                                                         else if    (cc == ',')                            // read "(a,b,c,d,e,f,g,"
                                                         {
                                                             is >> h;                                    // read "(a,b,c,d,e,f,g,h"                                    // read "(a,b,c,d,e,f,g"                                    // read "(a,b,c,d,e,f"
-                                                            
+
                                                             if    (!is.good())    goto finish;
-                                                            
+
                                                             is >> ch;                                    // get the next lexeme
-                                                                                        
+
                                                             if    (!is.good())    goto finish;
-                                                            
+
 #ifdef    BOOST_NO_STD_LOCALE
                                                             cc = ch;
 #else
                                                             cc = ct.narrow(ch, char());
 #endif /* BOOST_NO_STD_LOCALE */
-                                                            
+
                                                             if        (cc == ')')                            // read "(a,b,c,d,e,f,g,h)"
                                                             {
                                                                 o = octonion<T>(a,b,c,d,e,f,g,h);
@@ -3840,32 +3832,32 @@ namespace boost
             else                                        // format:    a
             {
                 is.putback(ch);
-                
+
                 is >> a;                                    // we extract the first component
-                
+
                 if    (!is.good())    goto finish;
-                
+
                 o = octonion<T>(a);
             }
-            
+
             finish:
             return(is);
         }
-        
-        
+
+
         template<typename T, typename charT, class traits>
         ::std::basic_ostream<charT,traits> &    operator << (    ::std::basic_ostream<charT,traits> & os,
                                                                 octonion<T> const & o)
         {
             ::std::basic_ostringstream<charT,traits>    s;
-            
+
             s.flags(os.flags());
 #ifdef    BOOST_NO_STD_LOCALE
 #else
             s.imbue(os.getloc());
 #endif /* BOOST_NO_STD_LOCALE */
             s.precision(os.precision());
-            
+
             s << '('    << o.R_component_1() << ','
                         << o.R_component_2() << ','
                         << o.R_component_3() << ','
@@ -3874,27 +3866,27 @@ namespace boost
                         << o.R_component_6() << ','
                         << o.R_component_7() << ','
                         << o.R_component_8() << ')';
-            
+
             return os << s.str();
         }
-        
-        
+
+
         // values
-        
+
         template<typename T>
         inline T                                real(octonion<T> const & o)
         {
             return(o.real());
         }
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        unreal(octonion<T> const & o)
         {
             return(o.unreal());
         }
-        
-        
+
+
 #define    BOOST_OCTONION_VALARRAY_LOADER   \
             using    ::std::valarray;       \
                                             \
@@ -3908,47 +3900,47 @@ namespace boost
             temp[5] = o.R_component_6();    \
             temp[6] = o.R_component_7();    \
             temp[7] = o.R_component_8();
-        
-        
+
+
         template<typename T>
         inline T                                sup(octonion<T> const & o)
         {
 #ifdef    BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP
             using    ::std::abs;
 #endif    /* BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP */
-            
+
             BOOST_OCTONION_VALARRAY_LOADER
-            
+
             return((abs(temp).max)());
         }
-        
-        
+
+
         template<typename T>
         inline T                                l1(octonion<T> const & o)
         {
 #ifdef    BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP
             using    ::std::abs;
 #endif    /* BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP */
-            
+
             BOOST_OCTONION_VALARRAY_LOADER
-            
+
             return(abs(temp).sum());
         }
-        
-        
+
+
         template<typename T>
         inline T                                abs(const octonion<T> & o)
         {
 #ifdef    BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP
             using    ::std::abs;
 #endif    /* BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP */
-            
+
             using    ::std::sqrt;
-            
+
             BOOST_OCTONION_VALARRAY_LOADER
-            
+
             T            maxim = (abs(temp).max)();    // overflow protection
-            
+
             if    (maxim == static_cast<T>(0))
             {
                 return(maxim);
@@ -3956,30 +3948,30 @@ namespace boost
             else
             {
                 T    mixam = static_cast<T>(1)/maxim;    // prefer multiplications over divisions
-                
+
                 temp *= mixam;
-                
+
                 temp *= temp;
-                
+
                 return(maxim*sqrt(temp.sum()));
             }
-            
+
             //return(::std::sqrt(norm(o)));
         }
-        
-        
+
+
 #undef    BOOST_OCTONION_VALARRAY_LOADER
-        
-        
+
+
         // Note:    This is the Cayley norm, not the Euclidean norm...
-        
+
         template<typename T>
         inline T                                norm(octonion<T> const & o)
         {
             return(real(o*conj(o)));
         }
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        conj(octonion<T> const & o)
         {
@@ -3992,12 +3984,12 @@ namespace boost
                                 -o.R_component_7(),
                                 -o.R_component_8()));
         }
-        
-        
+
+
         // Note:    There is little point, for the octonions, to introduce the equivalents
         //            to the complex "arg" and the quaternionic "cylindropolar".
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        spherical(T const & rho,
                                                             T const & theta,
@@ -4010,7 +4002,7 @@ namespace boost
         {
             using ::std::cos;
             using ::std::sin;
-            
+
             //T    a = cos(theta)*cos(phi1)*cos(phi2)*cos(phi3)*cos(phi4)*cos(phi5)*cos(phi6);
             //T    b = sin(theta)*cos(phi1)*cos(phi2)*cos(phi3)*cos(phi4)*cos(phi5)*cos(phi6);
             //T    c = sin(phi1)*cos(phi2)*cos(phi3)*cos(phi4)*cos(phi5)*cos(phi6);
@@ -4019,40 +4011,40 @@ namespace boost
             //T    f = sin(phi4)*cos(phi5)*cos(phi6);
             //T    g = sin(phi5)*cos(phi6);
             //T    h = sin(phi6);
-            
+
             T    courrant = static_cast<T>(1);
-            
+
             T    h = sin(phi6);
-            
+
             courrant *= cos(phi6);
-            
+
             T    g = sin(phi5)*courrant;
-            
+
             courrant *= cos(phi5);
-            
+
             T    f = sin(phi4)*courrant;
-            
+
             courrant *= cos(phi4);
-            
+
             T    e = sin(phi3)*courrant;
-            
+
             courrant *= cos(phi3);
-            
+
             T    d = sin(phi2)*courrant;
-            
+
             courrant *= cos(phi2);
-            
+
             T    c = sin(phi1)*courrant;
-            
+
             courrant *= cos(phi1);
-            
+
             T    b = sin(theta)*courrant;
             T    a = cos(theta)*courrant;
-            
+
             return(rho*octonion<T>(a,b,c,d,e,f,g,h));
         }
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        multipolar(T const & rho1,
                                                              T const & theta1,
@@ -4065,7 +4057,7 @@ namespace boost
         {
             using ::std::cos;
             using ::std::sin;
-            
+
             T    a = rho1*cos(theta1);
             T    b = rho1*sin(theta1);
             T    c = rho2*cos(theta2);
@@ -4074,11 +4066,11 @@ namespace boost
             T    f = rho3*sin(theta3);
             T    g = rho4*cos(theta4);
             T    h = rho4*sin(theta4);
-            
+
             return(octonion<T>(a,b,c,d,e,f,g,h));
         }
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        cylindrical(T const & r,
                                                               T const & angle,
@@ -4091,106 +4083,106 @@ namespace boost
         {
             using ::std::cos;
             using ::std::sin;
-            
+
             T    a = r*cos(angle);
             T    b = r*sin(angle);
-            
+
             return(octonion<T>(a,b,h1,h2,h3,h4,h5,h6));
         }
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        exp(octonion<T> const & o)
         {
             using    ::std::exp;
             using    ::std::cos;
-            
+
             using    ::boost::math::sinc_pi;
-            
+
             T    u = exp(real(o));
-            
+
             T    z = abs(unreal(o));
-            
+
             T    w = sinc_pi(z);
-            
+
             return(u*octonion<T>(cos(z),
                 w*o.R_component_2(), w*o.R_component_3(),
                 w*o.R_component_4(), w*o.R_component_5(),
                 w*o.R_component_6(), w*o.R_component_7(),
                 w*o.R_component_8()));
         }
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        cos(octonion<T> const & o)
         {
             using    ::std::sin;
             using    ::std::cos;
             using    ::std::cosh;
-            
+
             using    ::boost::math::sinhc_pi;
-            
+
             T    z = abs(unreal(o));
-            
+
             T    w = -sin(o.real())*sinhc_pi(z);
-            
+
             return(octonion<T>(cos(o.real())*cosh(z),
                 w*o.R_component_2(), w*o.R_component_3(),
                 w*o.R_component_4(), w*o.R_component_5(),
                 w*o.R_component_6(), w*o.R_component_7(),
                 w*o.R_component_8()));
         }
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        sin(octonion<T> const & o)
         {
             using    ::std::sin;
             using    ::std::cos;
             using    ::std::cosh;
-            
+
             using    ::boost::math::sinhc_pi;
-            
+
             T    z = abs(unreal(o));
-            
+
             T    w = +cos(o.real())*sinhc_pi(z);
-            
+
             return(octonion<T>(sin(o.real())*cosh(z),
                 w*o.R_component_2(), w*o.R_component_3(),
                 w*o.R_component_4(), w*o.R_component_5(),
                 w*o.R_component_6(), w*o.R_component_7(),
                 w*o.R_component_8()));
         }
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        tan(octonion<T> const & o)
         {
             return(sin(o)/cos(o));
         }
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        cosh(octonion<T> const & o)
         {
             return((exp(+o)+exp(-o))/static_cast<T>(2));
         }
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        sinh(octonion<T> const & o)
         {
             return((exp(+o)-exp(-o))/static_cast<T>(2));
         }
-        
-        
+
+
         template<typename T>
         inline octonion<T>                        tanh(octonion<T> const & o)
         {
             return(sinh(o)/cosh(o));
         }
-        
-        
+
+
         template<typename T>
         octonion<T>                                pow(octonion<T> const & o,
                                                     int n)
@@ -4198,16 +4190,16 @@ namespace boost
             if        (n > 1)
             {
                 int    m = n>>1;
-                
+
                 octonion<T>    result = pow(o, m);
-                
+
                 result *= result;
-                
+
                 if    (n != (m<<1))
                 {
                     result *= o; // n odd
                 }
-                
+
                 return(result);
             }
             else if    (n == 1)
@@ -4223,13 +4215,13 @@ namespace boost
                 return(pow(octonion<T>(static_cast<T>(1))/o,-n));
             }
         }
-        
-        
+
+
         // helper templates for converting copy constructors (definition)
-        
+
         namespace detail
         {
-            
+
             template<   typename T,
                         typename U
                     >

--- a/include/boost/math/special_functions/detail/airy_ai_bi_zero.hpp
+++ b/include/boost/math/special_functions/detail/airy_ai_bi_zero.hpp
@@ -46,7 +46,7 @@
                                            * one_over_z_squared + (       T(77125UL) /     82944UL))
                                            * one_over_z_squared - (           T(5U)  /        36U))
                                            * one_over_z_squared + (           T(5U)  /        48U))
-                                           * one_over_z_squared + (1)));
+                                           * one_over_z_squared + 1));
 
         return fz;
       }
@@ -60,23 +60,43 @@
 
           switch(m)
           {
-            case  0: { guess = T(0);                       break; }
-            case  1: { guess = T(-2.33810741045976703849); break; }
-            case  2: { guess = T(-4.08794944413097061664); break; }
-            case  3: { guess = T(-5.52055982809555105913); break; }
-            case  4: { guess = T(-6.78670809007175899878); break; }
-            case  5: { guess = T(-7.94413358712085312314); break; }
-            case  6: { guess = T(-9.02265085334098038016); break; }
-            case  7: { guess = T(-10.0401743415580859306); break; }
-            case  8: { guess = T(-11.0085243037332628932); break; }
-            case  9: { guess = T(-11.9360155632362625170); break; }
-            case 10:{ guess = T(-12.8287767528657572004); break; }
+            case  0:
+              guess = T(0);
+              break;
+            case  1:
+              guess = T(-2.33810741045976703849);
+              break;
+            case  2:
+              guess = T(-4.08794944413097061664);
+              break;
+            case  3:
+              guess = T(-5.52055982809555105913);
+              break;
+            case  4:
+              guess = T(-6.78670809007175899878);
+              break;
+            case  5:
+              guess = T(-7.94413358712085312314);
+              break;
+            case  6:
+              guess = T(-9.02265085334098038016);
+              break;
+            case  7:
+              guess = T(-10.0401743415580859306);
+              break;
+            case  8:
+              guess = T(-11.0085243037332628932);
+              break;
+            case  9:
+              guess = T(-11.9360155632362625170);
+              break;
+            case 10:
+              guess = T(-12.8287767528657572004);
+              break;
             default:
-            {
               const T t(((boost::math::constants::pi<T>() * 3) * ((T(m) * 4) - 1)) / 8);
               guess = -boost::math::detail::airy_zero::equation_as_10_4_105(t, pol);
               break;
-            }
           }
 
           return guess;
@@ -86,7 +106,9 @@
         class function_object_ai_and_ai_prime
         {
         public:
-          function_object_ai_and_ai_prime(const Policy& pol) : my_pol(pol) { }
+          explicit function_object_ai_and_ai_prime(const Policy& pol) : my_pol(pol) { }
+
+          function_object_ai_and_ai_prime(const function_object_ai_and_ai_prime&) = default;
 
           boost::math::tuple<T, T> operator()(const T& x) const
           {
@@ -111,23 +133,43 @@
 
           switch(m)
           {
-            case  0: { guess = T(0);                       break; }
-            case  1: { guess = T(-1.17371322270912792492); break; }
-            case  2: { guess = T(-3.27109330283635271568); break; }
-            case  3: { guess = T(-4.83073784166201593267); break; }
-            case  4: { guess = T(-6.16985212831025125983); break; }
-            case  5: { guess = T(-7.37676207936776371360); break; }
-            case  6: { guess = T(-8.49194884650938801345); break; }
-            case  7: { guess = T(-9.53819437934623888663); break; }
-            case  8: { guess = T(-10.5299135067053579244); break; }
-            case  9: { guess = T(-11.4769535512787794379); break; }
-            case 10: { guess = T(-12.3864171385827387456); break; }
+            case  0:
+              guess = T(0);
+              break;
+            case  1:
+              guess = T(-1.17371322270912792492);
+              break;
+            case  2:
+              guess = T(-3.27109330283635271568);
+              break;
+            case  3:
+              guess = T(-4.83073784166201593267);
+              break;
+            case  4:
+              guess = T(-6.16985212831025125983);
+              break;
+            case  5:
+              guess = T(-7.37676207936776371360);
+              break;
+            case  6:
+              guess = T(-8.49194884650938801345);
+              break;
+            case  7:
+              guess = T(-9.53819437934623888663);
+              break;
+            case  8:
+              guess = T(-10.5299135067053579244);
+              break;
+            case  9:
+              guess = T(-11.4769535512787794379);
+              break;
+            case 10:
+              guess = T(-12.3864171385827387456);
+              break;
             default:
-            {
               const T t(((boost::math::constants::pi<T>() * 3) * ((T(m) * 4) - 3)) / 8);
               guess = -boost::math::detail::airy_zero::equation_as_10_4_105(t, pol);
               break;
-            }
           }
 
           return guess;
@@ -137,7 +179,9 @@
         class function_object_bi_and_bi_prime
         {
         public:
-          function_object_bi_and_bi_prime(const Policy& pol) : my_pol(pol) { }
+          explicit function_object_bi_and_bi_prime(const Policy& pol) : my_pol(pol) { }
+
+          function_object_bi_and_bi_prime(const function_object_bi_and_bi_prime&) = default;
 
           boost::math::tuple<T, T> operator()(const T& x) const
           {

--- a/include/boost/math/special_functions/detail/bessel_jy_zero.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jy_zero.hpp
@@ -57,7 +57,9 @@
       class equation_as_9_3_39_and_its_derivative
       {
       public:
-        equation_as_9_3_39_and_its_derivative(const T& zt) : zeta(zt) { }
+        explicit equation_as_9_3_39_and_its_derivative(const T& zt) : zeta(zt) { }
+
+        equation_as_9_3_39_and_its_derivative(const equation_as_9_3_39_and_its_derivative&) = default;
 
         boost::math::tuple<T, T> operator()(const T& z) const
         {
@@ -126,11 +128,11 @@
         const T range_zmin = (std::max<T>)(z_estimate - T(1), T(1));
         const T range_zmax = z_estimate + T(1);
 
-        const int my_digits10 = static_cast<int>(static_cast<float>(boost::math::tools::digits<T>() * 0.301F));
+        const auto my_digits10 = static_cast<int>(static_cast<float>(boost::math::tools::digits<T>() * 0.301F));
 
         // Select the maximum allowed iterations based on the number
         // of decimal digits in the numeric type T, being at least 12.
-        const std::uintmax_t iterations_allowed = static_cast<std::uintmax_t>((std::max)(12, my_digits10 * 2));
+        const auto iterations_allowed = static_cast<std::uintmax_t>((std::max)(12, my_digits10 * 2));
 
         std::uintmax_t iterations_used = iterations_allowed;
 
@@ -187,6 +189,8 @@
                              const Policy& pol) : my_v(v),
                                                   my_pol(pol) { }
 
+          function_object_jv(const function_object_jv&) = default;
+
           T operator()(const T& x) const
           {
             return boost::math::cyl_bessel_j(my_v, x, my_pol);
@@ -207,6 +211,8 @@
                                           const Policy& pol) : my_v(v),
                                                                my_order_is_zero(order_is_zero),
                                                                my_pol(pol) { }
+
+          function_object_jv_and_jv_prime(const function_object_jv_and_jv_prime&) = default;
 
           boost::math::tuple<T, T> operator()(const T& x) const
           {
@@ -405,6 +411,8 @@
                              const Policy& pol) : my_v(v),
                                                   my_pol(pol) { }
 
+          function_object_yv(const function_object_yv&) = default;
+
           T operator()(const T& x) const
           {
             return boost::math::cyl_neumann(my_v, x, my_pol);
@@ -423,6 +431,8 @@
           function_object_yv_and_yv_prime(const T& v,
                                           const Policy& pol) : my_v(v),
                                                                my_pol(pol) { }
+
+          function_object_yv_and_yv_prime(const function_object_yv_and_yv_prime&) = default;
 
           boost::math::tuple<T, T> operator()(const T& x) const
           {

--- a/include/boost/math/special_functions/detail/hypergeometric_1F1_recurrence.hpp
+++ b/include/boost/math/special_functions/detail/hypergeometric_1F1_recurrence.hpp
@@ -29,12 +29,16 @@
   template <class T>
   struct hypergeometric_1F1_recurrence_a_coefficients
   {
-    typedef boost::math::tuple<T, T, T> result_type;
+    using result_type = boost::math::tuple<T, T, T>;
 
     hypergeometric_1F1_recurrence_a_coefficients(const T& a, const T& b, const T& z):
     a(a), b(b), z(z)
     {
     }
+
+    explicit hypergeometric_1F1_recurrence_a_coefficients(const hypergeometric_1F1_recurrence_a_coefficients&) = default;
+
+    hypergeometric_1F1_recurrence_a_coefficients operator=(const hypergeometric_1F1_recurrence_a_coefficients&) = delete;
 
     result_type operator()(std::intmax_t i) const
     {
@@ -48,19 +52,24 @@
     }
 
   private:
-    const T a, b, z;
-    hypergeometric_1F1_recurrence_a_coefficients operator=(const hypergeometric_1F1_recurrence_a_coefficients&);
+    const T a;
+    const T b;
+    const T z;
   };
 
   template <class T>
   struct hypergeometric_1F1_recurrence_b_coefficients
   {
-    typedef boost::math::tuple<T, T, T> result_type;
+    using result_type = boost::math::tuple<T, T, T>;
 
     hypergeometric_1F1_recurrence_b_coefficients(const T& a, const T& b, const T& z):
     a(a), b(b), z(z)
     {
     }
+
+    explicit hypergeometric_1F1_recurrence_b_coefficients(const hypergeometric_1F1_recurrence_b_coefficients&) = default;
+
+    hypergeometric_1F1_recurrence_b_coefficients& operator=(const hypergeometric_1F1_recurrence_b_coefficients&) = delete;
 
     result_type operator()(std::intmax_t i) const
     {
@@ -74,8 +83,9 @@
     }
 
   private:
-    const T a, b, z;
-    hypergeometric_1F1_recurrence_b_coefficients& operator=(const hypergeometric_1F1_recurrence_b_coefficients&) = delete;
+    const T a;
+    const T b;
+    const T z;
   };
   //
   // for use when we're recursing to a small b:
@@ -83,12 +93,16 @@
   template <class T>
   struct hypergeometric_1F1_recurrence_small_b_coefficients
   {
-     typedef boost::math::tuple<T, T, T> result_type;
+     using result_type = boost::math::tuple<T, T, T>;
 
      hypergeometric_1F1_recurrence_small_b_coefficients(const T& a, const T& b, const T& z, int N) :
         a(a), b(b), z(z), N(N)
      {
      }
+
+     explicit hypergeometric_1F1_recurrence_small_b_coefficients(const hypergeometric_1F1_recurrence_small_b_coefficients&) = default;
+
+     hypergeometric_1F1_recurrence_small_b_coefficients operator=(const hypergeometric_1F1_recurrence_small_b_coefficients&) = delete;
 
      result_type operator()(std::intmax_t i) const
      {
@@ -103,20 +117,25 @@
      }
 
   private:
-     hypergeometric_1F1_recurrence_small_b_coefficients operator=(const hypergeometric_1F1_recurrence_small_b_coefficients&) = delete;
-     const T a, b, z;
+     const T a;
+     const T b;
+     const T z;
      int N;
   };
 
   template <class T>
   struct hypergeometric_1F1_recurrence_a_and_b_coefficients
   {
-    typedef boost::math::tuple<T, T, T> result_type;
+    using result_type = boost::math::tuple<T, T, T>;
 
     hypergeometric_1F1_recurrence_a_and_b_coefficients(const T& a, const T& b, const T& z, int offset = 0):
     a(a), b(b), z(z), offset(offset)
     {
     }
+
+    hypergeometric_1F1_recurrence_a_and_b_coefficients(const hypergeometric_1F1_recurrence_a_and_b_coefficients&) = default;
+
+    hypergeometric_1F1_recurrence_a_and_b_coefficients operator=(const hypergeometric_1F1_recurrence_a_and_b_coefficients&) = delete;
 
     result_type operator()(std::intmax_t i) const
     {
@@ -131,9 +150,10 @@
     }
 
   private:
-    const T a, b, z;
+    const T a;
+    const T b;
+    const T z;
     int offset;
-    hypergeometric_1F1_recurrence_a_and_b_coefficients operator=(const hypergeometric_1F1_recurrence_a_and_b_coefficients&) = delete;
   };
 #if 0
   //
@@ -303,7 +323,8 @@
     if (-integer_part > static_cast<std::intmax_t>(policies::get_max_series_iterations<Policy>()))
        return policies::raise_evaluation_error<T>(function, "1F1 arguments sit in a range with a so negative that we have no evaluation method, got a = %1%", std::numeric_limits<T>::quiet_NaN(), pol);
 
-    T first, second;
+    T first {};
+    T second {};
     if(ak == 0)
     { 
        first = 1;
@@ -312,7 +333,8 @@
     }
     else
     {
-       long long scaling1(0), scaling2(0);
+       long long scaling1 {};
+       long long scaling2 {};
        first = detail::hypergeometric_1F1_imp(ak, b, z, pol, scaling1);
        ak -= 1;
        second = detail::hypergeometric_1F1_imp(ak, b, z, pol, scaling2);
@@ -416,8 +438,10 @@
         trailing_b_shift += diff;
      }
 
-     T first, second;
-     long long scale1(0), scale2(0);
+     T first {};
+     T second {};
+     long long scale1 {};
+     long long scale2 {};
      first = boost::math::detail::hypergeometric_1F1_imp(T(a + a_shift), T(b + b_shift), z, pol, scale1);
      //
      // It would be good to compute "second" from first and the ratio - unfortunately we are right on the cusp

--- a/include/boost/math/tools/traits.hpp
+++ b/include/boost/math/tools/traits.hpp
@@ -54,6 +54,7 @@ BOOST_MATH_HAS_NAMED_TRAIT(has_policy_type, policy_type)
 BOOST_MATH_HAS_NAMED_TRAIT(has_backend_type, backend_type)
 
 // C++17-esque helpers
+#if defined(__cpp_variable_templates) && __cpp_variable_templates >= 201304L
 template <typename T>
 constexpr bool has_value_type_v = has_value_type<T>::value;
 
@@ -62,6 +63,7 @@ constexpr bool has_policy_type_v = has_policy_type<T>::value;
 
 template <typename T>
 constexpr bool has_backend_type_v = has_backend_type<T>::value;
+#endif
 
 template <typename D>
 char cdf(const D& ...);

--- a/include/boost/math/tr1.hpp
+++ b/include/boost/math/tr1.hpp
@@ -739,44 +739,44 @@ inline typename tools::promote_args<T>::type trunc BOOST_PREVENT_MACRO_SUBSTITUT
 
 # define NO_MACRO_EXPAND /**/
 // C99 macros defined as C++ templates
-template<class T> bool signbit NO_MACRO_EXPAND(T x)
+template<class T> bool signbit NO_MACRO_EXPAND(T)
 { static_assert(sizeof(T) == 0, "Undefined behavior; this template should never be instantiated"); return false; } // must not be instantiated
 template<> bool BOOST_MATH_TR1_DECL signbit<float> NO_MACRO_EXPAND(float x);
 template<> bool BOOST_MATH_TR1_DECL signbit<double> NO_MACRO_EXPAND(double x);
 template<> bool BOOST_MATH_TR1_DECL signbit<long double> NO_MACRO_EXPAND(long double x);
 
-template<class T> int fpclassify NO_MACRO_EXPAND(T x)
+template<class T> int fpclassify NO_MACRO_EXPAND(T)
 { static_assert(sizeof(T) == 0, "Undefined behavior; this template should never be instantiated"); return false; } // must not be instantiated
 template<> int BOOST_MATH_TR1_DECL fpclassify<float> NO_MACRO_EXPAND(float x);
 template<> int BOOST_MATH_TR1_DECL fpclassify<double> NO_MACRO_EXPAND(double x);
 template<> int BOOST_MATH_TR1_DECL fpclassify<long double> NO_MACRO_EXPAND(long double x);
 
-template<class T> bool isfinite NO_MACRO_EXPAND(T x)
+template<class T> bool isfinite NO_MACRO_EXPAND(T)
 { static_assert(sizeof(T) == 0, "Undefined behavior; this template should never be instantiated"); return false; } // must not be instantiated
 template<> bool BOOST_MATH_TR1_DECL isfinite<float> NO_MACRO_EXPAND(float x);
 template<> bool BOOST_MATH_TR1_DECL isfinite<double> NO_MACRO_EXPAND(double x);
 template<> bool BOOST_MATH_TR1_DECL isfinite<long double> NO_MACRO_EXPAND(long double x);
 
-template<class T> bool isinf NO_MACRO_EXPAND(T x)
+template<class T> bool isinf NO_MACRO_EXPAND(T)
 { static_assert(sizeof(T) == 0, "Undefined behavior; this template should never be instantiated"); return false; } // must not be instantiated
 template<> bool BOOST_MATH_TR1_DECL isinf<float> NO_MACRO_EXPAND(float x);
 template<> bool BOOST_MATH_TR1_DECL isinf<double> NO_MACRO_EXPAND(double x);
 template<> bool BOOST_MATH_TR1_DECL isinf<long double> NO_MACRO_EXPAND(long double x);
 
-template<class T> bool isnan NO_MACRO_EXPAND(T x)
+template<class T> bool isnan NO_MACRO_EXPAND(T)
 { static_assert(sizeof(T) == 0, "Undefined behavior; this template should never be instantiated"); return false; } // must not be instantiated
 template<> bool BOOST_MATH_TR1_DECL isnan<float> NO_MACRO_EXPAND(float x);
 template<> bool BOOST_MATH_TR1_DECL isnan<double> NO_MACRO_EXPAND(double x);
 template<> bool BOOST_MATH_TR1_DECL isnan<long double> NO_MACRO_EXPAND(long double x);
 
-template<class T> bool isnormal NO_MACRO_EXPAND(T x)
+template<class T> bool isnormal NO_MACRO_EXPAND(T)
 { static_assert(sizeof(T) == 0, "Undefined behavior; this template should never be instantiated"); return false; } // must not be instantiated
 template<> bool BOOST_MATH_TR1_DECL isnormal<float> NO_MACRO_EXPAND(float x);
 template<> bool BOOST_MATH_TR1_DECL isnormal<double> NO_MACRO_EXPAND(double x);
 template<> bool BOOST_MATH_TR1_DECL isnormal<long double> NO_MACRO_EXPAND(long double x);
 
-#undef NO_MACRO_EXPAND   
-   
+#undef NO_MACRO_EXPAND
+
 // [5.2.1.1] associated Laguerre polynomials:
 inline float assoc_laguerref BOOST_PREVENT_MACRO_SUBSTITUTION(unsigned n, unsigned m, float x)
 { return boost::math::tr1::boost_assoc_laguerref BOOST_PREVENT_MACRO_SUBSTITUTION(n, m, x); }
@@ -788,7 +788,7 @@ inline float assoc_laguerre BOOST_PREVENT_MACRO_SUBSTITUTION(unsigned n, unsigne
 { return boost::math::tr1::assoc_laguerref BOOST_PREVENT_MACRO_SUBSTITUTION(n, m, x); }
 inline long double assoc_laguerre BOOST_PREVENT_MACRO_SUBSTITUTION(unsigned n, unsigned m, long double x)
 { return boost::math::tr1::assoc_laguerrel BOOST_PREVENT_MACRO_SUBSTITUTION(n, m, x); }
-template <class T> 
+template <class T>
 inline typename tools::promote_args<T>::type assoc_laguerre BOOST_PREVENT_MACRO_SUBSTITUTION(unsigned n, unsigned m, T x)
 { return boost::math::tr1::assoc_laguerre BOOST_PREVENT_MACRO_SUBSTITUTION(n, m, static_cast<typename tools::promote_args<T>::type>(x)); }
 

--- a/include_private/boost/math/tools/test.hpp
+++ b/include_private/boost/math/tools/test.hpp
@@ -133,7 +133,7 @@ test_result<typename calculate_result_type<A>::value_type> test(const A& a, F1 t
       }
       catch(const std::overflow_error&)
       {
-         point = std::numeric_limits<value_type>::has_infinity ? 
+         point = std::numeric_limits<value_type>::has_infinity ?
             std::numeric_limits<value_type>::infinity()
             : tools::max_value<value_type>();
       }
@@ -205,7 +205,7 @@ test_result<Real> test_hetero(const A& a, F1 test_func, F2 expect_func)
       }
       catch(const std::overflow_error&)
       {
-         point = std::numeric_limits<value_type>::has_infinity ? 
+         point = std::numeric_limits<value_type>::has_infinity ?
             std::numeric_limits<value_type>::infinity()
             : tools::max_value<value_type>();
       }
@@ -254,14 +254,14 @@ test_result<Real> test_hetero(const A& a, F1 test_func, F2 expect_func)
 }
 
 template <class Val, class Exception>
-void test_check_throw(Val v, Exception e)
+void test_check_throw(Val, Exception)
 {
    BOOST_CHECK(errno);
    errno = 0;
 }
 
 template <class Val>
-void test_check_throw(Val val, std::domain_error const* e)
+void test_check_throw(Val val, std::domain_error const*)
 {
    BOOST_CHECK(errno == EDOM);
    errno = 0;
@@ -272,7 +272,7 @@ void test_check_throw(Val val, std::domain_error const* e)
 }
 
 template <class Val>
-void test_check_throw(Val v, std::overflow_error const* e)
+void test_check_throw(Val v, std::overflow_error const*)
 {
    BOOST_CHECK(errno == ERANGE);
    errno = 0;
@@ -280,7 +280,7 @@ void test_check_throw(Val v, std::overflow_error const* e)
 }
 
 template <class Val>
-void test_check_throw(Val v, boost::math::rounding_error const* e)
+void test_check_throw(Val v, boost::math::rounding_error const*)
 {
    BOOST_CHECK(errno == ERANGE);
    errno = 0;

--- a/test/catmull_rom_test.cpp
+++ b/test/catmull_rom_test.cpp
@@ -335,7 +335,7 @@ private:
 
 // Must define the free function "size()":
 template<class Real>
-constexpr std::size_t size(const mypoint3d<Real>& c)
+constexpr std::size_t size(const mypoint3d<Real>&)
 {
     return 3;
 }

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -66,8 +66,10 @@ void instantiate(RealType)
    using namespace boost::math::concepts;
 
    long l;
+   (void)l;
 #ifdef BOOST_HAS_LONG_LONG
    boost::long_long_type ll;
+   (void)ll;
 #endif
 #ifdef TEST_GROUP_1
    function_requires<DistributionConcept<arcsine_distribution<RealType> > >();

--- a/test/quaternion_constexpr_test.cpp
+++ b/test/quaternion_constexpr_test.cpp
@@ -143,6 +143,11 @@ int main()
    (void)b8;
    (void)b9;
    (void)b10;
+   (void)q3;
+   (void)q4;
+   (void)q6;
+   (void)q7;
+   (void)q8;
 
 #endif
 
@@ -150,12 +155,12 @@ int main()
 
    constexpr qt q12 = c2 + q1;
    constexpr qt q13 = q1 + c2;
-   
+
    constexpr qt q17 = c2 - q1;
    constexpr qt q18 = q1 - c2;
-   
+
    constexpr qt q24 = full_constexpr_test(q5, q5 + 1, 3.2, q5.C_component_1());
-   
+
    (void)q12;
    (void)q13;
    (void)q17;

--- a/test/test_2F0.cpp
+++ b/test/test_2F0.cpp
@@ -103,11 +103,11 @@ BOOST_AUTO_TEST_CASE( test_main )
 #endif
 
 #ifndef BOOST_MATH_NO_MP_TESTS
-   using dec_40 = boost::multiprecision::number<boost::multiprecision::cpp_dec_float<40>>;
 #if !defined(TEST) || (TEST == 3)
    test_spots(boost::multiprecision::cpp_bin_float_quad(), "cpp_bin_float_quad");
 #endif
 #if !defined(TEST) || (TEST == 4)
+   using dec_40 = boost::multiprecision::number<boost::multiprecision::cpp_dec_float<40>>;
    test_spots(dec_40(), "dec_40");
 #endif
 #endif

--- a/test/test_nc_t.hpp
+++ b/test/test_nc_t.hpp
@@ -44,7 +44,7 @@
       }
 
 template <class RealType>
-RealType naive_pdf(RealType v, RealType delta, RealType x)
+RealType naive_pdf(RealType, RealType, RealType)
 {
 }
 

--- a/test/test_tr1.cpp
+++ b/test/test_tr1.cpp
@@ -981,6 +981,7 @@ void test_values(double, const char* name)
 
 void test_values(long double, const char* name)
 {
+   (void)name;
 #ifdef TEST_LD
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
    std::cout << "Testing type " << name << std::endl;
@@ -1623,6 +1624,6 @@ BOOST_AUTO_TEST_CASE( test_main )
    test_values(1.0L, "long double");
 #endif
 #endif
-   
+
 }
 


### PR DESCRIPTION
Large scale cleanup of warnings by running `-Wall -Wextra` through the complete test set. Fixed sonarlint complaints while in the file cleaning up warnings.