### PR TITLE
Improve ccmath signbit and copysign

### DIFF
--- a/include/boost/math/ccmath/signbit.hpp
+++ b/include/boost/math/ccmath/signbit.hpp
@@ -7,6 +7,7 @@
 #define BOOST_MATH_CCMATH_SIGNBIT_HPP
 
 #include <cmath>
+#include <cstdint>
 #include <limits>
 #include <type_traits>
 #include <boost/math/tools/is_constant_evaluated.hpp>
@@ -51,81 +52,84 @@ namespace detail {
 struct IEEEf2bits
 {
 #if BOOST_MATH_ENDIAN_LITTLE_BYTE
-    unsigned mantissa : 23;
-    unsigned exponent : 8;
-    unsigned sign : 1;
+    std::uint32_t mantissa : 23;
+    std::uint32_t exponent : 8;
+    std::uint32_t sign : 1;
 #else // Big endian
-    unsigned sign : 1;
-    unsigned exponent : 8;
-    unsigned mantissa : 23;
+    std::uint32_t sign : 1;
+    std::uint32_t exponent : 8;
+    std::uint32_t mantissa : 23;
 #endif 
 };
 
 struct IEEEd2bits
 {
 #if BOOST_MATH_ENDIAN_LITTLE_BYTE
-    unsigned mantissa_l : 32;
-    unsigned mantissa_h : 20;
-    unsigned exponent : 11;
-    unsigned sign : 1;
+    std::uint32_t mantissa_l : 32;
+    std::uint32_t mantissa_h : 20;
+    std::uint32_t exponent : 11;
+    std::uint32_t sign : 1;
 #else // Big endian
-    unsigned sign : 1;
-    unsigned exponent : 11;
-    unsigned mantissa_h : 20;
-    unsigned mantissa_l : 32;
+    std::uint32_t sign : 1;
+    std::uint32_t exponent : 11;
+    std::uint32_t mantissa_h : 20;
+    std::uint32_t mantissa_l : 32;
 #endif
 };
 
+// 80 bit long double
 #if LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384
 
 struct IEEEl2bits
 {
 #if BOOST_MATH_ENDIAN_LITTLE_BYTE
-    unsigned mantissa_l : 32;
-    unsigned mantissa_h : 32;
-    unsigned exponent : 15;
-    unsigned sign : 1;
-    unsigned pad : 16;
+    std::uint32_t mantissa_l : 32;
+    std::uint32_t mantissa_h : 32;
+    std::uint32_t exponent : 15;
+    std::uint32_t sign : 1;
+    std::uint32_t pad : 32;
 #else // Big endian
-    unsigned pad : 16;
-    unsigned sign : 1;
-    unsigned exponent : 15;
-    unsigned mantissa_h : 32;
-    unsigned mantissa_l : 32;
+    std::uint32_t pad : 32;
+    std::uint32_t sign : 1;
+    std::uint32_t exponent : 15;
+    std::uint32_t mantissa_h : 32;
+    std::uint32_t mantissa_l : 32;
 #endif
 };
 
+// 128 bit long double
 #elif LDBL_MANT_DIG == 113 && LDBL_MAX_EXP == 16384
 
 struct IEEEl2bits
 {
 #if BOOST_MATH_ENDIAN_LITTLE_BYTE
-    unsigned mantissa_l : 64;
-    unsigned mantissa_h : 48;
-    unsigned exponent : 15;
-    unsigned sign : 1;
+    std::uint32_t mantissa_l : 64;
+    std::uint32_t mantissa_h : 48;
+    std::uint32_t exponent : 15;
+    std::uint32_t sign : 1;
 #else // Big endian
-    unsigned sign : 1;
-    unsigned exponent : 15;
-    unsigned mantissa_h : 48;
-    unsigned mantissa_l : 64;
+    std::uint32_t sign : 1;
+    std::uint32_t exponent : 15;
+    std::uint32_t mantissa_h : 48;
+    std::uint32_t mantissa_l : 64;
 #endif
 };
 
+// 64 bit long double (double == long double on ARM)
 #elif LDBL_MANT_DIG == 53 && LDBL_MAX_EXP == 1024
 
 struct IEEEl2bits
 {
 #if BOOST_MATH_ENDIAN_LITTLE_BYTE
-    unsigned mantissa_l : 32;
-    unsigned mantissa_h : 20;
-    unsigned exponent : 11;
-    unsigned sign : 1;
+    std::uint32_t mantissa_l : 32;
+    std::uint32_t mantissa_h : 20;
+    std::uint32_t exponent : 11;
+    std::uint32_t sign : 1;
 #else // Big endian
-    unsigned sign : 1;
-    unsigned exponent : 11;
-    unsigned mantissa_h : 20;
-    unsigned mantissa_l : 32;
+    std::uint32_t sign : 1;
+    std::uint32_t exponent : 11;
+    std::uint32_t mantissa_h : 20;
+    std::uint32_t mantissa_l : 32;
 #endif
 };
 

--- a/include/boost/math/ccmath/signbit.hpp
+++ b/include/boost/math/ccmath/signbit.hpp
@@ -61,6 +61,21 @@ struct float_bits
 #endif 
 };
 
