### PR TITLE
Fix right endpoint derivative estimate error in cardinal cubic b spline

### DIFF
--- a/include/boost/math/interpolators/detail/cardinal_cubic_b_spline_detail.hpp
+++ b/include/boost/math/interpolators/detail/cardinal_cubic_b_spline_detail.hpp
@@ -159,8 +159,8 @@ cardinal_cubic_b_spline_imp<Real>::cardinal_cubic_b_spline_imp(BidiIterator f, B
     if (boost::math::isnan(b1))
     {
         size_t n = length - 1;
-        Real t0 = 4*(f[n-3] + third<Real>()*f[n - 1]);
-        Real t1 = -(25*third<Real>()*f[n - 4] + f[n])/4  - 3*f[n - 2];
+        Real t0 = -4*(f[n - 1] + third<Real>()*f[n - 3]);
+        Real t1 = (25*third<Real>()*f[n] + f[n - 4])/4  + 3*f[n - 2];
 
         b1 = m_h_inv*(t0 + t1);
     }


### PR DESCRIPTION
There is a bug in the current right endpoint derivative calculation for the `cardinal_cubic_b_spline` class, which this PR should now fix. The issue was that the signs of the forward finite difference coeffs were not flipped when applying to backwards finite difference at right endpoint, and these coefficients were incorrectly applied in reverse order.

I also added a test to verify these changes, based on the use-case (interpolation of cross-section of spherical conic section) where I first noticed this bug.