### PR TITLE
Modernize exception specification

### DIFF
--- a/include/boost/math/cstdfloat/cstdfloat_cmath.hpp
+++ b/include/boost/math/cstdfloat/cstdfloat_cmath.hpp
@@ -286,83 +286,83 @@ namespace boost {
 // Begin with some forward function declarations. Also implement patches
 // for compilers that have broken float128 exponential functions.
 
-extern "C" int quadmath_snprintf(char*, std::size_t, const char*, ...) throw();
+extern "C" int quadmath_snprintf(char*, std::size_t, const char*, ...) BOOST_NOEXCEPT_OR_NOTHROW;
 
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LDEXP(boost::math::cstdfloat::detail::float_internal128_t, int) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FREXP(boost::math::cstdfloat::detail::float_internal128_t, int*) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FABS(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FLOOR(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_CEIL(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SQRT(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TRUNC(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_POW(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LOG(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LOG10(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SIN(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_COS(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TAN(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ASIN(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ACOS(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATAN(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FMOD(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATAN2(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LGAMMA(boost::math::cstdfloat::detail::float_internal128_t) throw();
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LDEXP(boost::math::cstdfloat::detail::float_internal128_t, int) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FREXP(boost::math::cstdfloat::detail::float_internal128_t, int*) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FABS(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FLOOR(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_CEIL(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SQRT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TRUNC(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_POW(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LOG(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LOG10(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SIN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_COS(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TAN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ASIN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ACOS(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATAN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FMOD(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATAN2(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LGAMMA(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
 
 //   begin more functions
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_REMAINDER(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_REMQUO(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t, int*) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FMA(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FMAX(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FMIN(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FDIM(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NAN(const char*) throw();
-//extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_EXP2         (boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_LOG2(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_LOG1P(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_CBRT(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_HYPOT(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ERF(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ERFC(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" long long int                                BOOST_CSTDFLOAT_FLOAT128_LLROUND(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" long int                                   BOOST_CSTDFLOAT_FLOAT128_LROUND(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ROUND(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NEARBYINT(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" long long int                                BOOST_CSTDFLOAT_FLOAT128_LLRINT(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" long int                                   BOOST_CSTDFLOAT_FLOAT128_LRINT(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_RINT(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_MODF(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t*) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_SCALBLN(boost::math::cstdfloat::detail::float_internal128_t, long int) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_SCALBN(boost::math::cstdfloat::detail::float_internal128_t, int) throw();
-extern "C" int                                      BOOST_CSTDFLOAT_FLOAT128_ILOGB(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_LOGB(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NEXTAFTER(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-//extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NEXTTOWARD   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_COPYSIGN(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" int                                                  BOOST_CSTDFLOAT_FLOAT128_SIGNBIT(boost::math::cstdfloat::detail::float_internal128_t) throw();
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_FPCLASSIFY   (boost::math::cstdfloat::detail::float_internal128_t) throw();
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISFINITE      (boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" int                                                  BOOST_CSTDFLOAT_FLOAT128_ISINF(boost::math::cstdfloat::detail::float_internal128_t) throw();
-extern "C" int                                                  BOOST_CSTDFLOAT_FLOAT128_ISNAN(boost::math::cstdfloat::detail::float_internal128_t) throw();
-//extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ISNORMAL   (boost::math::cstdfloat::detail::float_internal128_t) throw();
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISGREATER   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISGREATEREQUAL(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISLESS      (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISLESSEQUAL   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISLESSGREATER(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISUNORDERED   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) throw();
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_REMAINDER(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_REMQUO(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t, int*) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FMA(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FMAX(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FMIN(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FDIM(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NAN(const char*) BOOST_NOEXCEPT_OR_NOTHROW;
+//extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_EXP2         (boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_LOG2(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_LOG1P(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_CBRT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_HYPOT(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ERF(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ERFC(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" long long int                                BOOST_CSTDFLOAT_FLOAT128_LLROUND(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" long int                                   BOOST_CSTDFLOAT_FLOAT128_LROUND(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ROUND(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NEARBYINT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" long long int                                BOOST_CSTDFLOAT_FLOAT128_LLRINT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" long int                                   BOOST_CSTDFLOAT_FLOAT128_LRINT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_RINT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_MODF(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t*) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_SCALBLN(boost::math::cstdfloat::detail::float_internal128_t, long int) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_SCALBN(boost::math::cstdfloat::detail::float_internal128_t, int) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" int                                      BOOST_CSTDFLOAT_FLOAT128_ILOGB(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_LOGB(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NEXTAFTER(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+//extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NEXTTOWARD   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_COPYSIGN(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" int                                                  BOOST_CSTDFLOAT_FLOAT128_SIGNBIT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_FPCLASSIFY   (boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISFINITE      (boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" int                                                  BOOST_CSTDFLOAT_FLOAT128_ISINF(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" int                                                  BOOST_CSTDFLOAT_FLOAT128_ISNAN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+//extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ISNORMAL   (boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISGREATER   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISGREATEREQUAL(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISLESS      (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISLESSEQUAL   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISLESSGREATER(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISUNORDERED   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
  //   end more functions
 
 #if !defined(BOOST_CSTDFLOAT_BROKEN_FLOAT128_MATH_FUNCTIONS)
 
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_EXP(boost::math::cstdfloat::detail::float_internal128_t x) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_EXPM1(boost::math::cstdfloat::detail::float_internal128_t x) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SINH(boost::math::cstdfloat::detail::float_internal128_t x) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_COSH(boost::math::cstdfloat::detail::float_internal128_t x) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TANH(boost::math::cstdfloat::detail::float_internal128_t x) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ASINH(boost::math::cstdfloat::detail::float_internal128_t x) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ACOSH(boost::math::cstdfloat::detail::float_internal128_t x) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATANH(boost::math::cstdfloat::detail::float_internal128_t x) throw();
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TGAMMA(boost::math::cstdfloat::detail::float_internal128_t x) throw();
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_EXP(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_EXPM1(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SINH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_COSH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TANH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ASINH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ACOSH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATANH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TGAMMA(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
  
 #else // BOOST_CSTDFLOAT_BROKEN_FLOAT128_MATH_FUNCTIONS
 
@@ -512,13 +512,13 @@ inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT
    const float_type ex_minus = (float_type(1) / ex_plus);
    return (ex_plus - ex_minus) / (ex_plus + ex_minus);
 }
-inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ASINH(boost::math::cstdfloat::detail::float_internal128_t x) throw()
+inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ASINH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW
 {
    // Patch the asinh() function since quadmath does not have it.
    typedef boost::math::cstdfloat::detail::float_internal128_t float_type;
    return ::BOOST_CSTDFLOAT_FLOAT128_LOG(x + ::BOOST_CSTDFLOAT_FLOAT128_SQRT((x * x) + float_type(1)));
 }
-inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ACOSH(boost::math::cstdfloat::detail::float_internal128_t x) throw()
+inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ACOSH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW
 {
    // Patch the acosh() function since quadmath does not have it.
    typedef boost::math::cstdfloat::detail::float_internal128_t float_type;
@@ -527,14 +527,14 @@ inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT
 
    return ::BOOST_CSTDFLOAT_FLOAT128_LOG(x + (zp * ::BOOST_CSTDFLOAT_FLOAT128_SQRT(zm / zp)));
 }
-inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATANH(boost::math::cstdfloat::detail::float_internal128_t x) throw()
+inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATANH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW
 {
    // Patch the atanh() function since quadmath does not have it.
    typedef boost::math::cstdfloat::detail::float_internal128_t float_type;
    return (::BOOST_CSTDFLOAT_FLOAT128_LOG(float_type(1) + x)
       - ::BOOST_CSTDFLOAT_FLOAT128_LOG(float_type(1) - x)) / 2;
 }
-inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TGAMMA(boost::math::cstdfloat::detail::float_internal128_t x) throw()
+inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TGAMMA(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW
 {
    // Patch the tgammaq() function for a subset of broken GCC compilers
    // like GCC 4.7, 4.8 on MinGW.

--- a/include/boost/math/cstdfloat/cstdfloat_cmath.hpp
+++ b/include/boost/math/cstdfloat/cstdfloat_cmath.hpp
@@ -24,6 +24,7 @@
 #include <type_traits>
 #include <memory>
 #include <boost/math/tools/assert.hpp>
+#include <boost/math/tools/nothrow.hpp>
 #include <boost/math/tools/throw_exception.hpp>
 
 #if defined(_WIN32) && defined(__GNUC__)
@@ -286,83 +287,83 @@ namespace boost {
 // Begin with some forward function declarations. Also implement patches
 // for compilers that have broken float128 exponential functions.
 
-extern "C" int quadmath_snprintf(char*, std::size_t, const char*, ...) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" int quadmath_snprintf(char*, std::size_t, const char*, ...) BOOST_MATH_NOTHROW;
 
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LDEXP(boost::math::cstdfloat::detail::float_internal128_t, int) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FREXP(boost::math::cstdfloat::detail::float_internal128_t, int*) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FABS(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FLOOR(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_CEIL(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SQRT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TRUNC(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_POW(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LOG(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LOG10(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SIN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_COS(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TAN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ASIN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ACOS(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATAN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FMOD(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATAN2(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LGAMMA(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LDEXP(boost::math::cstdfloat::detail::float_internal128_t, int) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FREXP(boost::math::cstdfloat::detail::float_internal128_t, int*) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FABS(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FLOOR(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_CEIL(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SQRT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TRUNC(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_POW(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LOG(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LOG10(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SIN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_COS(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TAN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ASIN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ACOS(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATAN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_FMOD(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATAN2(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_LGAMMA(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
 
 //   begin more functions
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_REMAINDER(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_REMQUO(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t, int*) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FMA(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FMAX(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FMIN(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FDIM(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NAN(const char*) BOOST_NOEXCEPT_OR_NOTHROW;
-//extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_EXP2         (boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_LOG2(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_LOG1P(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_CBRT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_HYPOT(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ERF(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ERFC(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" long long int                                BOOST_CSTDFLOAT_FLOAT128_LLROUND(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" long int                                   BOOST_CSTDFLOAT_FLOAT128_LROUND(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ROUND(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NEARBYINT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" long long int                                BOOST_CSTDFLOAT_FLOAT128_LLRINT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" long int                                   BOOST_CSTDFLOAT_FLOAT128_LRINT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_RINT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_MODF(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t*) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_SCALBLN(boost::math::cstdfloat::detail::float_internal128_t, long int) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_SCALBN(boost::math::cstdfloat::detail::float_internal128_t, int) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" int                                      BOOST_CSTDFLOAT_FLOAT128_ILOGB(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_LOGB(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NEXTAFTER(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-//extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NEXTTOWARD   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_COPYSIGN(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" int                                                  BOOST_CSTDFLOAT_FLOAT128_SIGNBIT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_FPCLASSIFY   (boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISFINITE      (boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" int                                                  BOOST_CSTDFLOAT_FLOAT128_ISINF(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" int                                                  BOOST_CSTDFLOAT_FLOAT128_ISNAN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-//extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ISNORMAL   (boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISGREATER   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISGREATEREQUAL(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISLESS      (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISLESSEQUAL   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISLESSGREATER(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
-//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISUNORDERED   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_REMAINDER(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_REMQUO(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t, int*) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FMA(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FMAX(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FMIN(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_FDIM(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NAN(const char*) BOOST_MATH_NOTHROW;
+//extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_EXP2         (boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_LOG2(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_LOG1P(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_CBRT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_HYPOT(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ERF(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ERFC(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" long long int                                BOOST_CSTDFLOAT_FLOAT128_LLROUND(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" long int                                   BOOST_CSTDFLOAT_FLOAT128_LROUND(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ROUND(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NEARBYINT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" long long int                                BOOST_CSTDFLOAT_FLOAT128_LLRINT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" long int                                   BOOST_CSTDFLOAT_FLOAT128_LRINT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_RINT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_MODF(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t*) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_SCALBLN(boost::math::cstdfloat::detail::float_internal128_t, long int) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_SCALBN(boost::math::cstdfloat::detail::float_internal128_t, int) BOOST_MATH_NOTHROW;
+extern "C" int                                      BOOST_CSTDFLOAT_FLOAT128_ILOGB(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_LOGB(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NEXTAFTER(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+//extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_NEXTTOWARD   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_COPYSIGN(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" int                                                  BOOST_CSTDFLOAT_FLOAT128_SIGNBIT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_FPCLASSIFY   (boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISFINITE      (boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" int                                                  BOOST_CSTDFLOAT_FLOAT128_ISINF(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+extern "C" int                                                  BOOST_CSTDFLOAT_FLOAT128_ISNAN(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+//extern "C" boost::math::cstdfloat::detail::float_internal128_t  BOOST_CSTDFLOAT_FLOAT128_ISNORMAL   (boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISGREATER   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISGREATEREQUAL(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISLESS      (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISLESSEQUAL   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISLESSGREATER(boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
+//extern "C" int                                                BOOST_CSTDFLOAT_FLOAT128_ISUNORDERED   (boost::math::cstdfloat::detail::float_internal128_t, boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
  //   end more functions
 
 #if !defined(BOOST_CSTDFLOAT_BROKEN_FLOAT128_MATH_FUNCTIONS)
 
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_EXP(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_EXPM1(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SINH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_COSH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TANH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ASINH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ACOSH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATANH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
-extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TGAMMA(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_EXP(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_EXPM1(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SINH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_COSH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TANH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ASINH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ACOSH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATANH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_MATH_NOTHROW;
+extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TGAMMA(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_MATH_NOTHROW;
  
 #else // BOOST_CSTDFLOAT_BROKEN_FLOAT128_MATH_FUNCTIONS
 
@@ -512,13 +513,13 @@ inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT
    const float_type ex_minus = (float_type(1) / ex_plus);
    return (ex_plus - ex_minus) / (ex_plus + ex_minus);
 }
-inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ASINH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW
+inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ASINH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_MATH_NOTHROW
 {
    // Patch the asinh() function since quadmath does not have it.
    typedef boost::math::cstdfloat::detail::float_internal128_t float_type;
    return ::BOOST_CSTDFLOAT_FLOAT128_LOG(x + ::BOOST_CSTDFLOAT_FLOAT128_SQRT((x * x) + float_type(1)));
 }
-inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ACOSH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW
+inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ACOSH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_MATH_NOTHROW
 {
    // Patch the acosh() function since quadmath does not have it.
    typedef boost::math::cstdfloat::detail::float_internal128_t float_type;
@@ -527,14 +528,14 @@ inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT
 
    return ::BOOST_CSTDFLOAT_FLOAT128_LOG(x + (zp * ::BOOST_CSTDFLOAT_FLOAT128_SQRT(zm / zp)));
 }
-inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATANH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW
+inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_ATANH(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_MATH_NOTHROW
 {
    // Patch the atanh() function since quadmath does not have it.
    typedef boost::math::cstdfloat::detail::float_internal128_t float_type;
    return (::BOOST_CSTDFLOAT_FLOAT128_LOG(float_type(1) + x)
       - ::BOOST_CSTDFLOAT_FLOAT128_LOG(float_type(1) - x)) / 2;
 }
-inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TGAMMA(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_NOEXCEPT_OR_NOTHROW
+inline boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_TGAMMA(boost::math::cstdfloat::detail::float_internal128_t x) BOOST_MATH_NOTHROW
 {
    // Patch the tgammaq() function for a subset of broken GCC compilers
    // like GCC 4.7, 4.8 on MinGW.

--- a/include/boost/math/cstdfloat/cstdfloat_iostream.hpp
+++ b/include/boost/math/cstdfloat/cstdfloat_iostream.hpp
@@ -29,14 +29,15 @@
   #include <stdexcept>
   #include <string>
   #include <boost/math/tools/assert.hpp>
+  #include <boost/math/tools/nothrow.hpp>
   #include <boost/math/tools/throw_exception.hpp>
 
 //  #if (0)
   #if defined(__GNUC__)
 
   // Forward declarations of quadruple-precision string functions.
-  extern "C" int quadmath_snprintf(char *str, size_t size, const char *format, ...) BOOST_NOEXCEPT_OR_NOTHROW;
-  extern "C" boost::math::cstdfloat::detail::float_internal128_t strtoflt128(const char*, char **) BOOST_NOEXCEPT_OR_NOTHROW;
+  extern "C" int quadmath_snprintf(char *str, size_t size, const char *format, ...) BOOST_MATH_NOTHROW;
+  extern "C" boost::math::cstdfloat::detail::float_internal128_t strtoflt128(const char*, char **) BOOST_MATH_NOTHROW;
 
   namespace std
   {

--- a/include/boost/math/cstdfloat/cstdfloat_iostream.hpp
+++ b/include/boost/math/cstdfloat/cstdfloat_iostream.hpp
@@ -35,8 +35,8 @@
   #if defined(__GNUC__)
 
   // Forward declarations of quadruple-precision string functions.
-  extern "C" int quadmath_snprintf(char *str, size_t size, const char *format, ...) throw();
-  extern "C" boost::math::cstdfloat::detail::float_internal128_t strtoflt128(const char*, char **) throw();
+  extern "C" int quadmath_snprintf(char *str, size_t size, const char *format, ...) BOOST_NOEXCEPT_OR_NOTHROW;
+  extern "C" boost::math::cstdfloat::detail::float_internal128_t strtoflt128(const char*, char **) BOOST_NOEXCEPT_OR_NOTHROW;
 
   namespace std
   {

--- a/include/boost/math/cstdfloat/cstdfloat_limits.hpp
+++ b/include/boost/math/cstdfloat/cstdfloat_limits.hpp
@@ -37,7 +37,7 @@
     #endif
 
     // Forward declaration of the quadruple-precision square root function.
-    extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SQRT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
+    extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SQRT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_MATH_NOTHROW;
 
     namespace std
     {

--- a/include/boost/math/cstdfloat/cstdfloat_limits.hpp
+++ b/include/boost/math/cstdfloat/cstdfloat_limits.hpp
@@ -37,7 +37,7 @@
     #endif
 
     // Forward declaration of the quadruple-precision square root function.
-    extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SQRT(boost::math::cstdfloat::detail::float_internal128_t) throw();
+    extern "C" boost::math::cstdfloat::detail::float_internal128_t BOOST_CSTDFLOAT_FLOAT128_SQRT(boost::math::cstdfloat::detail::float_internal128_t) BOOST_NOEXCEPT_OR_NOTHROW;
 
     namespace std
     {

--- a/include/boost/math/cstdfloat/cstdfloat_limits.hpp
+++ b/include/boost/math/cstdfloat/cstdfloat_limits.hpp
@@ -27,6 +27,7 @@
   #if defined(BOOST_CSTDFLOAT_HAS_INTERNAL_FLOAT128_T) && defined(BOOST_MATH_USE_FLOAT128) && !defined(BOOST_CSTDFLOAT_NO_LIBQUADMATH_SUPPORT)
 
     #include <limits>
+    #include <boost/math/tools/nothrow.hpp>
 
     // Define the name of the global quadruple-precision function to be used for
     // calculating quiet_NaN() in the specialization of std::numeric_limits<>.

--- a/include/boost/math/tools/nothrow.hpp
+++ b/include/boost/math/tools/nothrow.hpp
@@ -1,0 +1,27 @@
+//  (C) Copyright Antony Polukhin 2022.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_TOOLS_NOTHROW_HPP
+#define BOOST_MATH_TOOLS_NOTHROW_HPP
+
+#include <boost/math/tools/is_standalone.hpp>
+
+#ifndef BOOST_MATH_STANDALONE
+
+#include <boost/config.hpp>
+
+#define BOOST_MATH_NOTHROW BOOST_NOEXCEPT_OR_NOTHROW
+
+#else // Standalone mode - use noexcept or throw()
+
+#if __cplusplus >= 201103L
+#define BOOST_MATH_NOTHROW noexcept
+#else
+#define BOOST_MATH_NOTHROW throw()
+#endif
+
+#endif
+
+#endif // BOOST_MATH_TOOLS_NOTHROW_HPP

--- a/test/compile_test/std_real_concept_check.cpp
+++ b/test/compile_test/std_real_concept_check.cpp
@@ -48,8 +48,8 @@ template<>
 struct numeric_limits<boost::math::concepts::std_real_concept>
 {
    static const bool is_specialized = true;
-   static boost::math::concepts::std_real_concept min NULL_MACRO() throw();
-   static boost::math::concepts::std_real_concept max NULL_MACRO() throw();
+   static boost::math::concepts::std_real_concept min NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept max NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int digits = 24;
    static const int digits10 = 6;
    static const int max_digits10 = 9;
@@ -57,8 +57,8 @@ struct numeric_limits<boost::math::concepts::std_real_concept>
    static const bool is_integer = false;
    static const bool is_exact = false;
    static const int radix = 2;
-   static boost::math::concepts::std_real_concept epsilon() throw();
-   static boost::math::concepts::std_real_concept round_error() throw();
+   static boost::math::concepts::std_real_concept epsilon() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept round_error() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int min_exponent = -125;
    static const int min_exponent10 = -37;
    static const int max_exponent = 128;
@@ -68,10 +68,10 @@ struct numeric_limits<boost::math::concepts::std_real_concept>
    static const bool has_signaling_NaN = true;
    static const float_denorm_style has_denorm = denorm_absent;
    static const bool has_denorm_loss = false;
-   static boost::math::concepts::std_real_concept infinity() throw();
-   static boost::math::concepts::std_real_concept quiet_NaN() throw();
-   static boost::math::concepts::std_real_concept signaling_NaN() throw();
-   static boost::math::concepts::std_real_concept denorm_min() throw();
+   static boost::math::concepts::std_real_concept infinity() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept quiet_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept signaling_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept denorm_min() BOOST_NOEXCEPT_OR_NOTHROW;
    static const bool is_iec559 = true;
    static const bool is_bounded = false;
    static const bool is_modulo = false;
@@ -87,8 +87,8 @@ template<>
 struct numeric_limits<boost::math::concepts::std_real_concept>
 {
    static const bool is_specialized = true;
-   static boost::math::concepts::std_real_concept min NULL_MACRO() throw();
-   static boost::math::concepts::std_real_concept max NULL_MACRO() throw();
+   static boost::math::concepts::std_real_concept min NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept max NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int digits = 53;
    static const int digits10 = 15;
    static const int max_digits10 = 17;
@@ -96,8 +96,8 @@ struct numeric_limits<boost::math::concepts::std_real_concept>
    static const bool is_integer = false;
    static const bool is_exact = false;
    static const int radix = 2;
-   static boost::math::concepts::std_real_concept epsilon() throw();
-   static boost::math::concepts::std_real_concept round_error() throw();
+   static boost::math::concepts::std_real_concept epsilon() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept round_error() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int min_exponent = -1021;
    static const int min_exponent10 = -307;
    static const int max_exponent = 1024;
@@ -107,10 +107,10 @@ struct numeric_limits<boost::math::concepts::std_real_concept>
    static const bool has_signaling_NaN = true;
    static const float_denorm_style has_denorm = denorm_absent;
    static const bool has_denorm_loss = false;
-   static boost::math::concepts::std_real_concept infinity() throw();
-   static boost::math::concepts::std_real_concept quiet_NaN() throw();
-   static boost::math::concepts::std_real_concept signaling_NaN() throw();
-   static boost::math::concepts::std_real_concept denorm_min() throw();
+   static boost::math::concepts::std_real_concept infinity() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept quiet_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept signaling_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept denorm_min() BOOST_NOEXCEPT_OR_NOTHROW;
    static const bool is_iec559 = true;
    static const bool is_bounded = false;
    static const bool is_modulo = false;
@@ -126,8 +126,8 @@ template<>
 struct numeric_limits<boost::math::concepts::std_real_concept>
 {
    static const bool is_specialized = true;
-   static boost::math::concepts::std_real_concept min NULL_MACRO() throw();
-   static boost::math::concepts::std_real_concept max NULL_MACRO() throw();
+   static boost::math::concepts::std_real_concept min NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept max NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int digits = 64;
    static const int digits10 = 18;
    static const int max_digits10 = 22;
@@ -135,8 +135,8 @@ struct numeric_limits<boost::math::concepts::std_real_concept>
    static const bool is_integer = false;
    static const bool is_exact = false;
    static const int radix = 2;
-   static boost::math::concepts::std_real_concept epsilon() throw();
-   static boost::math::concepts::std_real_concept round_error() throw();
+   static boost::math::concepts::std_real_concept epsilon() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept round_error() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int min_exponent = -16381;
    static const int min_exponent10 = -4931;
    static const int max_exponent = 16384;
@@ -146,10 +146,10 @@ struct numeric_limits<boost::math::concepts::std_real_concept>
    static const bool has_signaling_NaN = true;
    static const float_denorm_style has_denorm = denorm_absent;
    static const bool has_denorm_loss = false;
-   static boost::math::concepts::std_real_concept infinity() throw();
-   static boost::math::concepts::std_real_concept quiet_NaN() throw();
-   static boost::math::concepts::std_real_concept signaling_NaN() throw();
-   static boost::math::concepts::std_real_concept denorm_min() throw();
+   static boost::math::concepts::std_real_concept infinity() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept quiet_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept signaling_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept denorm_min() BOOST_NOEXCEPT_OR_NOTHROW;
    static const bool is_iec559 = true;
    static const bool is_bounded = false;
    static const bool is_modulo = false;
@@ -165,8 +165,8 @@ template<>
 struct numeric_limits<boost::math::concepts::std_real_concept>
 {
    static const bool is_specialized = true;
-   static boost::math::concepts::std_real_concept min NULL_MACRO() throw();
-   static boost::math::concepts::std_real_concept max NULL_MACRO() throw();
+   static boost::math::concepts::std_real_concept min NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept max NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int digits = 113;
    static const int digits10 = 33;
    static const int max_digits10 = 37;
@@ -174,8 +174,8 @@ struct numeric_limits<boost::math::concepts::std_real_concept>
    static const bool is_integer = false;
    static const bool is_exact = false;
    static const int radix = 2;
-   static boost::math::concepts::std_real_concept epsilon() throw();
-   static boost::math::concepts::std_real_concept round_error() throw();
+   static boost::math::concepts::std_real_concept epsilon() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept round_error() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int min_exponent = -16381;
    static const int min_exponent10 = -4931;
    static const int max_exponent = 16384;
@@ -185,10 +185,10 @@ struct numeric_limits<boost::math::concepts::std_real_concept>
    static const bool has_signaling_NaN = true;
    static const float_denorm_style has_denorm = denorm_absent;
    static const bool has_denorm_loss = false;
-   static boost::math::concepts::std_real_concept infinity() throw();
-   static boost::math::concepts::std_real_concept quiet_NaN() throw();
-   static boost::math::concepts::std_real_concept signaling_NaN() throw();
-   static boost::math::concepts::std_real_concept denorm_min() throw();
+   static boost::math::concepts::std_real_concept infinity() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept quiet_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept signaling_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept denorm_min() BOOST_NOEXCEPT_OR_NOTHROW;
    static const bool is_iec559 = true;
    static const bool is_bounded = false;
    static const bool is_modulo = false;

--- a/test/std_real_concept_check.cpp
+++ b/test/std_real_concept_check.cpp
@@ -42,16 +42,16 @@ template<>
 struct numeric_limits<boost::math::concepts::std_real_concept>
 {
    static const bool is_specialized = true;
-   static boost::math::concepts::std_real_concept min NULL_MACRO() throw();
-   static boost::math::concepts::std_real_concept max NULL_MACRO() throw();
+   static boost::math::concepts::std_real_concept min NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept max NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int digits = 24;
    static const int digits10 = 6;
    static const bool is_signed = true;
    static const bool is_integer = false;
    static const bool is_exact = false;
    static const int radix = 2;
-   static boost::math::concepts::std_real_concept epsilon() throw();
-   static boost::math::concepts::std_real_concept round_error() throw();
+   static boost::math::concepts::std_real_concept epsilon() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept round_error() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int min_exponent = -125;
    static const int min_exponent10 = -37;
    static const int max_exponent = 128;
@@ -61,10 +61,10 @@ struct numeric_limits<boost::math::concepts::std_real_concept>
    static const bool has_signaling_NaN = true;
    static const float_denorm_style has_denorm = denorm_absent;
    static const bool has_denorm_loss = false;
-   static boost::math::concepts::std_real_concept infinity() throw();
-   static boost::math::concepts::std_real_concept quiet_NaN() throw();
-   static boost::math::concepts::std_real_concept signaling_NaN() throw();
-   static boost::math::concepts::std_real_concept denorm_min() throw();
+   static boost::math::concepts::std_real_concept infinity() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept quiet_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept signaling_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept denorm_min() BOOST_NOEXCEPT_OR_NOTHROW;
    static const bool is_iec559 = true;
    static const bool is_bounded = false;
    static const bool is_modulo = false;
@@ -80,16 +80,16 @@ template<>
 struct numeric_limits<boost::math::concepts::std_real_concept>
 {
    static const bool is_specialized = true;
-   static boost::math::concepts::std_real_concept min NULL_MACRO() throw();
-   static boost::math::concepts::std_real_concept max NULL_MACRO() throw();
+   static boost::math::concepts::std_real_concept min NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept max NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int digits = 53;
    static const int digits10 = 15;
    static const bool is_signed = true;
    static const bool is_integer = false;
    static const bool is_exact = false;
    static const int radix = 2;
-   static boost::math::concepts::std_real_concept epsilon() throw();
-   static boost::math::concepts::std_real_concept round_error() throw();
+   static boost::math::concepts::std_real_concept epsilon() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept round_error() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int min_exponent = -1021;
    static const int min_exponent10 = -307;
    static const int max_exponent = 1024;
@@ -99,10 +99,10 @@ struct numeric_limits<boost::math::concepts::std_real_concept>
    static const bool has_signaling_NaN = true;
    static const float_denorm_style has_denorm = denorm_absent;
    static const bool has_denorm_loss = false;
-   static boost::math::concepts::std_real_concept infinity() throw();
-   static boost::math::concepts::std_real_concept quiet_NaN() throw();
-   static boost::math::concepts::std_real_concept signaling_NaN() throw();
-   static boost::math::concepts::std_real_concept denorm_min() throw();
+   static boost::math::concepts::std_real_concept infinity() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept quiet_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept signaling_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept denorm_min() BOOST_NOEXCEPT_OR_NOTHROW;
    static const bool is_iec559 = true;
    static const bool is_bounded = false;
    static const bool is_modulo = false;
@@ -118,16 +118,16 @@ template<>
 struct numeric_limits<boost::math::concepts::std_real_concept>
 {
    static const bool is_specialized = true;
-   static boost::math::concepts::std_real_concept min NULL_MACRO() throw();
-   static boost::math::concepts::std_real_concept max NULL_MACRO() throw();
+   static boost::math::concepts::std_real_concept min NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept max NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int digits = 64;
    static const int digits10 = 18;
    static const bool is_signed = true;
    static const bool is_integer = false;
    static const bool is_exact = false;
    static const int radix = 2;
-   static boost::math::concepts::std_real_concept epsilon() throw();
-   static boost::math::concepts::std_real_concept round_error() throw();
+   static boost::math::concepts::std_real_concept epsilon() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept round_error() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int min_exponent = -16381;
    static const int min_exponent10 = -4931;
    static const int max_exponent = 16384;
@@ -137,10 +137,10 @@ struct numeric_limits<boost::math::concepts::std_real_concept>
    static const bool has_signaling_NaN = true;
    static const float_denorm_style has_denorm = denorm_absent;
    static const bool has_denorm_loss = false;
-   static boost::math::concepts::std_real_concept infinity() throw();
-   static boost::math::concepts::std_real_concept quiet_NaN() throw();
-   static boost::math::concepts::std_real_concept signaling_NaN() throw();
-   static boost::math::concepts::std_real_concept denorm_min() throw();
+   static boost::math::concepts::std_real_concept infinity() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept quiet_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept signaling_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept denorm_min() BOOST_NOEXCEPT_OR_NOTHROW;
    static const bool is_iec559 = true;
    static const bool is_bounded = false;
    static const bool is_modulo = false;
@@ -156,16 +156,16 @@ template<>
 struct numeric_limits<boost::math::concepts::std_real_concept>
 {
    static const bool is_specialized = true;
-   static boost::math::concepts::std_real_concept min NULL_MACRO() throw();
-   static boost::math::concepts::std_real_concept max NULL_MACRO() throw();
+   static boost::math::concepts::std_real_concept min NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept max NULL_MACRO() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int digits = 113;
    static const int digits10 = 33;
    static const bool is_signed = true;
    static const bool is_integer = false;
    static const bool is_exact = false;
    static const int radix = 2;
-   static boost::math::concepts::std_real_concept epsilon() throw();
-   static boost::math::concepts::std_real_concept round_error() throw();
+   static boost::math::concepts::std_real_concept epsilon() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept round_error() BOOST_NOEXCEPT_OR_NOTHROW;
    static const int min_exponent = -16381;
    static const int min_exponent10 = -4931;
    static const int max_exponent = 16384;
@@ -175,10 +175,10 @@ struct numeric_limits<boost::math::concepts::std_real_concept>
    static const bool has_signaling_NaN = true;
    static const float_denorm_style has_denorm = denorm_absent;
    static const bool has_denorm_loss = false;
-   static boost::math::concepts::std_real_concept infinity() throw();
-   static boost::math::concepts::std_real_concept quiet_NaN() throw();
-   static boost::math::concepts::std_real_concept signaling_NaN() throw();
-   static boost::math::concepts::std_real_concept denorm_min() throw();
+   static boost::math::concepts::std_real_concept infinity() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept quiet_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept signaling_NaN() BOOST_NOEXCEPT_OR_NOTHROW;
+   static boost::math::concepts::std_real_concept denorm_min() BOOST_NOEXCEPT_OR_NOTHROW;
    static const bool is_iec559 = true;
    static const bool is_bounded = false;
    static const bool is_modulo = false;


### PR DESCRIPTION
Done via `find include src/ example/ meta/ test/ tools/ include_private/ config/ -type f | xargs sed -i 's/throw()/BOOST_MATH_NOTHROW/g'` and by adding the include/boost/math/tools/nothrow.hpp 