+struct double_bits
+{
+#if BOOST_MATH_ENDIAN_LITTLE_BYTE
+    unsigned mantissa_l : 32;
+    unsigned mantissa_h : 20;
+    unsigned exponent : 11;
+    unsigned sign : 1;
+#else // Big endian
+    unsigned sign : 1;
+    unsigned exponent : 11;
+    unsigned mantissa_h : 20;
+    unsigned mantissa_l : 32;
+#endif
+};
+
 template <typename T>
 constexpr bool signbit_impl(T arg)
 {
@@ -69,13 +84,20 @@ constexpr bool signbit_impl(T arg)
         const auto u = BOOST_MATH_BIT_CAST(float_bits, arg);
         return u.sign;
     }
-
-    if (boost::math::ccmath::isnan(arg))
+    else if constexpr (std::is_same_v<T, double>)
     {
-        return false;
+        const auto u = BOOST_MATH_BIT_CAST(double_bits, arg);
+        return u.sign;
     }
-    
-    return arg < static_cast<T>(0);
+    else
+    {
+        if (boost::math::ccmath::isnan(arg))
+        {
+            return false;
+        }
+        
+        return arg < static_cast<T>(0);
+    }
 }
 
 #else

--- a/include/boost/math/ccmath/signbit.hpp
+++ b/include/boost/math/ccmath/signbit.hpp
@@ -10,16 +10,78 @@
 #include <limits>
 #include <type_traits>
 #include <boost/math/tools/is_constant_evaluated.hpp>
+#include <boost/math/special_functions/detail/fp_traits.hpp>
 #include <boost/math/ccmath/isnan.hpp>
