### PR TITLE
Corrected paths for cubic and quartic roots headers in doc

### DIFF
--- a/doc/roots/cubic_roots.qbk
+++ b/doc/roots/cubic_roots.qbk
@@ -10,7 +10,7 @@ LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 [heading Synopsis]
 
 ```
-#include <boost/math/roots/cubic_roots.hpp>
+#include <boost/math/tools/cubic_roots.hpp>
 
 namespace boost::math::tools {
 

--- a/doc/roots/quartic_roots.qbk
+++ b/doc/roots/quartic_roots.qbk
@@ -10,7 +10,7 @@ LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 [heading Synopsis]
 
 ```
-#include <boost/math/roots/quartic_roots.hpp>
+#include <boost/math/tools/quartic_roots.hpp>
 
 namespace boost::math::tools {
 


### PR DESCRIPTION
The current documentation lists `cubic_roots.hpp` and `quartic_roots.hpp` as located in `boost/math/`**`roots/`**, however, they are now both located in `boost/math/`**`tools`**.

It appears that these two doc files are the only ones affected. Checked with `grep -rn "roots/" . | grep -v "doc/roots"` in the `libs/math/doc/roots` directory.