### PR TITLE
More warning fixes

### DIFF
--- a/include/boost/math/bindings/mpfr.hpp
+++ b/include/boost/math/bindings/mpfr.hpp
@@ -15,7 +15,7 @@
 
 #ifdef _MSC_VER
 //
-// We get a lot of warnings from the gmp, mpfr and gmpfrxx headers, 
+// We get a lot of warnings from the gmp, mpfr and gmpfrxx headers,
 // disable them here, so we only see warnings from *our* code:
 //
 #pragma warning(push)
@@ -181,7 +181,7 @@ inline long long lltrunc(__gmp_expr<T,U> const& x, const Policy& pol)
    return lltrunc(static_cast<mpfr_class>(x), pol);
 }
 
-namespace boost{ 
+namespace boost{
 
 #ifdef BOOST_MATH_USE_FLOAT128
    template<> struct std::is_convertible<BOOST_MATH_FLOAT128_TYPE, mpfr_class> : public std::integral_constant<bool, false>{};
@@ -253,7 +253,7 @@ struct mpfr_lanczos
          return lanczos61UDT::lanczos_sum_near_2(z);
    }
    static mpfr_class g()
-   { 
+   {
       unsigned long p = mpfr_class::get_dprec();
       if(p <= 72)
          return lanczos13UDT::g();
@@ -335,7 +335,7 @@ inline mpfr_class real_cast<mpfr_class, long long>(long long t)
    }
    while(t)
    {
-      result += ldexp((double)(t & 0xffffL), expon);
+      result += ldexp(static_cast<double>(t & 0xffffL), expon);
       expon += 32;
       t >>= 32;
    }
@@ -554,7 +554,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
    BOOST_MATH_STD_USING // for ADL of std names.
 
    mpfr_class result = 0;
-   
+
    if(p <= 0.5)
    {
       //
@@ -570,7 +570,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
       // Maximum Deviation Found (actual empfr_classor term at infinite precision) 8.030e-21
       //
       static const float Y = 0.0891314744949340820313f;
-      static const mpfr_class P[] = {    
+      static const mpfr_class P[] = {
          -0.000508781949658280665617,
          -0.00836874819741736770379,
          0.0334806625409744615033,
@@ -580,7 +580,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
          0.00822687874676915743155,
          -0.00538772965071242932965
       };
-      static const mpfr_class Q[] = {    
+      static const mpfr_class Q[] = {
          1,
          -0.970005043303290640362,
          -1.56574558234175846809,
@@ -611,7 +611,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
       // Maximum Deviation Found (empfr_classor term) 4.811e-20
       //
       static const float Y = 2.249481201171875f;
-      static const mpfr_class P[] = {    
+      static const mpfr_class P[] = {
          -0.202433508355938759655,
          0.105264680699391713268,
          8.37050328343119927838,
@@ -622,7 +622,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
          21.1294655448340526258,
          -3.67192254707729348546
       };
-      static const mpfr_class Q[] = {    
+      static const mpfr_class Q[] = {
          1,
          6.24264124854247537712,
          3.9713437953343869095,
@@ -650,7 +650,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
       //
       // x(Y+R(x-B))
       //
-      // where Y is a constant, B is the lowest value of x for which 
+      // where Y is a constant, B is the lowest value of x for which
       // the approximation is valid, and R(x-B) is optimised for a low
       // absolute empfr_classor compared to Y.
       //
@@ -664,7 +664,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
       {
          // Max empfr_classor found: 1.089051e-20
          static const float Y = 0.807220458984375f;
-         static const mpfr_class P[] = {    
+         static const mpfr_class P[] = {
             -0.131102781679951906451,
             -0.163794047193317060787,
             0.117030156341995252019,
@@ -677,7 +677,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
             0.285225331782217055858e-7,
             -0.681149956853776992068e-9
          };
-         static const mpfr_class Q[] = {    
+         static const mpfr_class Q[] = {
             1,
             3.46625407242567245975,
             5.38168345707006855425,
@@ -695,7 +695,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
       {
          // Max empfr_classor found: 8.389174e-21
          static const float Y = 0.93995571136474609375f;
-         static const mpfr_class P[] = {    
+         static const mpfr_class P[] = {
             -0.0350353787183177984712,
             -0.00222426529213447927281,
             0.0185573306514231072324,
@@ -706,7 +706,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
             -0.230404776911882601748e-9,
             0.266339227425782031962e-11
          };
-         static const mpfr_class Q[] = {    
+         static const mpfr_class Q[] = {
             1,
             1.3653349817554063097,
             0.762059164553623404043,
@@ -723,7 +723,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
       {
          // Max empfr_classor found: 1.481312e-19
          static const float Y = 0.98362827301025390625f;
-         static const mpfr_class P[] = {    
+         static const mpfr_class P[] = {
             -0.0167431005076633737133,
             -0.00112951438745580278863,
             0.00105628862152492910091,
@@ -734,7 +734,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
             -0.281128735628831791805e-13,
             0.99055709973310326855e-16
          };
-         static const mpfr_class Q[] = {    
+         static const mpfr_class Q[] = {
             1,
             0.591429344886417493481,
             0.138151865749083321638,
@@ -751,7 +751,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
       {
          // Max empfr_classor found: 5.697761e-20
          static const float Y = 0.99714565277099609375f;
-         static const mpfr_class P[] = {    
+         static const mpfr_class P[] = {
             -0.0024978212791898131227,
             -0.779190719229053954292e-5,
             0.254723037413027451751e-4,
@@ -761,7 +761,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
             0.145596286718675035587e-11,
             -0.116765012397184275695e-17
          };
-         static const mpfr_class Q[] = {    
+         static const mpfr_class Q[] = {
             1,
             0.207123112214422517181,
             0.0169410838120975906478,
@@ -778,7 +778,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
       {
          // Max empfr_classor found: 1.279746e-20
          static const float Y = 0.99941349029541015625f;
-         static const mpfr_class P[] = {    
+         static const mpfr_class P[] = {
             -0.000539042911019078575891,
             -0.28398759004727721098e-6,
             0.899465114892291446442e-6,
@@ -788,7 +788,7 @@ inline mpfr_class erf_inv_imp(const mpfr_class& p, const mpfr_class& q, const Po
             0.135880130108924861008e-14,
             -0.348890393399948882918e-21
          };
-         static const mpfr_class Q[] = {    
+         static const mpfr_class Q[] = {
             1,
             0.0845746234001899436914,
             0.00282092984726264681981,
@@ -810,7 +810,7 @@ inline mpfr_class bessel_i0(mpfr_class x)
    #ifdef BOOST_MATH_STANDALONE
    static_assert(sizeof(x) == 0, "mpfr bessel_i0 can not be calculated in standalone mode");
    #endif
-    
+
     static const mpfr_class P1[] = {
         static_cast<mpfr_class>("-2.2335582639474375249e+15"),
         static_cast<mpfr_class>("-5.5050369673018427753e+14"),

--- a/include/boost/math/bindings/mpreal.hpp
+++ b/include/boost/math/bindings/mpreal.hpp
@@ -15,7 +15,7 @@
 
 #ifdef _MSC_VER
 //
-// We get a lot of warnings from the gmp, mpfr and gmpfrxx headers, 
+// We get a lot of warnings from the gmp, mpfr and gmpfrxx headers,
 // disable them here, so we only see warnings from *our* code:
 //
 #pragma warning(push)
@@ -232,7 +232,7 @@ struct mpreal_lanczos
          return lanczos61UDT::lanczos_sum_near_2(z);
    }
    static mpfr::mpreal g()
-   { 
+   {
       unsigned long p = mpfr::mpreal::get_default_prec();
       if(p <= 72)
          return lanczos13UDT::g();
@@ -295,7 +295,7 @@ inline mpfr::mpreal real_cast<mpfr::mpreal, long long>(long long t)
    }
    while(t)
    {
-      result += ldexp((double)(t & 0xffffL), expon);
+      result += ldexp(static_cast<double>(t & 0xffffL), expon);
       expon += 32;
       t >>= 32;
    }
@@ -504,7 +504,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
    BOOST_MATH_STD_USING // for ADL of std names.
 
    mpfr::mpreal result = 0;
-   
+
    if(p <= 0.5)
    {
       //
@@ -520,7 +520,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
       // Maximum Deviation Found (actual empfr_classor term at infinite precision) 8.030e-21
       //
       static const float Y = 0.0891314744949340820313f;
-      static const mpfr::mpreal P[] = {    
+      static const mpfr::mpreal P[] = {
          -0.000508781949658280665617,
          -0.00836874819741736770379,
          0.0334806625409744615033,
@@ -530,7 +530,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
          0.00822687874676915743155,
          -0.00538772965071242932965
       };
-      static const mpfr::mpreal Q[] = {    
+      static const mpfr::mpreal Q[] = {
          1,
          -0.970005043303290640362,
          -1.56574558234175846809,
@@ -561,7 +561,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
       // Maximum Deviation Found (empfr_classor term) 4.811e-20
       //
       static const float Y = 2.249481201171875f;
-      static const mpfr::mpreal P[] = {    
+      static const mpfr::mpreal P[] = {
          -0.202433508355938759655,
          0.105264680699391713268,
          8.37050328343119927838,
@@ -572,7 +572,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
          21.1294655448340526258,
          -3.67192254707729348546
       };
-      static const mpfr::mpreal Q[] = {    
+      static const mpfr::mpreal Q[] = {
          1,
          6.24264124854247537712,
          3.9713437953343869095,
@@ -600,7 +600,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
       //
       // x(Y+R(x-B))
       //
-      // where Y is a constant, B is the lowest value of x for which 
+      // where Y is a constant, B is the lowest value of x for which
       // the approximation is valid, and R(x-B) is optimised for a low
       // absolute empfr_classor compared to Y.
       //
@@ -614,7 +614,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
       {
          // Max empfr_classor found: 1.089051e-20
          static const float Y = 0.807220458984375f;
-         static const mpfr::mpreal P[] = {    
+         static const mpfr::mpreal P[] = {
             -0.131102781679951906451,
             -0.163794047193317060787,
             0.117030156341995252019,
@@ -627,7 +627,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
             0.285225331782217055858e-7,
             -0.681149956853776992068e-9
          };
-         static const mpfr::mpreal Q[] = {    
+         static const mpfr::mpreal Q[] = {
             1,
             3.46625407242567245975,
             5.38168345707006855425,
@@ -645,7 +645,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
       {
          // Max empfr_classor found: 8.389174e-21
          static const float Y = 0.93995571136474609375f;
-         static const mpfr::mpreal P[] = {    
+         static const mpfr::mpreal P[] = {
             -0.0350353787183177984712,
             -0.00222426529213447927281,
             0.0185573306514231072324,
@@ -656,7 +656,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
             -0.230404776911882601748e-9,
             0.266339227425782031962e-11
          };
-         static const mpfr::mpreal Q[] = {    
+         static const mpfr::mpreal Q[] = {
             1,
             1.3653349817554063097,
             0.762059164553623404043,
@@ -673,7 +673,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
       {
          // Max empfr_classor found: 1.481312e-19
          static const float Y = 0.98362827301025390625f;
-         static const mpfr::mpreal P[] = {    
+         static const mpfr::mpreal P[] = {
             -0.0167431005076633737133,
             -0.00112951438745580278863,
             0.00105628862152492910091,
@@ -684,7 +684,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
             -0.281128735628831791805e-13,
             0.99055709973310326855e-16
          };
-         static const mpfr::mpreal Q[] = {    
+         static const mpfr::mpreal Q[] = {
             1,
             0.591429344886417493481,
             0.138151865749083321638,
@@ -701,7 +701,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
       {
          // Max empfr_classor found: 5.697761e-20
          static const float Y = 0.99714565277099609375f;
-         static const mpfr::mpreal P[] = {    
+         static const mpfr::mpreal P[] = {
             -0.0024978212791898131227,
             -0.779190719229053954292e-5,
             0.254723037413027451751e-4,
@@ -711,7 +711,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
             0.145596286718675035587e-11,
             -0.116765012397184275695e-17
          };
-         static const mpfr::mpreal Q[] = {    
+         static const mpfr::mpreal Q[] = {
             1,
             0.207123112214422517181,
             0.0169410838120975906478,
@@ -728,7 +728,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
       {
          // Max empfr_classor found: 1.279746e-20
          static const float Y = 0.99941349029541015625f;
-         static const mpfr::mpreal P[] = {    
+         static const mpfr::mpreal P[] = {
             -0.000539042911019078575891,
             -0.28398759004727721098e-6,
             0.899465114892291446442e-6,
@@ -738,7 +738,7 @@ mpfr::mpreal erf_inv_imp(const mpfr::mpreal& p, const mpfr::mpreal& q, const Pol
             0.135880130108924861008e-14,
             -0.348890393399948882918e-21
          };
-         static const mpfr::mpreal Q[] = {    
+         static const mpfr::mpreal Q[] = {
             1,
             0.0845746234001899436914,
             0.00282092984726264681981,
@@ -760,7 +760,7 @@ inline mpfr::mpreal bessel_i0(mpfr::mpreal x)
    #ifdef BOOST_MATH_STANDALONE
    static_assert(sizeof(x) == 0, "mpreal bessel_i0 can not be calculated in standalone mode");
    #endif
-    
+
     static const mpfr::mpreal P1[] = {
         boost::lexical_cast<mpfr::mpreal>("-2.2335582639474375249e+15"),
         boost::lexical_cast<mpfr::mpreal>("-5.5050369673018427753e+14"),

--- a/include/boost/math/distributions/detail/hypergeometric_cdf.hpp
+++ b/include/boost/math/distributions/detail/hypergeometric_cdf.hpp
@@ -27,7 +27,7 @@ namespace boost{ namespace math{ namespace detail{
       {
          result = hypergeometric_pdf<T>(x, r, n, N, pol);
          T diff = result;
-         unsigned lower_limit = static_cast<unsigned>((std::max)(0, (int)(n + r) - (int)(N)));
+         unsigned lower_limit = static_cast<unsigned>((std::max)(0, static_cast<int>(n + r) - static_cast<int>(N)));
          while(diff > (invert ? T(1) : result) * tools::epsilon<T>())
          {
             diff = T(x) * T((N + x) - n - r) * diff / (T(1 + n - x) * T(1 + r - x));
@@ -75,9 +75,9 @@ namespace boost{ namespace math{ namespace detail{
       typedef typename tools::promote_args<T>::type result_type;
       typedef typename policies::evaluation<result_type, Policy>::type value_type;
       typedef typename policies::normalise<
-         Policy, 
-         policies::promote_float<false>, 
-         policies::promote_double<false>, 
+         Policy,
+         policies::promote_float<false>,
+         policies::promote_double<false>,
          policies::discrete_quantile<>,
          policies::assert_undefined<> >::type forwarding_policy;
 

--- a/include/boost/math/distributions/detail/hypergeometric_quantile.hpp
+++ b/include/boost/math/distributions/detail/hypergeometric_quantile.hpp
@@ -113,7 +113,7 @@ unsigned hypergeometric_quantile_imp(T p, T q, unsigned r, unsigned n, unsigned 
    BOOST_FPU_EXCEPTION_GUARD
    T result;
    T fudge_factor = 1 + tools::epsilon<T>() * ((N <= boost::math::prime(boost::math::max_prime - 1)) ? 50 : 2 * N);
-   unsigned base = static_cast<unsigned>((std::max)(0, (int)(n + r) - (int)(N)));
+   unsigned base = static_cast<unsigned>((std::max)(0, static_cast<int>(n + r) - static_cast<int>(N)));
    unsigned lim = (std::min)(r, n);
 
    BOOST_MATH_INSTRUMENT_VARIABLE(p);
@@ -155,7 +155,7 @@ unsigned hypergeometric_quantile_imp(T p, T q, unsigned r, unsigned n, unsigned 
       }
       while(result < p)
       {
-         diff = (diff > tools::min_value<T>() * 8) 
+         diff = (diff > tools::min_value<T>() * 8)
             ? T(n - x) * T(r - x) * diff / (T(x + 1) * T(N + x + 1 - n - r))
             : hypergeometric_pdf<T>(x + 1, r, n, N, pol);
          if(result + diff / 2 > p)
@@ -231,9 +231,9 @@ inline unsigned hypergeometric_quantile(T p, T q, unsigned r, unsigned n, unsign
    typedef typename tools::promote_args<T>::type result_type;
    typedef typename policies::evaluation<result_type, Policy>::type value_type;
    typedef typename policies::normalise<
-      Policy, 
-      policies::promote_float<false>, 
-      policies::promote_double<false>, 
+      Policy,
+      policies::promote_float<false>,
+      policies::promote_double<false>,
       policies::assert_undefined<> >::type forwarding_policy;
 
    return detail::hypergeometric_quantile_imp<value_type>(p, q, r, n, N, forwarding_policy());

--- a/include/boost/math/distributions/hypergeometric.hpp
+++ b/include/boost/math/distributions/hypergeometric.hpp
@@ -67,7 +67,7 @@ namespace boost { namespace math {
       }
       bool check_x(unsigned x, const char* function, RealType* result)const
       {
-         if(x < static_cast<unsigned>((std::max)(0, (int)(m_n + m_r) - (int)(m_N))))
+         if(x < static_cast<unsigned>((std::max)(0, static_cast<int>(m_n + m_r) - static_cast<int>(m_N))))
          {
             *result = boost::math::policies::raise_domain_error<RealType>(
                function, "Random variable out of range: must be > 0 and > m + r - N but got %1%", static_cast<RealType>(x), Policy());
@@ -102,7 +102,7 @@ namespace boost { namespace math {
       unsigned r = dist.defective();
       unsigned n = dist.sample_count();
       unsigned N = dist.total();
-      unsigned l = static_cast<unsigned>((std::max)(0, (int)(n + r) - (int)(N)));
+      unsigned l = static_cast<unsigned>((std::max)(0, static_cast<int>(n + r) - static_cast<int>(N)));
       unsigned u = (std::min)(r, n);
       return std::pair<unsigned, unsigned>(l, u);
 #ifdef _MSC_VER
@@ -112,7 +112,7 @@ namespace boost { namespace math {
 
    template <class RealType, class Policy>
    inline const std::pair<unsigned, unsigned> support(const hypergeometric_distribution<RealType, Policy>& d)
-   { 
+   {
       return range(d);
    }
 
@@ -231,7 +231,7 @@ namespace boost { namespace math {
       return static_cast<RealType>(detail::hypergeometric_quantile(RealType(1 - c.param), c.param, c.dist.defective(), c.dist.sample_count(), c.dist.total(), Policy()));
    } // quantile
 
-   // https://www.wolframalpha.com/input/?i=kurtosis+hypergeometric+distribution 
+   // https://www.wolframalpha.com/input/?i=kurtosis+hypergeometric+distribution
 
    template <class RealType, class Policy>
    inline RealType mean(const hypergeometric_distribution<RealType, Policy>& dist)
@@ -281,11 +281,11 @@ namespace boost { namespace math {
       RealType m = static_cast<RealType>(dist.defective()); // Failures or success events. (Also symbols K or M are used).
       RealType n = static_cast<RealType>(dist.sample_count()); // draws or trials.
       RealType n2 = n * n; // n^2
-      RealType N = static_cast<RealType>(dist.total()); // Total population from which n draws or trials are made. 
+      RealType N = static_cast<RealType>(dist.total()); // Total population from which n draws or trials are made.
       RealType N2 = N * N; // N^2
       // result = ((N - 1) N^2 ((3 m(N - m) (n^2 (-N) + (n - 2) N^2 + 6 n(N - n)))/N^2 - 6 n(N - n) + N(N + 1)))/(m n(N - 3) (N - 2) (N - m) (N - n));
       RealType result = ((N-1)*N2*((3*m*(N-m)*(n2*(-N)+(n-2)*N2+6*n*(N-n)))/N2-6*n*(N-n)+N*(N+1)))/(m*n*(N-3)*(N-2)*(N-m)*(N-n));
-      // Agrees with kurtosis hypergeometric distribution(50,200,500) kurtosis = 2.96917 
+      // Agrees with kurtosis hypergeometric distribution(50,200,500) kurtosis = 2.96917
       // N[kurtosis[hypergeometricdistribution(50,200,500)], 55]  2.969174035736058474901169623721804275002985337280263464
       return result;
    } // RealType kurtosis_excess(const hypergeometric_distribution<RealType, Policy>& dist)

--- a/include/boost/math/distributions/non_central_t.hpp
+++ b/include/boost/math/distributions/non_central_t.hpp
@@ -47,7 +47,7 @@ namespace boost
             T pois;
             if(k == 0) k = 1;
             // Starting Poisson weight:
-            pois = gamma_p_derivative(T(k+1), d2, pol) 
+            pois = gamma_p_derivative(T(k+1), d2, pol)
                * tgamma_delta_ratio(T(k + 1), T(0.5f))
                * delta / constants::root_two<T>();
             if(pois == 0)
@@ -97,7 +97,7 @@ namespace boost
                if(count > max_iter)
                {
                   return policies::raise_evaluation_error(
-                     "cdf(non_central_t_distribution<%1%>, %1%)", 
+                     "cdf(non_central_t_distribution<%1%>, %1%)",
                      "Series did not converge, closest value was %1%", sum, pol);
                }
             }
@@ -125,7 +125,7 @@ namespace boost
             if(k == 0) k = 1;
             // Starting Poisson weight:
             T pois;
-            if((k < (int)(max_factorial<T>::value)) && (d2 < tools::log_max_value<T>()) && (log(d2) * k < tools::log_max_value<T>()))
+            if((k < static_cast<int>(max_factorial<T>::value)) && (d2 < tools::log_max_value<T>()) && (log(d2) * k < tools::log_max_value<T>()))
             {
                //
                // For small k we can optimise this calculation by using
@@ -138,7 +138,7 @@ namespace boost
             }
             else
             {
-               pois = gamma_p_derivative(T(k+1), d2, pol) 
+               pois = gamma_p_derivative(T(k+1), d2, pol)
                   * tgamma_delta_ratio(T(k + 1), T(0.5f))
                   * delta / constants::root_two<T>();
             }
@@ -150,8 +150,8 @@ namespace boost
             // Starting beta term:
             if(k != 0)
             {
-               beta = x < y 
-                  ? detail::ibeta_imp(T(k + 1), T(v / 2), x, pol, true, true, &xterm) 
+               beta = x < y
+                  ? detail::ibeta_imp(T(k + 1), T(v / 2), x, pol, true, true, &xterm)
                   : detail::ibeta_imp(T(v / 2), T(k + 1), y, pol, false, true, &xterm);
 
                xterm *= y / (v / 2 + k);
@@ -194,7 +194,7 @@ namespace boost
                if(count > max_iter)
                {
                   return policies::raise_evaluation_error(
-                     "cdf(non_central_t_distribution<%1%>, %1%)", 
+                     "cdf(non_central_t_distribution<%1%>, %1%)",
                      "Series did not converge, closest value was %1%", sum, pol);
                }
                ++count;
@@ -208,7 +208,7 @@ namespace boost
             BOOST_MATH_STD_USING
             if ((boost::math::isinf)(v))
             { // Infinite degrees of freedom, so use normal distribution located at delta.
-               normal_distribution<T, Policy> n(delta, 1); 
+               normal_distribution<T, Policy> n(delta, 1);
                return cdf(n, t);
             }
             //
@@ -294,9 +294,9 @@ namespace boost
      // now passed as function
             typedef typename policies::evaluation<T, Policy>::type value_type;
             typedef typename policies::normalise<
-               Policy, 
-               policies::promote_float<false>, 
-               policies::promote_double<false>, 
+               Policy,
+               policies::promote_float<false>,
+               policies::promote_double<false>,
                policies::discrete_quantile<>,
                policies::assert_undefined<> >::type forwarding_policy;
 
@@ -342,14 +342,14 @@ namespace boost
                   guess = quantile(complement(normal_distribution<value_type, forwarding_policy>(mean, var), q));
             }
             //
-            // We *must* get the sign of the initial guess correct, 
+            // We *must* get the sign of the initial guess correct,
             // or our root-finder will fail, so double check it now:
             //
             value_type pzero = non_central_t_cdf(
-               static_cast<value_type>(v), 
-               static_cast<value_type>(delta), 
-               static_cast<value_type>(0), 
-               !(p < q), 
+               static_cast<value_type>(v),
+               static_cast<value_type>(delta),
+               static_cast<value_type>(0),
+               !(p < q),
                forwarding_policy());
             int s;
             if(p < q)
@@ -362,13 +362,13 @@ namespace boost
             }
 
             value_type result = detail::generic_quantile(
-               non_central_t_distribution<value_type, forwarding_policy>(v, delta), 
-               (p < q ? p : q), 
-               guess, 
-               (p >= q), 
+               non_central_t_distribution<value_type, forwarding_policy>(v, delta),
+               (p < q ? p : q),
+               guess,
+               (p >= q),
                function);
             return policies::checked_narrowing_cast<T, forwarding_policy>(
-               result, 
+               result,
                function);
          }
 
@@ -391,7 +391,7 @@ namespace boost
             if(k == 0)
                k = 1;
             // Starting Poisson weight:
-            pois = gamma_p_derivative(T(k+1), d2, pol) 
+            pois = gamma_p_derivative(T(k+1), d2, pol)
                * tgamma_delta_ratio(T(k + 1), T(0.5f))
                * delta / constants::root_two<T>();
             // Starting beta term:
@@ -420,7 +420,7 @@ namespace boost
                if(count > max_iter)
                {
                   return policies::raise_evaluation_error(
-                     "pdf(non_central_t_distribution<%1%>, %1%)", 
+                     "pdf(non_central_t_distribution<%1%>, %1%)",
                      "Series did not converge, closest value was %1%", sum, pol);
                }
             }
@@ -436,7 +436,7 @@ namespace boost
                if(count > max_iter)
                {
                   return policies::raise_evaluation_error(
-                     "pdf(non_central_t_distribution<%1%>, %1%)", 
+                     "pdf(non_central_t_distribution<%1%>, %1%)",
                      "Series did not converge, closest value was %1%", sum, pol);
                }
             }
@@ -449,7 +449,7 @@ namespace boost
             BOOST_MATH_STD_USING
             if ((boost::math::isinf)(n))
             { // Infinite degrees of freedom, so use normal distribution located at delta.
-               normal_distribution<T, Policy> norm(delta, 1); 
+               normal_distribution<T, Policy> norm(delta, 1);
                return pdf(norm, t);
             }
             //
@@ -463,16 +463,16 @@ namespace boost
             {
                //
                // Handle this as a special case, using the formula
-               // from Weisstein, Eric W. 
-               // "Noncentral Student's t-Distribution." 
-               // From MathWorld--A Wolfram Web Resource. 
-               // http://mathworld.wolfram.com/NoncentralStudentst-Distribution.html 
-               // 
+               // from Weisstein, Eric W.
+               // "Noncentral Student's t-Distribution."
+               // From MathWorld--A Wolfram Web Resource.
+               // http://mathworld.wolfram.com/NoncentralStudentst-Distribution.html
+               //
                // The formula is simplified thanks to the relation
                // 1F1(a,b,0) = 1.
                //
                return tgamma_delta_ratio(n / 2 + 0.5f, T(0.5f))
-                  * sqrt(n / constants::pi<T>()) 
+                  * sqrt(n / constants::pi<T>())
                   * exp(-delta * delta / 2) / 2;
             }
             if(fabs(delta / (4 * n)) < policies::get_epsilon<T, Policy>())
@@ -523,7 +523,7 @@ namespace boost
             if (v > 1 / boost::math::tools::epsilon<T>() )
             {
               //normal_distribution<T, Policy> n(delta, 1);
-              //return boost::math::mean(n); 
+              //return boost::math::mean(n);
               return delta;
             }
             else
@@ -596,7 +596,7 @@ namespace boost
          }
 
 #if 0
-         // 
+         //
          // This code is disabled, since there can be multiple answers to the
          // question, and it's not clear how to find the "right" one.
          //
@@ -631,8 +631,8 @@ namespace boost
                //
                // Can't a thing if one of p and q is zero:
                //
-               return policies::raise_evaluation_error<RealType>(function, 
-                  "Can't find degrees of freedom when the probability is 0 or 1, only possible answer is %1%", 
+               return policies::raise_evaluation_error<RealType>(function,
+                  "Can't find degrees of freedom when the probability is 0 or 1, only possible answer is %1%",
                   RealType(std::numeric_limits<RealType>::quiet_NaN()), Policy());
             }
             t_degrees_of_freedom_finder<RealType, Policy> f(delta, x, p < q ? p : q, p < q ? false : true);
@@ -684,8 +684,8 @@ namespace boost
                //
                // Can't do a thing if one of p and q is zero:
                //
-               return policies::raise_evaluation_error<RealType>(function, 
-                  "Can't find non-centrality parameter when the probability is 0 or 1, only possible answer is %1%", 
+               return policies::raise_evaluation_error<RealType>(function,
+                  "Can't find non-centrality parameter when the probability is 0 or 1, only possible answer is %1%",
                   RealType(std::numeric_limits<RealType>::quiet_NaN()), Policy());
             }
             t_non_centrality_finder<RealType, Policy> f(v, x, p < q ? p : q, p < q ? false : true);
@@ -721,7 +721,7 @@ namespace boost
          typedef Policy policy_type;
 
          non_central_t_distribution(RealType v_, RealType lambda) : v(v_), ncp(lambda)
-         { 
+         {
             const char* function = "boost::math::non_central_t_distribution<%1%>::non_central_t_distribution(%1%,%1%)";
             RealType r;
             detail::check_df_gt0_to_inf(
@@ -743,7 +743,7 @@ namespace boost
             return ncp;
          }
 #if 0
-         // 
+         //
          // This code is disabled, since there can be multiple answers to the
          // question, and it's not clear how to find the "right" one.
          //
@@ -752,19 +752,19 @@ namespace boost
             const char* function = "non_central_t<%1%>::find_degrees_of_freedom";
             typedef typename policies::evaluation<RealType, Policy>::type value_type;
             typedef typename policies::normalise<
-               Policy, 
-               policies::promote_float<false>, 
-               policies::promote_double<false>, 
+               Policy,
+               policies::promote_float<false>,
+               policies::promote_double<false>,
                policies::discrete_quantile<>,
                policies::assert_undefined<> >::type forwarding_policy;
             value_type result = detail::find_t_degrees_of_freedom(
-               static_cast<value_type>(delta), 
-               static_cast<value_type>(x), 
-               static_cast<value_type>(p), 
-               static_cast<value_type>(1-p), 
+               static_cast<value_type>(delta),
+               static_cast<value_type>(x),
+               static_cast<value_type>(p),
+               static_cast<value_type>(1-p),
                forwarding_policy());
             return policies::checked_narrowing_cast<RealType, forwarding_policy>(
-               result, 
+               result,
                function);
          }
          template <class A, class B, class C>
@@ -773,19 +773,19 @@ namespace boost
             const char* function = "non_central_t<%1%>::find_degrees_of_freedom";
             typedef typename policies::evaluation<RealType, Policy>::type value_type;
             typedef typename policies::normalise<
-               Policy, 
-               policies::promote_float<false>, 
-               policies::promote_double<false>, 
+               Policy,
+               policies::promote_float<false>,
+               policies::promote_double<false>,
                policies::discrete_quantile<>,
                policies::assert_undefined<> >::type forwarding_policy;
             value_type result = detail::find_t_degrees_of_freedom(
-               static_cast<value_type>(c.dist), 
-               static_cast<value_type>(c.param1), 
-               static_cast<value_type>(1-c.param2), 
-               static_cast<value_type>(c.param2), 
+               static_cast<value_type>(c.dist),
+               static_cast<value_type>(c.param1),
+               static_cast<value_type>(1-c.param2),
+               static_cast<value_type>(c.param2),
                forwarding_policy());
             return policies::checked_narrowing_cast<RealType, forwarding_policy>(
-               result, 
+               result,
                function);
          }
          static RealType find_non_centrality(RealType v, RealType x, RealType p)
@@ -793,19 +793,19 @@ namespace boost
             const char* function = "non_central_t<%1%>::find_t_non_centrality";
             typedef typename policies::evaluation<RealType, Policy>::type value_type;
             typedef typename policies::normalise<
-               Policy, 
-               policies::promote_float<false>, 
-               policies::promote_double<false>, 
+               Policy,
+               policies::promote_float<false>,
+               policies::promote_double<false>,
                policies::discrete_quantile<>,
                policies::assert_undefined<> >::type forwarding_policy;
             value_type result = detail::find_t_non_centrality(
-               static_cast<value_type>(v), 
-               static_cast<value_type>(x), 
-               static_cast<value_type>(p), 
-               static_cast<value_type>(1-p), 
+               static_cast<value_type>(v),
+               static_cast<value_type>(x),
+               static_cast<value_type>(p),
+               static_cast<value_type>(1-p),
                forwarding_policy());
             return policies::checked_narrowing_cast<RealType, forwarding_policy>(
-               result, 
+               result,
                function);
          }
          template <class A, class B, class C>
@@ -814,19 +814,19 @@ namespace boost
             const char* function = "non_central_t<%1%>::find_t_non_centrality";
             typedef typename policies::evaluation<RealType, Policy>::type value_type;
             typedef typename policies::normalise<
-               Policy, 
-               policies::promote_float<false>, 
-               policies::promote_double<false>, 
+               Policy,
+               policies::promote_float<false>,
+               policies::promote_double<false>,
                policies::discrete_quantile<>,
                policies::assert_undefined<> >::type forwarding_policy;
             value_type result = detail::find_t_non_centrality(
-               static_cast<value_type>(c.dist), 
-               static_cast<value_type>(c.param1), 
-               static_cast<value_type>(1-c.param2), 
-               static_cast<value_type>(c.param2), 
+               static_cast<value_type>(c.dist),
+               static_cast<value_type>(c.param1),
+               static_cast<value_type>(1-c.param2),
+               static_cast<value_type>(c.param2),
                forwarding_policy());
             return policies::checked_narrowing_cast<RealType, forwarding_policy>(
-               result, 
+               result,
                function);
          }
 #endif
@@ -884,7 +884,7 @@ namespace boost
          RealType var = v < 4 ? 1 : detail::variance(v, l, Policy());
 
          return detail::generic_find_mode(
-            dist, 
+            dist,
             m,
             function,
             sqrt(var));
@@ -892,14 +892,14 @@ namespace boost
 
       template <class RealType, class Policy>
       inline RealType mean(const non_central_t_distribution<RealType, Policy>& dist)
-      { 
+      {
          BOOST_MATH_STD_USING
          const char* function = "mean(const non_central_t_distribution<%1%>&)";
          typedef typename policies::evaluation<RealType, Policy>::type value_type;
          typedef typename policies::normalise<
-            Policy, 
-            policies::promote_float<false>, 
-            policies::promote_double<false>, 
+            Policy,
+            policies::promote_float<false>,
+            policies::promote_double<false>,
             policies::discrete_quantile<>,
             policies::assert_undefined<> >::type forwarding_policy;
          RealType v = dist.degrees_of_freedom();
@@ -917,7 +917,7 @@ namespace boost
                return (RealType)r;
          if(v <= 1)
             return policies::raise_domain_error<RealType>(
-               function, 
+               function,
                "The non-central t distribution has no defined mean for degrees of freedom <= 1: got v=%1%.", v, Policy());
          // return l * sqrt(v / 2) * tgamma_delta_ratio((v - 1) * 0.5f, RealType(0.5f));
          return policies::checked_narrowing_cast<RealType, forwarding_policy>(
@@ -931,9 +931,9 @@ namespace boost
          const char* function = "variance(const non_central_t_distribution<%1%>&)";
          typedef typename policies::evaluation<RealType, Policy>::type value_type;
          typedef typename policies::normalise<
-            Policy, 
-            policies::promote_float<false>, 
-            policies::promote_double<false>, 
+            Policy,
+            policies::promote_float<false>,
+            policies::promote_double<false>,
             policies::discrete_quantile<>,
             policies::assert_undefined<> >::type forwarding_policy;
          BOOST_MATH_STD_USING
@@ -952,7 +952,7 @@ namespace boost
                return (RealType)r;
          if(v <= 2)
             return policies::raise_domain_error<RealType>(
-               function, 
+               function,
                "The non-central t distribution has no defined variance for degrees of freedom <= 2: got v=%1%.", v, Policy());
          return policies::checked_narrowing_cast<RealType, forwarding_policy>(
             detail::variance(static_cast<value_type>(v), static_cast<value_type>(l), forwarding_policy()), function);
@@ -967,9 +967,9 @@ namespace boost
          const char* function = "skewness(const non_central_t_distribution<%1%>&)";
          typedef typename policies::evaluation<RealType, Policy>::type value_type;
          typedef typename policies::normalise<
-            Policy, 
-            policies::promote_float<false>, 
-            policies::promote_double<false>, 
+            Policy,
+            policies::promote_float<false>,
+            policies::promote_double<false>,
             policies::discrete_quantile<>,
             policies::assert_undefined<> >::type forwarding_policy;
          RealType v = dist.degrees_of_freedom();
@@ -987,7 +987,7 @@ namespace boost
                return (RealType)r;
          if(v <= 3)
             return policies::raise_domain_error<RealType>(
-               function, 
+               function,
                "The non-central t distribution has no defined skewness for degrees of freedom <= 3: got v=%1%.", v, Policy());;
          return policies::checked_narrowing_cast<RealType, forwarding_policy>(
             detail::skewness(static_cast<value_type>(v), static_cast<value_type>(l), forwarding_policy()), function);
@@ -995,13 +995,13 @@ namespace boost
 
       template <class RealType, class Policy>
       inline RealType kurtosis_excess(const non_central_t_distribution<RealType, Policy>& dist)
-      { 
+      {
          const char* function = "kurtosis_excess(const non_central_t_distribution<%1%>&)";
          typedef typename policies::evaluation<RealType, Policy>::type value_type;
          typedef typename policies::normalise<
-            Policy, 
-            policies::promote_float<false>, 
-            policies::promote_double<false>, 
+            Policy,
+            policies::promote_float<false>,
+            policies::promote_double<false>,
             policies::discrete_quantile<>,
             policies::assert_undefined<> >::type forwarding_policy;
          RealType v = dist.degrees_of_freedom();
@@ -1019,7 +1019,7 @@ namespace boost
                return (RealType)r;
          if(v <= 4)
             return policies::raise_domain_error<RealType>(
-               function, 
+               function,
                "The non-central t distribution has no defined kurtosis for degrees of freedom <= 4: got v=%1%.", v, Policy());;
          return policies::checked_narrowing_cast<RealType, forwarding_policy>(
             detail::kurtosis_excess(static_cast<value_type>(v), static_cast<value_type>(l), forwarding_policy()), function);
@@ -1037,9 +1037,9 @@ namespace boost
          const char* function = "pdf(non_central_t_distribution<%1%>, %1%)";
          typedef typename policies::evaluation<RealType, Policy>::type value_type;
          typedef typename policies::normalise<
-            Policy, 
-            policies::promote_float<false>, 
-            policies::promote_double<false>, 
+            Policy,
+            policies::promote_float<false>,
+            policies::promote_double<false>,
             policies::discrete_quantile<>,
             policies::assert_undefined<> >::type forwarding_policy;
 
@@ -1063,23 +1063,23 @@ namespace boost
             Policy()))
                return (RealType)r;
          return policies::checked_narrowing_cast<RealType, forwarding_policy>(
-            detail::non_central_t_pdf(static_cast<value_type>(v), 
-               static_cast<value_type>(l), 
-               static_cast<value_type>(t), 
+            detail::non_central_t_pdf(static_cast<value_type>(v),
+               static_cast<value_type>(l),
+               static_cast<value_type>(t),
                Policy()),
             function);
       } // pdf
 
       template <class RealType, class Policy>
       RealType cdf(const non_central_t_distribution<RealType, Policy>& dist, const RealType& x)
-      { 
+      {
          const char* function = "boost::math::cdf(non_central_t_distribution<%1%>&, %1%)";
 //   was const char* function = "boost::math::non_central_t_distribution<%1%>::cdf(%1%)";
          typedef typename policies::evaluation<RealType, Policy>::type value_type;
          typedef typename policies::normalise<
-            Policy, 
-            policies::promote_float<false>, 
-            policies::promote_double<false>, 
+            Policy,
+            policies::promote_float<false>,
+            policies::promote_double<false>,
             policies::discrete_quantile<>,
             policies::assert_undefined<> >::type forwarding_policy;
 
@@ -1104,7 +1104,7 @@ namespace boost
                return (RealType)r;
           if ((boost::math::isinf)(v))
           { // Infinite degrees of freedom, so use normal distribution located at delta.
-             normal_distribution<RealType, Policy> n(l, 1); 
+             normal_distribution<RealType, Policy> n(l, 1);
              cdf(n, x);
               //return cdf(normal_distribution<RealType, Policy>(l, 1), x);
           }
@@ -1115,9 +1115,9 @@ namespace boost
          }
          return policies::checked_narrowing_cast<RealType, forwarding_policy>(
             detail::non_central_t_cdf(
-               static_cast<value_type>(v), 
-               static_cast<value_type>(l), 
-               static_cast<value_type>(x), 
+               static_cast<value_type>(v),
+               static_cast<value_type>(l),
+               static_cast<value_type>(x),
                false, Policy()),
             function);
       } // cdf
@@ -1129,9 +1129,9 @@ namespace boost
          const char* function = "boost::math::cdf(const complement(non_central_t_distribution<%1%>&), %1%)";
          typedef typename policies::evaluation<RealType, Policy>::type value_type;
          typedef typename policies::normalise<
-            Policy, 
-            policies::promote_float<false>, 
-            policies::promote_double<false>, 
+            Policy,
+            policies::promote_float<false>,
+            policies::promote_double<false>,
             policies::discrete_quantile<>,
             policies::assert_undefined<> >::type forwarding_policy;
 
@@ -1159,7 +1159,7 @@ namespace boost
 
          if ((boost::math::isinf)(v))
          { // Infinite degrees of freedom, so use normal distribution located at delta.
-             normal_distribution<RealType, Policy> n(l, 1); 
+             normal_distribution<RealType, Policy> n(l, 1);
              return cdf(complement(n, x));
          }
          if(l == 0)
@@ -1168,9 +1168,9 @@ namespace boost
          }
          return policies::checked_narrowing_cast<RealType, forwarding_policy>(
             detail::non_central_t_cdf(
-               static_cast<value_type>(v), 
-               static_cast<value_type>(l), 
-               static_cast<value_type>(x), 
+               static_cast<value_type>(v),
+               static_cast<value_type>(l),
+               static_cast<value_type>(x),
                true, Policy()),
             function);
       } // ccdf

--- a/include/boost/math/distributions/skew_normal.hpp
+++ b/include/boost/math/distributions/skew_normal.hpp
@@ -70,17 +70,17 @@ namespace boost{ namespace math{
     }
 
     RealType location()const
-    { 
+    {
       return location_;
     }
 
     RealType scale()const
-    { 
+    {
       return scale_;
     }
 
     RealType shape()const
-    { 
+    {
       return shape_;
     }
 
@@ -110,7 +110,7 @@ namespace boost{ namespace math{
   { // Range of permissible values for random variable x.
     using boost::math::tools::max_value;
     return std::pair<RealType, RealType>(
-       std::numeric_limits<RealType>::has_infinity ? -std::numeric_limits<RealType>::infinity() : -max_value<RealType>(), 
+       std::numeric_limits<RealType>::has_infinity ? -std::numeric_limits<RealType>::infinity() : -max_value<RealType>(),
        std::numeric_limits<RealType>::has_infinity ? std::numeric_limits<RealType>::infinity() : max_value<RealType>()); // - to + max value.
   }
 
@@ -310,7 +310,7 @@ namespace boost{ namespace math{
     /*
       TODO No closed expression for mode, so use max of pdf.
     */
-    
+
     template <class RealType, class Policy>
     inline RealType mode_fallback(const skew_normal_distribution<RealType, Policy>& dist)
     { // mode.
@@ -318,7 +318,7 @@ namespace boost{ namespace math{
         const RealType scale = dist.scale();
         const RealType location = dist.location();
         const RealType shape = dist.shape();
-        
+
         RealType result;
         if(!detail::check_scale(
           function,
@@ -343,7 +343,7 @@ namespace boost{ namespace math{
           result = location-scale*result;
           return result;
         }
-        
+
         BOOST_MATH_STD_USING
 
         // 21 elements
@@ -398,9 +398,9 @@ namespace boost{ namespace math{
         const RealType* result_ptr = std::lower_bound(shapes, shapes+21, shape);
 
         typedef typename std::iterator_traits<RealType*>::difference_type diff_type;
-        
+
         const diff_type d = std::distance(shapes, result_ptr);
-        
+
         BOOST_MATH_ASSERT(d > static_cast<diff_type>(0));
 
         // refine
@@ -416,21 +416,21 @@ namespace boost{ namespace math{
         }
 
         skew_normal_distribution<RealType, Policy> helper(0, 1, shape);
-        
+
         result = detail::generic_find_mode_01(helper, result, function);
-        
+
         result = result*scale + location;
-        
+
         return result;
     } // mode_fallback
-    
-    
+
+
     /*
      * TODO No closed expression for mode, so use f'(x) = 0
      */
     template <class RealType, class Policy>
     struct skew_normal_mode_functor
-    { 
+    {
       skew_normal_mode_functor(const boost::math::skew_normal_distribution<RealType, Policy> dist)
         : distribution(dist)
       {
@@ -451,9 +451,9 @@ namespace boost{ namespace math{
     private:
       const boost::math::skew_normal_distribution<RealType, Policy> distribution;
     };
-    
+
   } // namespace detail
-  
+
   template <class RealType, class Policy>
   inline RealType mode(const skew_normal_distribution<RealType, Policy>& dist)
   {
@@ -537,9 +537,9 @@ namespace boost{ namespace math{
     const RealType* result_ptr = std::lower_bound(shapes, shapes+21, shape);
 
     typedef typename std::iterator_traits<RealType*>::difference_type diff_type;
-    
+
     const diff_type d = std::distance(shapes, result_ptr);
-    
+
     BOOST_MATH_ASSERT(d > static_cast<diff_type>(0));
 
     // TODO: make the search bounds smarter, depending on the shape parameter
@@ -559,22 +559,22 @@ namespace boost{ namespace math{
       result = 1e-4f;
       search_max = guess[19]; // set 19 instead of 20 to have a safety margin because the table may not be exact @ shape=100
     }
-    
-    const int get_digits = policies::digits<RealType, Policy>();// get digits from policy, 
+
+    const int get_digits = policies::digits<RealType, Policy>();// get digits from policy,
     std::uintmax_t m = policies::get_max_root_iterations<Policy>(); // and max iterations.
 
     skew_normal_distribution<RealType, Policy> helper(0, 1, shape);
 
     result = tools::newton_raphson_iterate(detail::skew_normal_mode_functor<RealType, Policy>(helper), result,
       search_min, search_max, get_digits, m);
-    
+
     result = result*scale + location;
 
     return result;
   }
-  
 
-  
+
+
   template <class RealType, class Policy>
   inline RealType skewness(const skew_normal_distribution<RealType, Policy>& dist)
   {
@@ -584,8 +584,8 @@ namespace boost{ namespace math{
     static const RealType factor = four_minus_pi<RealType>()/static_cast<RealType>(2);
     const RealType delta = dist.shape() / sqrt(static_cast<RealType>(1)+dist.shape()*dist.shape());
 
-    return factor * pow(root_two_div_pi<RealType>() * delta, 3) /
-      pow(static_cast<RealType>(1)-two_div_pi<RealType>()*delta*delta, static_cast<RealType>(1.5));
+    return static_cast<RealType>(factor * pow(root_two_div_pi<RealType>() * delta, 3) /
+      pow(static_cast<RealType>(1)-two_div_pi<RealType>()*delta*delta, static_cast<RealType>(1.5)));
   }
 
   template <class RealType, class Policy>
@@ -614,7 +614,7 @@ namespace boost{ namespace math{
 
     template <class RealType, class Policy>
     struct skew_normal_quantile_functor
-    { 
+    {
       skew_normal_quantile_functor(const boost::math::skew_normal_distribution<RealType, Policy> dist, RealType const& p)
         : distribution(dist), prob(p)
       {
@@ -630,7 +630,7 @@ namespace boost{ namespace math{
       }
     private:
       const boost::math::skew_normal_distribution<RealType, Policy> distribution;
-      RealType prob; 
+      RealType prob;
     };
 
   } // namespace detail
@@ -679,7 +679,7 @@ namespace boost{ namespace math{
     const RealType search_min = range(dist).first;
     const RealType search_max = range(dist).second;
 
-    const int get_digits = policies::digits<RealType, Policy>();// get digits from policy, 
+    const int get_digits = policies::digits<RealType, Policy>();// get digits from policy,
     std::uintmax_t m = policies::get_max_root_iterations<Policy>(); // and max iterations.
 
     result = tools::newton_raphson_iterate(detail::skew_normal_quantile_functor<RealType, Policy>(dist, p), result,

--- a/include/boost/math/interpolators/detail/bilinear_uniform_detail.hpp
+++ b/include/boost/math/interpolators/detail/bilinear_uniform_detail.hpp
@@ -70,15 +70,15 @@ public:
             std::cerr << __FILE__ << ":" << __LINE__ << ":" << __func__ << "\n";
             std::cerr << "Querying the bilinear_uniform interpolator at (x,y) = (" << x << ", " << y << ") is not allowed.\n";
             std::cerr << "y must lie in the interval [" << y0_ << ", " << y0_ + (rows_ -1)*dy_ << "]\n";
-            return std::numeric_limits<Real>::quiet_NaN(); 
+            return std::numeric_limits<Real>::quiet_NaN();
         }
 
         Real s = (x - x0_)/dx_;
         Real s0 = floor(s);
         Real t = (y - y0_)/dy_;
         Real t0 = floor(t);
-        Z xidx = s0;
-        Z yidx = t0;
+        auto xidx = static_cast<Z>(s0);
+        auto yidx = static_cast<Z>(t0);
         Z idx = yidx*cols_  + xidx;
         Real alpha = s - s0;
         Real beta = t - t0;

--- a/include/boost/math/interpolators/detail/cardinal_quadratic_b_spline_detail.hpp
+++ b/include/boost/math/interpolators/detail/cardinal_quadratic_b_spline_detail.hpp
@@ -154,8 +154,8 @@ public:
         using std::floor;
         using std::ceil;
         Real x = (t-m_t0)*m_inv_h;
-        size_t j_min = ceil(x - Real(1)/Real(2));
-        size_t j_max = ceil(x + Real(5)/Real(2));
+        auto j_min = static_cast<size_t>(ceil(x - Real(1)/Real(2)));
+        auto j_max = static_cast<size_t>(ceil(x + Real(5)/Real(2)));
         if (j_max >= m_alpha.size()) {
             j_max = m_alpha.size() - 1;
         }
@@ -180,8 +180,8 @@ public:
         using std::floor;
         using std::ceil;
         Real x = (t-m_t0)*m_inv_h;
-        size_t j_min = ceil(x - Real(1)/Real(2));
-        size_t j_max = ceil(x + Real(5)/Real(2));
+        auto j_min = static_cast<size_t>(ceil(x - Real(1)/Real(2)));
+        auto j_max = static_cast<size_t>(ceil(x + Real(5)/Real(2)));
         if (j_max >= m_alpha.size()) {
             j_max = m_alpha.size() - 1;
         }

--- a/include/boost/math/interpolators/detail/whittaker_shannon_detail.hpp
+++ b/include/boost/math/interpolators/detail/whittaker_shannon_detail.hpp
@@ -40,7 +40,6 @@ public:
         auto end = m_y.end();
         while(it != end)
         {
-
             y += *it++/z;
             z -= 1;
         }
@@ -48,7 +47,7 @@ public:
         if (!isfinite(y))
         {
             BOOST_MATH_ASSERT_MSG(floor(x) == ceil(x), "Floor and ceiling should be equal.\n");
-            size_t i = static_cast<size_t>(floor(x));
+            auto i = static_cast<size_t>(floor(x));
             if (i & 1)
             {
                 return -m_y[i];
@@ -66,8 +65,8 @@ public:
         Real x = (t - m_t0)/m_h;
         if (ceil(x) == x) {
             Real s = 0;
-            long j = static_cast<long>(x);
-            long n = m_y.size();
+            auto j = static_cast<long>(x);
+            auto n = static_cast<long>(m_y.size());
             for (long i = 0; i < n; ++i)
             {
                 if (j - i != 0)

--- a/include/boost/math/special_functions/bernoulli.hpp
+++ b/include/boost/math/special_functions/bernoulli.hpp
@@ -15,8 +15,8 @@
 #include <boost/math/special_functions/detail/unchecked_bernoulli.hpp>
 #include <boost/math/special_functions/detail/bernoulli_details.hpp>
 
-namespace boost { namespace math { 
-   
+namespace boost { namespace math {
+
 namespace detail {
 
 template <class T, class OutputIterator, class Policy, int N>
@@ -27,7 +27,7 @@ OutputIterator bernoulli_number_imp(OutputIterator out, std::size_t start, std::
       *out = unchecked_bernoulli_imp<T>(i, tag);
       ++out;
    }
-   
+
    for(std::size_t i = (std::max)(static_cast<std::size_t>(max_bernoulli_b2n<T>::value + 1), start); i < start + n; ++i)
    {
       // We must overflow:
@@ -49,7 +49,9 @@ OutputIterator bernoulli_number_imp(OutputIterator out, std::size_t start, std::
    // Short circuit return so we don't grab the mutex below unless we have to:
    //
    if(start + n <= max_bernoulli_b2n<T>::value)
+   {
       return out;
+   }
 
    return get_bernoulli_numbers_cache<T, Policy>().copy_bernoulli_numbers(out, start, n, pol);
 }
@@ -59,11 +61,13 @@ OutputIterator bernoulli_number_imp(OutputIterator out, std::size_t start, std::
 template <class T, class Policy>
 inline T bernoulli_b2n(const int i, const Policy &pol)
 {
-   typedef std::integral_constant<int, detail::bernoulli_imp_variant<T>::value> tag_type;
+   using tag_type = std::integral_constant<int, detail::bernoulli_imp_variant<T>::value>;
    if(i < 0)
+   {
       return policies::raise_domain_error<T>("boost::math::bernoulli_b2n<%1%>", "Index should be >= 0 but got %1%", T(i), pol);
+   }
 
-   T result = static_cast<T>(0); // The = 0 is just to silence compiler warnings :-(
+   T result {};
    boost::math::detail::bernoulli_number_imp<T>(&result, static_cast<std::size_t>(i), 1u, pol, tag_type());
    return result;
 }
@@ -80,7 +84,7 @@ inline OutputIterator bernoulli_b2n(const int start_index,
                                     OutputIterator out_it,
                                     const Policy& pol)
 {
-   typedef std::integral_constant<int, detail::bernoulli_imp_variant<T>::value> tag_type;
+   using tag_type = std::integral_constant<int, detail::bernoulli_imp_variant<T>::value>;
    if(start_index < 0)
    {
       *out_it = policies::raise_domain_error<T>("boost::math::bernoulli_b2n<%1%>", "Index should be >= 0 but got %1%", T(start_index), pol);
@@ -102,9 +106,11 @@ template <class T, class Policy>
 inline T tangent_t2n(const int i, const Policy &pol)
 {
    if(i < 0)
+   {
       return policies::raise_domain_error<T>("boost::math::tangent_t2n<%1%>", "Index should be >= 0 but got %1%", T(i), pol);
+   }
 
-   T result;
+   T result {};
    boost::math::detail::get_bernoulli_numbers_cache<T, Policy>().copy_tangent_numbers(&result, i, 1, pol);
    return result;
 }

--- a/include/boost/math/special_functions/chebyshev.hpp
+++ b/include/boost/math/special_functions/chebyshev.hpp
@@ -22,8 +22,8 @@
 
 namespace boost { namespace math {
 
-template<class T1, class T2, class T3>
-inline typename tools::promote_args<T1, T2, T3>::type chebyshev_next(T1 const & x, T2 const & Tn, T3 const & Tn_1)
+template <class T1, class T2, class T3>
+inline tools::promote_args_t<T1, T2, T3> chebyshev_next(T1 const & x, T2 const & Tn, T3 const & Tn_1)
 {
     return 2*x*Tn - Tn_1;
 }
@@ -45,12 +45,13 @@ inline Real chebyshev_imp(unsigned n, Real const & x, const Policy&)
     using std::sqrt;
     Real T0 = 1;
     Real T1;
-    if (second)
+
+    BOOST_IF_CONSTEXPR (second)
     {
         if (x > 1 || x < -1)
         {
             Real t = sqrt(x*x -1);
-            return static_cast<Real>((pow(x+t, (int)(n+1)) - pow(x-t, (int)(n+1)))/(2*t));
+            return static_cast<Real>((pow(x+t, static_cast<int>(n+1)) - pow(x-t, static_cast<int>(n+1)))/(2*t));
         }
         T1 = 2*x;
     }
@@ -91,61 +92,58 @@ inline Real chebyshev_imp(unsigned n, Real const & x, const Policy&)
 } // namespace detail
 
 template <class Real, class Policy>
-inline typename tools::promote_args<Real>::type
-chebyshev_t(unsigned n, Real const & x, const Policy&)
+inline tools::promote_args_t<Real> chebyshev_t(unsigned n, Real const & x, const Policy&)
 {
-   typedef typename tools::promote_args<Real>::type result_type;
-   typedef typename policies::evaluation<result_type, Policy>::type value_type;
-   typedef typename policies::normalise<
-      Policy,
-      policies::promote_float<false>,
-      policies::promote_double<false>,
-      policies::discrete_quantile<>,
-      policies::assert_undefined<> >::type forwarding_policy;
+   using result_type = tools::promote_args_t<Real>;
+   using value_type = typename policies::evaluation<result_type, Policy>::type;
+   using forwarding_policy = typename policies::normalise<
+                                                            Policy,
+                                                            policies::promote_float<false>,
+                                                            policies::promote_double<false>,
+                                                            policies::discrete_quantile<>,
+                                                            policies::assert_undefined<> >::type;
 
    return policies::checked_narrowing_cast<result_type, Policy>(detail::chebyshev_imp<value_type, false>(n, static_cast<value_type>(x), forwarding_policy()), "boost::math::chebyshev_t<%1%>(unsigned, %1%)");
 }
 
-template<class Real>
-inline typename tools::promote_args<Real>::type chebyshev_t(unsigned n, Real const & x)
+template <class Real>
+inline tools::promote_args_t<Real> chebyshev_t(unsigned n, Real const & x)
 {
     return chebyshev_t(n, x, policies::policy<>());
 }
 
 template <class Real, class Policy>
-inline typename tools::promote_args<Real>::type
-chebyshev_u(unsigned n, Real const & x, const Policy&)
+inline tools::promote_args_t<Real> chebyshev_u(unsigned n, Real const & x, const Policy&)
 {
-   typedef typename tools::promote_args<Real>::type result_type;
-   typedef typename policies::evaluation<result_type, Policy>::type value_type;
-   typedef typename policies::normalise<
-      Policy,
-      policies::promote_float<false>,
-      policies::promote_double<false>,
-      policies::discrete_quantile<>,
-      policies::assert_undefined<> >::type forwarding_policy;
+   using result_type = tools::promote_args_t<Real>;
+   using value_type = typename policies::evaluation<result_type, Policy>::type;
+   using forwarding_policy =  typename policies::normalise<
+                                                            Policy,
+                                                            policies::promote_float<false>,
+                                                            policies::promote_double<false>,
+                                                            policies::discrete_quantile<>,
+                                                            policies::assert_undefined<> >::type;
 
    return policies::checked_narrowing_cast<result_type, Policy>(detail::chebyshev_imp<value_type, true>(n, static_cast<value_type>(x), forwarding_policy()), "boost::math::chebyshev_u<%1%>(unsigned, %1%)");
 }
 
-template<class Real>
-inline typename tools::promote_args<Real>::type chebyshev_u(unsigned n, Real const & x)
+template <class Real>
+inline tools::promote_args_t<Real> chebyshev_u(unsigned n, Real const & x)
 {
     return chebyshev_u(n, x, policies::policy<>());
 }
 
 template <class Real, class Policy>
-inline typename tools::promote_args<Real>::type
-chebyshev_t_prime(unsigned n, Real const & x, const Policy&)
+inline tools::promote_args_t<Real> chebyshev_t_prime(unsigned n, Real const & x, const Policy&)
 {
-   typedef typename tools::promote_args<Real>::type result_type;
-   typedef typename policies::evaluation<result_type, Policy>::type value_type;
-   typedef typename policies::normalise<
-      Policy,
-      policies::promote_float<false>,
-      policies::promote_double<false>,
-      policies::discrete_quantile<>,
-      policies::assert_undefined<> >::type forwarding_policy;
+   using result_type = tools::promote_args_t<Real>;
+   using value_type = typename policies::evaluation<result_type, Policy>::type;
+   using forwarding_policy = typename policies::normalise<
+                                                            Policy,
+                                                            policies::promote_float<false>,
+                                                            policies::promote_double<false>,
+                                                            policies::discrete_quantile<>,
+                                                            policies::assert_undefined<> >::type;
    if (n == 0)
    {
       return result_type(0);
@@ -153,8 +151,8 @@ chebyshev_t_prime(unsigned n, Real const & x, const Policy&)
    return policies::checked_narrowing_cast<result_type, Policy>(n * detail::chebyshev_imp<value_type, true>(n - 1, static_cast<value_type>(x), forwarding_policy()), "boost::math::chebyshev_t_prime<%1%>(unsigned, %1%)");
 }
 
-template<class Real>
-inline typename tools::promote_args<Real>::type chebyshev_t_prime(unsigned n, Real const & x)
+template <class Real>
+inline tools::promote_args_t<Real> chebyshev_t_prime(unsigned n, Real const & x)
 {
    return chebyshev_t_prime(n, x, policies::policy<>());
 }
@@ -167,7 +165,7 @@ inline typename tools::promote_args<Real>::type chebyshev_t_prime(unsigned n, Re
  * https://www.siam.org/books/ot99/OT99SampleChapter.pdf
  * However, our definition of c0 differs by a factor of 1/2, as stated in the docs. . .
  */
-template<class Real, class T2>
+template <class Real, class T2>
 inline Real chebyshev_clenshaw_recurrence(const Real* const c, size_t length, const T2& x)
 {
     using boost::math::constants::half;
@@ -193,7 +191,7 @@ inline Real chebyshev_clenshaw_recurrence(const Real* const c, size_t length, co
 
 
 namespace detail {
-template<class Real>
+template <class Real>
 inline Real unchecked_chebyshev_clenshaw_recurrence(const Real* const c, size_t length, const Real & a, const Real & b, const Real& x)
 {
     Real t;
@@ -221,16 +219,16 @@ inline Real unchecked_chebyshev_clenshaw_recurrence(const Real* const c, size_t 
         }
         else
         {
-            Real b = c[length -1];
-            Real d = b;
+            Real b1 = c[length - 1];
+            Real d = b1;
             Real b2 = 0;
             for (size_t r = length - 2; r >= 1; --r)
             {
-                d = 2*u*b - d + c[r];
-                b2 = b;
-                b = d - b;
+                d = 2*u*b1 - d + c[r];
+                b2 = b1;
+                b1 = d - b1;
             }
-            return t*b - b2 + c[0]/2;
+            return t*b1 - b2 + c[0]/2;
         }
     }
     else
@@ -251,23 +249,23 @@ inline Real unchecked_chebyshev_clenshaw_recurrence(const Real* const c, size_t 
         }
         else
         {
-            Real b = c[length -1];
-            Real d = b;
+            Real b1 = c[length - 1];
+            Real d = b1;
             Real b2 = 0;
             for (size_t r = length - 2; r >= 1; --r)
             {
-                d = 2*u*b + d + c[r];
-                b2 = b;
-                b = d + b;
+                d = 2*u*b1 + d + c[r];
+                b2 = b1;
+                b1 = d + b1;
             }
-            return t*b - b2 + c[0]/2;
+            return t*b1 - b2 + c[0]/2;
         }
     }
 }
 
 } // namespace detail
 
-template<class Real>
+template <class Real>
 inline Real chebyshev_clenshaw_recurrence(const Real* const c, size_t length, const Real & a, const Real & b, const Real& x)
 {
     if (x < a || x > b)
@@ -285,6 +283,6 @@ inline Real chebyshev_clenshaw_recurrence(const Real* const c, size_t length, co
     return detail::unchecked_chebyshev_clenshaw_recurrence(c, length, a, b, x);
 }
 
+}} // Namespace boost::math
 
-}}
-#endif
+#endif // BOOST_MATH_SPECIAL_CHEBYSHEV_HPP

--- a/include/boost/math/special_functions/daubechies_wavelet.hpp
+++ b/include/boost/math/special_functions/daubechies_wavelet.hpp
@@ -72,25 +72,25 @@ namespace boost::math {
       //
       // Some type manipulation so we know the type of the interpolator, and the vector type it requires:
       //
-      typedef std::vector < std::array < Real, p < 6 ? 2 : p < 10 ? 3 : 4>> vector_type;
+      using vector_type = std::vector < std::array < Real, p < 6 ? 2 : p < 10 ? 3 : 4>>;
       //
       // List our interpolators:
       //
-      typedef std::tuple<
+      using interpolator_list = std::tuple<
          detail::null_interpolator, detail::matched_holder_aos<vector_type>, detail::linear_interpolation_aos<vector_type>,
          interpolators::detail::cardinal_cubic_hermite_detail_aos<vector_type>, interpolators::detail::cardinal_quintic_hermite_detail_aos<vector_type>,
-         interpolators::detail::cardinal_septic_hermite_detail_aos<vector_type> > interpolator_list;
+         interpolators::detail::cardinal_septic_hermite_detail_aos<vector_type> > ;
       //
       // Select the one we need:
       //
-      typedef std::tuple_element_t<
+      using interpolator_type = std::tuple_element_t<
          p == 1 ? 0 :
          p == 2 ? 1 :
          p == 3 ? 2 :
          p <= 5 ? 3 :
-         p <= 9 ? 4 : 5, interpolator_list> interpolator_type;
+         p <= 9 ? 4 : 5, interpolator_list>;
    public:
-      daubechies_wavelet(int grid_refinements = -1)
+      explicit daubechies_wavelet(int grid_refinements = -1)
       {
          static_assert(p < 20, "Daubechies wavelets are only implemented for p < 20.");
          static_assert(p > 0, "Daubechies wavelets must have at least 1 vanishing moment.");
@@ -106,7 +106,7 @@ namespace boost::math {
          {
             if (grid_refinements < 0)
             {
-               if (std::is_same_v<Real, float>)
+               if constexpr (std::is_same_v<Real, float>)
                {
                   if (grid_refinements == -2)
                   {
@@ -123,7 +123,7 @@ namespace boost::math {
                      grid_refinements = r[p];
                   }
                }
-               else if (std::is_same_v<Real, double>)
+               else if constexpr (std::is_same_v<Real, double>)
                {
                   //                          p= 2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
                   std::array<int, 20> r{ -1, -1, 21, 21, 21, 21, 21, 21, 21, 21, 20, 20, 19, 18, 18, 18, 18, 18, 18, 18 };
@@ -200,6 +200,7 @@ namespace boost::math {
          {
             return 0;
          }
+
          if constexpr (p == 1)
          {
             if (x < Real(1) / Real(2))
@@ -212,7 +213,10 @@ namespace boost::math {
             }
             return -1;
          }
-         return (*m_interpolator)(x);
+         else
+         {
+            return (*m_interpolator)(x);
+         }
       }
 
       inline Real prime(Real x) const
@@ -237,7 +241,7 @@ namespace boost::math {
 
       std::pair<Real, Real> support() const
       {
-         return { Real(-p + 1), Real(p) };
+         return std::make_pair(Real(-p + 1), Real(p));
       }
 
       int64_t bytes() const
@@ -250,4 +254,5 @@ namespace boost::math {
    };
 
 }
-#endif
+
+#endif // BOOST_MATH_SPECIAL_DAUBECHIES_WAVELET_HPP

--- a/include/boost/math/tools/cohen_acceleration.hpp
+++ b/include/boost/math/tools/cohen_acceleration.hpp
@@ -12,7 +12,7 @@
 namespace boost::math::tools {
 
 // Algorithm 1 of https://people.mpim-bonn.mpg.de/zagier/files/exp-math-9/fulltext.pdf
-// Convergence Acceleration of Alternating Series: Henri Cohen, Fernando Rodriguez Villegas, and Don Zagier    
+// Convergence Acceleration of Alternating Series: Henri Cohen, Fernando Rodriguez Villegas, and Don Zagier
 template<class G>
 auto cohen_acceleration(G& generator, std::int64_t n = -1)
 {
@@ -23,16 +23,16 @@ auto cohen_acceleration(G& generator, std::int64_t n = -1)
     using std::pow;
     using std::ceil;
     using std::sqrt;
-    Real n_ = n;
+    auto n_ = static_cast<Real>(n);
     if (n < 0)
     {
         // relative error grows as 2*5.828^-n; take 5.828^-n < eps/4 => -nln(5.828) < ln(eps/4) => n > ln(4/eps)/ln(5.828).
         // Is there a way to do it rapidly with std::log2? (Yes, of course; but for primitive types it's computed at compile-time anyway.)
-        n_ = ceil(log(4/std::numeric_limits<Real>::epsilon())*0.5672963285532555);
+        n_ = static_cast<Real>(ceil(log(4/std::numeric_limits<Real>::epsilon())*0.5672963285532555));
         n = static_cast<std::int64_t>(n_);
     }
     // d can get huge and overflow if you pick n too large:
-    Real d = pow(3 + sqrt(Real(8)), n);
+    auto d = static_cast<Real>(pow(3 + sqrt(Real(8)), n));
     d = (d + 1/d)/2;
     Real b = -1;
     Real c = -d;


### PR DESCRIPTION
Primarily unreachable code, and changing implicit conversions from floating point to int and vice versa to be explicit. As always addressed viable sonarlint comments while in the file.