+#include <boost/math/ccmath/abs.hpp>
+
+#if __cpp_lib_bit_cast >= 201806L
+#include <bit>
+#  define BOOST_MATH_BIT_CAST(T, x) std::bit_cast<T>(x)
+#elif __has_builtin(__builtin_bit_cast)
+#  define BOOST_MATH_BIT_CAST(T, x) __builtin_bit_cast(T, x)
+#endif
+
+/*
+The following error is given using Apple Clang version 13.1.6
+TODO: Remove the following undef when Clang supports
+
+ccmath_signbit_test.cpp:32:19: error: static_assert expression is not an integral constant expression
+    static_assert(boost::math::ccmath::signbit(T(-1)) == true);
+                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../../../boost/math/ccmath/signbit.hpp:62:24: note: constexpr bit_cast involving bit-field is not yet supported
+        const auto u = BOOST_MATH_BIT_CAST(float_bits, arg);
+                       ^
+../../../boost/math/ccmath/signbit.hpp:20:37: note: expanded from macro 'BOOST_MATH_BIT_CAST'
+#  define BOOST_MATH_BIT_CAST(T, x) __builtin_bit_cast(T, x)
+                                    ^
+*/
+
+#if defined(__clang__) && defined(BOOST_MATH_BIT_CAST)
+#  undef BOOST_MATH_BIT_CAST
+#endif
 
 namespace boost::math::ccmath {
 
 namespace detail {
 
+#ifdef BOOST_MATH_BIT_CAST
+
+struct float_bits
+{
+#if BOOST_MATH_ENDIAN_LITTLE_BYTE
+    unsigned mantissa : 23;
+    unsigned exponent : 8;
+    unsigned sign : 1;
+#else // Big endian
+    unsigned sign : 1;
+    unsigned exponent : 8;
+    unsigned mantissa : 23;
+#endif 
+};
+
+template <typename T>
+constexpr bool signbit_impl(T arg)
+{
+    if constexpr (std::is_same_v<T, float>)
+    {   
+        const auto u = BOOST_MATH_BIT_CAST(float_bits, arg);
+        return u.sign;
+    }
+
+    if (boost::math::ccmath::isnan(arg))
+    {
+        return false;
+    }
+    
+    return arg < static_cast<T>(0);
+}
+
+#else
+
 // Typical implementations of signbit involve type punning via union and manipulating
 // overflow (see libc++ or musl). Neither of these are allowed in constexpr contexts
 // (technically type punning via union in general is UB in c++ but well defined in C) 
-// therefore NANs and 0s are treated as positive
+// therefore NANs and 0s are treated as positive if bit cast is unavailable
 
 template <typename T>
 constexpr bool signbit_impl(T arg)
@@ -31,6 +93,8 @@ constexpr bool signbit_impl(T arg)
     
     return arg < static_cast<T>(0);
 }
+
+#endif
 
 }
 

--- a/include/boost/math/ccmath/signbit.hpp
+++ b/include/boost/math/ccmath/signbit.hpp
@@ -17,8 +17,10 @@
 #if __cpp_lib_bit_cast >= 201806L
 #include <bit>
 #  define BOOST_MATH_BIT_CAST(T, x) std::bit_cast<T>(x)
