### PR TITLE
Change looping over array to be unsigned

### DIFF
--- a/include/boost/math/interpolators/catmull_rom.hpp
+++ b/include/boost/math/interpolators/catmull_rom.hpp
@@ -111,9 +111,9 @@ catmull_rom<Point, RandomAccessContainer>::catmull_rom(RandomAccessContainer&& p
     m_pnts[num_pnts+2] = m_pnts[1];
 
     auto tmp = m_pnts[num_pnts-1];
-    for (std::ptrdiff_t i = num_pnts-1; i >= 0; --i)
+    for (auto i = num_pnts; i > 0; --i)
     {
-        m_pnts[i+1] = m_pnts[i];
+        m_pnts[i] = m_pnts[i - 1];
     }
     m_pnts[0] = tmp;
 


### PR DESCRIPTION
This way of writing the loops is better and does not invoke undefined behavior or implementation defined behavior since size_t is unsigned