### PR TITLE
short-circuit overflow protection for M1 Mac clang

### DIFF
--- a/include/boost/math/special_functions/detail/igamma_inverse.hpp
+++ b/include/boost/math/special_functions/detail/igamma_inverse.hpp
@@ -362,10 +362,19 @@ struct gamma_p_inverse_func
       T f2;
       T div = (a - x - 1) / x;
       f2 = f1;
-      if((fabs(div) > 1) && (tools::max_value<T>() / fabs(div) < f2))
+      if(fabs(div) > 1)
       {
-         // overflow:
-         f2 = -tools::max_value<T>() / 2;
+         // split if statement to address M1 mac clang bug;
+         // see issue 826
+         if (tools::max_value<T>() / fabs(div) < f2)
+         {
+            // overflow:
+            f2 = -tools::max_value<T>() / 2;
+         }
+         else
+         {
+            f2 *= div;
+         }
       }
       else
       {

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -166,6 +166,7 @@ test-suite special_fun :
    [ run powm1_sqrtp1m1_test.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]
    [ run git_issue_705.cpp ../../test/build//boost_unit_test_framework  ]
    [ run git_issue_810.cpp ../../test/build//boost_unit_test_framework  ]
+   [ run git_issue_826.cpp ../../test/build//boost_unit_test_framework  ]
    [ run special_functions_test.cpp ../../test/build//boost_unit_test_framework  ]
    [ run test_airy.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]
    [ run test_bessel_j.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]

--- a/test/git_issue_826.cpp
+++ b/test/git_issue_826.cpp
@@ -1,0 +1,31 @@
+// Copyright Nicholas McKibben, 2022
+// Use, modification and distribution are subject to the
+// Boost Software License, Version 1.0. (See accompanying file
+// LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <cfenv>
+#include <iostream>
+#include <boost/math/distributions/beta.hpp>
+#include "math_unit_test.hpp"
+
+#pragma STDC FENV_ACCESS ON
+
+int main() {
+    constexpr double q {0.999995};
+    constexpr double a {2};
+    constexpr double b {99999};
+    std::feclearexcept(FE_ALL_EXCEPT);
+    boost::math::beta_distribution<double> d {a, b};
+    const auto ans = boost::math::quantile(d, q);
+    if(std::fetestexcept(FE_OVERFLOW)) {
+        std::cout << "overflow reported" << std::endl;
+    } else {
+        std::cout << "overflow not reported" << std::endl;
+    }
+    std::cout << std::setprecision(16) << "Ans is: " << ans << std::endl;
+    return 0;
+
+    CHECK_ULP_CLOSE(ans, 0.000149761910560502, 1);
+}
+// overflow reported
+// Ans is: 0.000149761910560502


### PR DESCRIPTION
Closes https://github.com/boostorg/math/issues/826
xref https://github.com/scipy/scipy/issues/14901 

Splits single if statement into two to avoid apparent clang short-circuit bug on M1 Mac platforms.