-#elif __has_builtin(__builtin_bit_cast)
-#  define BOOST_MATH_BIT_CAST(T, x) __builtin_bit_cast(T, x)
+#elif defined(__has_builtin)
+#  if __has_builtin(__builtin_bit_cast)
+#    define BOOST_MATH_BIT_CAST(T, x) __builtin_bit_cast(T, x)
+#  endif
 #endif
 
 /*

--- a/include/boost/math/ccmath/signbit.hpp
+++ b/include/boost/math/ccmath/signbit.hpp
@@ -103,15 +103,15 @@ struct IEEEl2bits
 struct IEEEl2bits
 {
 #if BOOST_MATH_ENDIAN_LITTLE_BYTE
-    std::uint32_t mantissa_l : 64;
-    std::uint32_t mantissa_h : 48;
+    std::uint64_t mantissa_l : 64;
+    std::uint64_t mantissa_h : 48;
     std::uint32_t exponent : 15;
     std::uint32_t sign : 1;
 #else // Big endian
     std::uint32_t sign : 1;
     std::uint32_t exponent : 15;
-    std::uint32_t mantissa_h : 48;
-    std::uint32_t mantissa_l : 64;
+    std::uint64_t mantissa_h : 48;
+    std::uint64_t mantissa_l : 64;
 #endif
 };
 

--- a/test/ccmath_signbit_test.cpp
+++ b/test/ccmath_signbit_test.cpp
@@ -12,17 +12,14 @@ void test()
 {
     // Edge cases
     #ifdef BOOST_MATH_BIT_CAST
-    if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>)
-    {
-        static_assert(boost::math::ccmath::signbit(T(0)) == false);
-        static_assert(boost::math::ccmath::signbit(T(0)*-1) == true);
+    static_assert(boost::math::ccmath::signbit(T(0)) == false);
+    static_assert(boost::math::ccmath::signbit(T(0)*-1) == true);
 
-        static_assert(boost::math::ccmath::signbit(std::numeric_limits<T>::quiet_NaN()) == false);
-        static_assert(boost::math::ccmath::signbit(-std::numeric_limits<T>::quiet_NaN()) == true);
+    static_assert(boost::math::ccmath::signbit(std::numeric_limits<T>::quiet_NaN()) == false);
+    static_assert(boost::math::ccmath::signbit(-std::numeric_limits<T>::quiet_NaN()) == true);
 
-        static_assert(boost::math::ccmath::signbit(std::numeric_limits<T>::signaling_NaN()) == false);
-        static_assert(boost::math::ccmath::signbit(-std::numeric_limits<T>::signaling_NaN()) == true);
-    }
+    static_assert(boost::math::ccmath::signbit(std::numeric_limits<T>::signaling_NaN()) == false);
+    static_assert(boost::math::ccmath::signbit(-std::numeric_limits<T>::signaling_NaN()) == true);
     #else
     static_assert(boost::math::ccmath::signbit(T(0)) == false);
     static_assert(boost::math::ccmath::signbit(std::numeric_limits<T>::quiet_NaN()) == false);

--- a/test/ccmath_signbit_test.cpp
+++ b/test/ccmath_signbit_test.cpp
@@ -12,7 +12,7 @@ void test()
 {
     // Edge cases
     #ifdef BOOST_MATH_BIT_CAST
-    if constexpr (std::is_same_v<T, float>)
+    if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>)
     {
         static_assert(boost::math::ccmath::signbit(T(0)) == false);
         static_assert(boost::math::ccmath::signbit(T(0)*-1) == true);

--- a/test/ccmath_signbit_test.cpp
+++ b/test/ccmath_signbit_test.cpp
@@ -20,10 +20,6 @@ void test()
 
     static_assert(boost::math::ccmath::signbit(std::numeric_limits<T>::signaling_NaN()) == false);
     static_assert(boost::math::ccmath::signbit(-std::numeric_limits<T>::signaling_NaN()) == true);
-    #else
-    static_assert(boost::math::ccmath::signbit(T(0)) == false);
-    static_assert(boost::math::ccmath::signbit(std::numeric_limits<T>::quiet_NaN()) == false);
-    static_assert(boost::math::ccmath::signbit(std::numeric_limits<T>::signaling_NaN()) == false);
     #endif
 
     // Positive numbers

--- a/test/ccmath_signbit_test.cpp
+++ b/test/ccmath_signbit_test.cpp
@@ -11,9 +11,23 @@ template <typename T>
 void test()
 {
     // Edge cases
+    #ifdef BOOST_MATH_BIT_CAST
+    if constexpr (std::is_same_v<T, float>)
+    {
+        static_assert(boost::math::ccmath::signbit(T(0)) == false);
+        static_assert(boost::math::ccmath::signbit(T(0)*-1) == true);
+
+        static_assert(boost::math::ccmath::signbit(std::numeric_limits<T>::quiet_NaN()) == false);
+        static_assert(boost::math::ccmath::signbit(-std::numeric_limits<T>::quiet_NaN()) == true);
+
+        static_assert(boost::math::ccmath::signbit(std::numeric_limits<T>::signaling_NaN()) == false);
+        static_assert(boost::math::ccmath::signbit(-std::numeric_limits<T>::signaling_NaN()) == true);
+    }
+    #else
     static_assert(boost::math::ccmath::signbit(T(0)) == false);
     static_assert(boost::math::ccmath::signbit(std::numeric_limits<T>::quiet_NaN()) == false);
     static_assert(boost::math::ccmath::signbit(std::numeric_limits<T>::signaling_NaN()) == false);
+    #endif
 
     // Positive numbers
     static_assert(boost::math::ccmath::signbit(std::numeric_limits<T>::infinity()) == false);


### PR DESCRIPTION
Use `std::bit_cast` or `__builtin_bit_cast` when available to support signed zeros and NANs.