### PR TITLE
Fix Clang-15 warnings

### DIFF
--- a/include/boost/math/concepts/std_real_concept.hpp
+++ b/include/boost/math/concepts/std_real_concept.hpp
@@ -340,7 +340,6 @@ inline std::basic_istream<charT, traits>& operator>>(std::basic_istream<charT, t
 } // namespace concepts
 }}
 
-#include <boost/math/tools/precision.hpp>
 #include <boost/math/tools/big_constant.hpp>
 
 namespace boost{ namespace math{

--- a/include/boost/math/differentiation/lanczos_smoothing.hpp
+++ b/include/boost/math/differentiation/lanczos_smoothing.hpp
@@ -569,8 +569,8 @@ public:
     discrete_lanczos_derivative& operator=(const discrete_lanczos_derivative&) = delete;
 
     // Allow moves:
-    discrete_lanczos_derivative(discrete_lanczos_derivative&&) = default;
-    discrete_lanczos_derivative& operator=(discrete_lanczos_derivative&&) = default;
+    discrete_lanczos_derivative(discrete_lanczos_derivative&&) noexcept = default;
+    discrete_lanczos_derivative& operator=(discrete_lanczos_derivative&&) noexcept = default;
 
 private:
     std::vector<Real> m_f;

--- a/include/boost/math/distributions/complement.hpp
+++ b/include/boost/math/distributions/complement.hpp
@@ -29,7 +29,7 @@ struct complemented2_type
    const RealType& param;
 
 private:
-   complemented2_type& operator=(const complemented2_type&);
+   complemented2_type& operator=(const complemented2_type&) = delete;
 };
 
 template <class Dist, class RealType1, class RealType2>
@@ -47,7 +47,7 @@ struct complemented3_type
    const RealType1& param1;
    const RealType2& param2;
 private:
-   complemented3_type& operator=(const complemented3_type&);
+   complemented3_type& operator=(const complemented3_type&) = delete;
 };
 
 template <class Dist, class RealType1, class RealType2, class RealType3>
@@ -68,7 +68,7 @@ struct complemented4_type
    const RealType2& param2;
    const RealType3& param3;
 private:
-   complemented4_type& operator=(const complemented4_type&);
+   complemented4_type& operator=(const complemented4_type&) = delete;
 };
 
 template <class Dist, class RealType1, class RealType2, class RealType3, class RealType4>
@@ -92,7 +92,7 @@ struct complemented5_type
    const RealType3& param3;
    const RealType4& param4;
 private:
-   complemented5_type& operator=(const complemented5_type&);
+   complemented5_type& operator=(const complemented5_type&) = delete;
 };
 
 template <class Dist, class RealType1, class RealType2, class RealType3, class RealType4, class RealType5>
@@ -119,7 +119,7 @@ struct complemented6_type
    const RealType4& param4;
    const RealType5& param5;
 private:
-   complemented6_type& operator=(const complemented6_type&);
+   complemented6_type& operator=(const complemented6_type&) = delete;
 };
 
 template <class Dist, class RealType1, class RealType2, class RealType3, class RealType4, class RealType5, class RealType6>
@@ -149,7 +149,7 @@ struct complemented7_type
    const RealType5& param5;
    const RealType6& param6;
 private:
-   complemented7_type& operator=(const complemented7_type&);
+   complemented7_type& operator=(const complemented7_type&) = delete;
 };
 
 template <class Dist, class RealType>

