### PR TITLE
Don't inline is_value_non_zero () to be evaluated at runtime.

### DIFF
--- a/include/boost/math/special_functions/detail/erf_inv.hpp
+++ b/include/boost/math/special_functions/detail/erf_inv.hpp
@@ -13,6 +13,7 @@
 #pragma warning(disable:4702) // Unreachable code: optimization warning
 #endif
 
+#include <boost/config.hpp>
 #include <type_traits>
 
 namespace boost{ namespace math{
@@ -384,7 +385,7 @@ template <class T, class Policy>
 const typename erf_inv_initializer<T, Policy>::init erf_inv_initializer<T, Policy>::initializer;
 
 template <class T, class Policy>
-bool erf_inv_initializer<T, Policy>::init::is_value_non_zero(T v)
+BOOST_NOINLINE bool erf_inv_initializer<T, Policy>::init::is_value_non_zero(T v)
 {
    // This needs to be non-inline to detect whether v is non zero at runtime
    // rather than at compile time, only relevant when running under valgrind


### PR DESCRIPTION
I'm compiling a program using boost math (1.79.0) with gcc 7.3.1. When I run the program with Valgrind, I have an overflow exception at startup. The following patch fixes the issue.