--- a/include/boost/math/distributions/hyperexponential.hpp
+++ b/include/boost/math/distributions/hyperexponential.hpp
@@ -137,7 +137,7 @@ bool check_dist(char const* function, std::vector<RealT> const& probabilities, s
     if (probabilities.size() != rates.size())
     {
         *presult = policies::raise_domain_error<RealT>(function,
-                                                       "The parameters \"probabilities\" and \"rates\" must have the same length, but their size differ by: %1%.",
+                                                       R"(The parameters "probabilities" and "rates" must have the same length, but their size differ by: %1%.)",
                                                        fabs(static_cast<RealT>(probabilities.size())-static_cast<RealT>(rates.size())),
                                                        pol);
         return false;

--- a/include/boost/math/distributions/kolmogorov_smirnov.hpp
+++ b/include/boost/math/distributions/kolmogorov_smirnov.hpp
@@ -140,7 +140,7 @@ RealType kolmogorov_smirnov_pdf_small_x(RealType x, RealType n, const Policy&) {
     if (x2n*x2n == 0.0) {
         return static_cast<RealType>(0);
     }
-    while (1) {
+    while (true) {
         delta = exp(-RealType(i+0.5)*RealType(i+0.5)*pi2/(2*x2n)) * (RealType(i+0.5)*RealType(i+0.5)*pi2 - x2n);
 
         if (delta == 0.0)
@@ -164,7 +164,7 @@ inline RealType kolmogorov_smirnov_pdf_large_x(RealType x, RealType n, const Pol
     RealType value = RealType(0), delta = RealType(0), last_delta = RealType(0);
     RealType eps = policies::get_epsilon<RealType, Policy>();
     int i = 1;
-    while (1) {
+    while (true) {
         delta = 8*x*i*i*exp(-2*i*i*x*x*n);
 
         if (delta == 0.0)

--- a/include/boost/math/policies/error_handling.hpp
+++ b/include/boost/math/policies/error_handling.hpp
@@ -152,8 +152,7 @@ void raise_error(const char* pfunction, const char* message)
   msg += ": ";
   msg += message;
 
-  E e(msg);
-  BOOST_MATH_THROW_EXCEPTION(e)
+  BOOST_MATH_THROW_EXCEPTION(E(msg))
 }
 
 template <class E, class T>
@@ -183,8 +182,7 @@ void raise_error(const char* pfunction, const char* pmessage, const T& val)
   replace_all_in_string(message, "%1%", sval.c_str());
   msg += message;
 
-  E e(msg);
-  BOOST_MATH_THROW_EXCEPTION(e)
+  BOOST_MATH_THROW_EXCEPTION(E(msg))
 }
 #endif
 

--- a/include/boost/math/policies/policy.hpp
+++ b/include/boost/math/policies/policy.hpp
@@ -641,7 +641,7 @@ struct normalise<policy<detail::forwarding_arg1, detail::forwarding_arg2>,
 };
 
 inline constexpr policy<> make_policy() noexcept
-{ return policy<>(); }
+{ return {}; }
 
 template <class A1>
 inline constexpr typename normalise<policy<>, A1>::type make_policy(const A1&) noexcept
@@ -948,7 +948,7 @@ struct method_error_check
 {
    using domain_error_type = typename Policy::domain_error_type;
    using type = typename std::conditional<
-      (domain_error_type::value == throw_on_error) && (domain_error_type::value != user_error),
+      (domain_error_type::value == throw_on_error),
       std::false_type,
       std::true_type>::type;
 };

--- a/include/boost/math/quadrature/detail/exp_sinh_detail.hpp
+++ b/include/boost/math/quadrature/detail/exp_sinh_detail.hpp
@@ -131,7 +131,7 @@ private:
     mutable std::vector<std::vector<Real>> m_weights;
     std::size_t                       m_max_refinements;
 #if !defined(BOOST_MATH_NO_ATOMIC_INT) && defined(BOOST_HAS_THREADS)
-    mutable boost::math::detail::atomic_unsigned_type      m_committed_refinements;
+    mutable boost::math::detail::atomic_unsigned_type      m_committed_refinements{};
     mutable std::mutex m_mutex;
 #else
     mutable unsigned                  m_committed_refinements;

--- a/include/boost/math/quadrature/detail/ooura_fourier_integrals_detail.hpp
+++ b/include/boost/math/quadrature/detail/ooura_fourier_integrals_detail.hpp
@@ -434,7 +434,7 @@ private:
     Real rel_err_goal_;
 
     #ifdef BOOST_HAS_THREADS
-    std::atomic<long> starting_level_;
+    std::atomic<long> starting_level_{};
     #else
     long starting_level_;
     #endif
@@ -663,7 +663,7 @@ private:
     Real rel_err_goal_;
 
     #ifdef BOOST_HAS_THREADS
-    std::atomic<long> starting_level_;
+    std::atomic<long> starting_level_{};
     #else
     long starting_level_;
     #endif

--- a/include/boost/math/quadrature/detail/sinh_sinh_detail.hpp
+++ b/include/boost/math/quadrature/detail/sinh_sinh_detail.hpp
@@ -132,7 +132,7 @@ private:
    mutable std::vector<std::vector<Real>> m_weights;
    std::size_t                       m_max_refinements;
 #if !defined(BOOST_MATH_NO_ATOMIC_INT) && defined(BOOST_HAS_THREADS)
-   mutable boost::math::detail::atomic_unsigned_type      m_committed_refinements;
+   mutable boost::math::detail::atomic_unsigned_type      m_committed_refinements{};
    mutable std::mutex m_mutex;
 #else
    mutable unsigned                  m_committed_refinements;

--- a/include/boost/math/quadrature/detail/tanh_sinh_detail.hpp
+++ b/include/boost/math/quadrature/detail/tanh_sinh_detail.hpp
@@ -177,9 +177,9 @@ private:
    mutable std::vector<std::vector<Real>> m_abscissas;
    mutable std::vector<std::vector<Real>> m_weights;
    mutable std::vector<std::size_t>       m_first_complements;
-   std::size_t                       m_max_refinements, m_inital_row_length;
+   std::size_t                       m_max_refinements, m_inital_row_length{};
 #if !defined(BOOST_MATH_NO_ATOMIC_INT) && defined(BOOST_HAS_THREADS)
-   mutable boost::math::detail::atomic_unsigned_type      m_committed_refinements;
+   mutable boost::math::detail::atomic_unsigned_type      m_committed_refinements{};
    mutable std::mutex m_mutex;
 #else
    mutable unsigned                  m_committed_refinements;

--- a/include/boost/math/quadrature/naive_monte_carlo.hpp
+++ b/include/boost/math/quadrature/naive_monte_carlo.hpp
@@ -41,7 +41,7 @@ public:
                       Real error_goal,
                       bool singular = true,
                       uint64_t threads = std::thread::hardware_concurrency(),
-                      uint64_t seed = 0) noexcept : m_num_threads{threads}, m_seed{seed}
+                      uint64_t seed = 0) noexcept : m_num_threads{threads}, m_seed{seed}, m_volume(1)
     {
         using std::numeric_limits;
         using std::sqrt;
@@ -49,7 +49,7 @@ public:
         m_lbs.resize(n);
         m_dxs.resize(n);
         m_limit_types.resize(n);
-        m_volume = 1;
+
         static const char* function = "boost::math::quadrature::naive_monte_carlo<%1%>";
         for (uint64_t i = 0; i < n; ++i)
         {
@@ -439,12 +439,12 @@ private:
     uint64_t m_num_threads;
     std::atomic<uint64_t> m_seed;
     std::atomic<Real> m_error_goal;
-    std::atomic<bool> m_done;
+    std::atomic<bool> m_done{};
     std::vector<Real> m_lbs;
     std::vector<Real> m_dxs;
     std::vector<detail::limit_classification> m_limit_types;
     Real m_volume;
-    std::atomic<uint64_t> m_total_calls;
+    std::atomic<uint64_t> m_total_calls{};
     // I wanted these to be vectors rather than maps,
     // but you can't resize a vector of atomics.
     std::unique_ptr<std::atomic<uint64_t>[]> m_thread_calls;

--- a/include/boost/math/special_functions/detail/hypergeometric_1F1_bessel.hpp
+++ b/include/boost/math/special_functions/detail/hypergeometric_1F1_bessel.hpp
@@ -148,7 +148,7 @@
         int n, cache_offset;
         long long log_scale;
 
-        hypergeometric_1F1_AS_13_3_7_tricomi_series operator=(const hypergeometric_1F1_AS_13_3_7_tricomi_series&);
+        hypergeometric_1F1_AS_13_3_7_tricomi_series operator=(const hypergeometric_1F1_AS_13_3_7_tricomi_series&) = delete;
 
         void refill_cache()
         {
@@ -559,9 +559,9 @@
               *j *= ratio;
         }
 
-        hypergeometric_1F1_AS_13_3_6_series();
-        hypergeometric_1F1_AS_13_3_6_series(const hypergeometric_1F1_AS_13_3_6_series&);
-        hypergeometric_1F1_AS_13_3_6_series& operator=(const hypergeometric_1F1_AS_13_3_6_series&);
+        hypergeometric_1F1_AS_13_3_6_series() = delete;
+        hypergeometric_1F1_AS_13_3_6_series(const hypergeometric_1F1_AS_13_3_6_series&) = delete;
+        hypergeometric_1F1_AS_13_3_6_series& operator=(const hypergeometric_1F1_AS_13_3_6_series&) = delete;
      };
 
      template <class T, class Policy>

--- a/include/boost/math/special_functions/detail/hypergeometric_1F1_recurrence.hpp
+++ b/include/boost/math/special_functions/detail/hypergeometric_1F1_recurrence.hpp
@@ -36,7 +36,7 @@
     {
     }
 
-    explicit hypergeometric_1F1_recurrence_a_coefficients(const hypergeometric_1F1_recurrence_a_coefficients&) = default;
+    hypergeometric_1F1_recurrence_a_coefficients(const hypergeometric_1F1_recurrence_a_coefficients&) = default;
 
     hypergeometric_1F1_recurrence_a_coefficients operator=(const hypergeometric_1F1_recurrence_a_coefficients&) = delete;
 
@@ -67,7 +67,7 @@
     {
     }
 
-    explicit hypergeometric_1F1_recurrence_b_coefficients(const hypergeometric_1F1_recurrence_b_coefficients&) = default;
+    hypergeometric_1F1_recurrence_b_coefficients(const hypergeometric_1F1_recurrence_b_coefficients&) = default;
 
     hypergeometric_1F1_recurrence_b_coefficients& operator=(const hypergeometric_1F1_recurrence_b_coefficients&) = delete;
 
@@ -100,7 +100,7 @@
      {
      }
 
-     explicit hypergeometric_1F1_recurrence_small_b_coefficients(const hypergeometric_1F1_recurrence_small_b_coefficients&) = default;
+     hypergeometric_1F1_recurrence_small_b_coefficients(const hypergeometric_1F1_recurrence_small_b_coefficients&) = default;
 
      hypergeometric_1F1_recurrence_small_b_coefficients operator=(const hypergeometric_1F1_recurrence_small_b_coefficients&) = delete;
 

--- a/include/boost/math/special_functions/detail/t_distribution_inv.hpp
+++ b/include/boost/math/special_functions/detail/t_distribution_inv.hpp
@@ -204,7 +204,7 @@ T inverse_students_t_body_series(T df, T u, const Policy& pol)
 }
 
 template <class T, class Policy>
-T inverse_students_t(T df, T u, T v, const Policy& pol, bool* pexact = 0)
+T inverse_students_t(T df, T u, T v, const Policy& pol, bool* pexact = nullptr)
 {
    //
    // df = number of degrees of freedom.

--- a/include/boost/math/special_functions/expm1.hpp
+++ b/include/boost/math/special_functions/expm1.hpp
@@ -65,8 +65,8 @@ namespace detail
      int k;
      const T m_x;
      T m_term;
-     expm1_series(const expm1_series&);
-     expm1_series& operator=(const expm1_series&);
+     expm1_series(const expm1_series&) = delete;
+     expm1_series& operator=(const expm1_series&) = delete;
   };
 
 template <class T, class Policy, class tag>

--- a/include/boost/math/special_functions/heuman_lambda.hpp
+++ b/include/boost/math/special_functions/heuman_lambda.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/math/special_functions/math_fwd.hpp>
 #include <boost/math/special_functions/ellint_rj.hpp>
-#include <boost/math/special_functions/ellint_rj.hpp>
 #include <boost/math/special_functions/ellint_1.hpp>
 #include <boost/math/special_functions/jacobi_zeta.hpp>
 #include <boost/math/constants/constants.hpp>

--- a/include/boost/math/special_functions/legendre.hpp
+++ b/include/boost/math/special_functions/legendre.hpp
@@ -100,7 +100,7 @@ T legendre_p_prime_imp(unsigned l, T x, const Policy& pol, T* Pn
     T p0 = 1;
     T p1 = x;
     T p_prime;
-    bool odd = l & 1;
+    bool odd = (l & 1 == 1);
     // If the order is odd, we sum all the even polynomials:
     if (odd)
     {

--- a/include/boost/math/special_functions/legendre_stieltjes.hpp
+++ b/include/boost/math/special_functions/legendre_stieltjes.hpp
@@ -38,8 +38,7 @@ public:
         std::ptrdiff_t n = m - 1;
         std::ptrdiff_t q;
         std::ptrdiff_t r;
-        bool odd = n & 1;
-        if (odd)
+        if (n & 1 == 1)
         {
            q = 1;
            r = (n-1)/2 + 2;
@@ -75,7 +74,7 @@ public:
     Real norm_sq() const
     {
         Real t = 0;
-        bool odd = m_m & 1;
+        bool odd = (m_m & 1 == 1);
         for (size_t i = 1; i < m_a.size(); ++i)
         {
             if(odd)
@@ -101,7 +100,7 @@ public:
         Real p1 = x;
 
         Real Em;
-        bool odd = m_m & 1;
+        bool odd = (m_m & 1 == 1);
         if (odd)
         {
             Em = m_a[1]*p1;

--- a/include/boost/math/special_functions/log1p.hpp
+++ b/include/boost/math/special_functions/log1p.hpp
@@ -65,8 +65,8 @@ namespace detail
      int k;
      const T m_mult;
      T m_prod;
-     log1p_series(const log1p_series&);
-     log1p_series& operator=(const log1p_series&);
+     log1p_series(const log1p_series&) = delete;
+     log1p_series& operator=(const log1p_series&) = delete;
   };
 
 // Algorithm log1p is part of C99, but is not yet provided by many compilers.

--- a/include/boost/math/special_functions/sin_pi.hpp
+++ b/include/boost/math/special_functions/sin_pi.hpp
@@ -27,9 +27,9 @@ inline T sin_pi_imp(T x, const Policy& pol)
    if(x < 0)
       return -sin_pi_imp(T(-x), pol);
    // sin of pi*x:
-   bool invert;
    if(x < 0.5)
       return sin(constants::pi<T>() * x);
+   bool invert;
    if(x < 1)
    {
       invert = true;

--- a/include/boost/math/special_functions/ulp.hpp
+++ b/include/boost/math/special_functions/ulp.hpp
@@ -26,7 +26,7 @@ T ulp_imp(const T& val, const std::true_type&, const Policy& pol)
 
    int fpclass = (boost::math::fpclassify)(val);
 
-   if(fpclass == (int)FP_NAN)
+   if(fpclass == FP_NAN)
    {
       return policies::raise_domain_error<T>(
          function,
@@ -60,13 +60,13 @@ T ulp_imp(const T& val, const std::false_type&, const Policy& pol)
 
    int fpclass = (boost::math::fpclassify)(val);
 
-   if(fpclass == (int)FP_NAN)
+   if(fpclass == FP_NAN)
    {
       return policies::raise_domain_error<T>(
          function,
          "Argument must be finite, but got %1%", val, pol);
    }
-   else if((fpclass == (int)FP_INFINITE) || (fabs(val) >= tools::max_value<T>()))
+   else if((fpclass == FP_INFINITE) || (fabs(val) >= tools::max_value<T>()))
    {
       return (val < 0 ? -1 : 1) * policies::raise_overflow_error<T>(function, nullptr, pol);
    }

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -283,7 +283,7 @@ public:
    typedef typename std::vector<T>::size_type size_type;
 
    // construct:
-   polynomial(){}
+   polynomial()= default;
 
    template <class U>
    polynomial(const U* data, unsigned order)
@@ -379,7 +379,7 @@ public:
 
    T operator()(T z) const
    {
-      return m_data.size() > 0 ? boost::math::tools::evaluate_polynomial(&m_data[0], z, m_data.size()) : T(0);
+      return m_data.size() > 0 ? boost::math::tools::evaluate_polynomial((m_data).data(), z, m_data.size()) : T(0);
    }
    std::vector<T> chebyshev() const
    {

--- a/include/boost/math/tools/polynomial_gcd.hpp
+++ b/include/boost/math/tools/polynomial_gcd.hpp
@@ -23,7 +23,6 @@
 #include <numeric>
 #include <utility>
 #include <iterator>
-#include <type_traits>
 #include <boost/math/tools/assert.hpp>
 #include <boost/math/tools/config.hpp>
 

--- a/include/boost/math/tools/recurrence.hpp
+++ b/include/boost/math/tools/recurrence.hpp
@@ -50,7 +50,7 @@ namespace boost {
                }
 
             private:
-               function_ratio_from_backwards_recurrence_fraction operator=(const function_ratio_from_backwards_recurrence_fraction&);
+               function_ratio_from_backwards_recurrence_fraction operator=(const function_ratio_from_backwards_recurrence_fraction&) = delete;
 
                Recurrence r;
                int k;

--- a/include/boost/math/tools/stats.hpp
+++ b/include/boost/math/tools/stats.hpp
@@ -24,8 +24,7 @@ public:
       : m_min(tools::max_value<T>()),
         m_max(-tools::max_value<T>()),
         m_total(0),
-        m_squared_total(0),
-        m_count(0)
+        m_squared_total(0)
    {}
    void add(const T& val)
    {
@@ -77,7 +76,7 @@ public:
    }
 private:
    T m_min, m_max, m_total, m_squared_total;
-   std::uintmax_t m_count;
+   std::uintmax_t m_count{0};
 };
 
 } // namespace tools

--- a/include/boost/math/tools/toms748_solve.hpp
+++ b/include/boost/math/tools/toms748_solve.hpp
@@ -32,9 +32,9 @@ template <class T>
 class eps_tolerance
 {
 public:
-   eps_tolerance()
+   eps_tolerance() : eps(4 * tools::epsilon<T>())
    {
-      eps = 4 * tools::epsilon<T>();
+
    }
    eps_tolerance(unsigned bits)
    {
@@ -52,7 +52,7 @@ private:
 
 struct equal_floor
 {
-   equal_floor(){}
+   equal_floor()= default;
    template <class T>
    bool operator()(const T& a, const T& b)
    {
@@ -63,7 +63,7 @@ struct equal_floor
 
 struct equal_ceil
 {
-   equal_ceil(){}
+   equal_ceil()= default;
    template <class T>
    bool operator()(const T& a, const T& b)
    {
@@ -74,7 +74,7 @@ struct equal_ceil
 
 struct equal_nearest_integer
 {
-   equal_nearest_integer(){}
+   equal_nearest_integer()= default;
    template <class T>
    bool operator()(const T& a, const T& b)
    {

--- a/include/boost/math/tools/ulps_plot.hpp
+++ b/include/boost/math/tools/ulps_plot.hpp
@@ -212,11 +212,11 @@ public:
         else
         {
             std::vector<double> ys{-3.0, -2.5, -2.0, -1.5, -1.0, -0.5, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0};
-            for (size_t i = 0; i < ys.size(); ++i)
+            for (double & i : ys)
             {
-                if (min_y <= ys[i] && ys[i] <= max_y)
+                if (min_y <= i && i <= max_y)
                 {
-                    PreciseReal y_cord_dataspace = ys[i];
+                    PreciseReal y_cord_dataspace = i;
                     PreciseReal y = y_scale(y_cord_dataspace);
                     fs << "<line x1='0' y1='" << y << "' x2='" << graph_width
                        << "' y2='" << y


### PR DESCRIPTION
Redundant casts, noexcept for move constructors, and usage of default and delete make the code more performant and maintainable