### PR TITLE
Fix warnings in quadrature tests

### DIFF
--- a/include/boost/math/quadrature/detail/exp_sinh_detail.hpp
+++ b/include/boost/math/quadrature/detail/exp_sinh_detail.hpp
@@ -21,7 +21,6 @@
 
 namespace boost{ namespace math{ namespace quadrature { namespace detail{
 
-
 // Returns the exp-sinh quadrature of a function f over the open interval (0, infinity)
 
 template<class Real, class Policy>
@@ -227,7 +226,7 @@ auto exp_sinh_detail<Real, Policy>::integrate(const F& f, Real* error, Real* L1,
         auto weight_row = get_weight_row(i);
 
         first_j = first_j == 0 ? 0 : 2 * first_j - 1;  // appoximate location to start looking for lowest meaningful abscissa value
-        Real abterm1 = 1;
+        BOOST_MATH_MAYBE_UNUSED Real abterm1 = 1;
         std::size_t j = first_j;
         while (abscissas_row[j] < min_abscissa)
            ++j;

--- a/include/boost/math/special_functions/legendre.hpp
+++ b/include/boost/math/special_functions/legendre.hpp
@@ -100,7 +100,7 @@ T legendre_p_prime_imp(unsigned l, T x, const Policy& pol, T* Pn
     T p0 = 1;
     T p1 = x;
     T p_prime;
-    bool odd = (l & 1 == 1);
+    bool odd = ((l & 1) == 1);
     // If the order is odd, we sum all the even polynomials:
     if (odd)
     {

--- a/include/boost/math/special_functions/legendre_stieltjes.hpp
+++ b/include/boost/math/special_functions/legendre_stieltjes.hpp
@@ -38,7 +38,7 @@ public:
         std::ptrdiff_t n = m - 1;
         std::ptrdiff_t q;
         std::ptrdiff_t r;
-        if (n & 1 == 1)
+        if ((n & 1) == 1)
         {
            q = 1;
            r = (n-1)/2 + 2;
@@ -74,7 +74,7 @@ public:
     Real norm_sq() const
     {
         Real t = 0;
-        bool odd = (m_m & 1 == 1);
+        bool odd = ((m_m & 1) == 1);
         for (size_t i = 1; i < m_a.size(); ++i)
         {
             if(odd)
@@ -100,7 +100,7 @@ public:
         Real p1 = x;
 
         Real Em;
-        bool odd = (m_m & 1 == 1);
+        bool odd = ((m_m & 1) == 1);
         if (odd)
         {
             Em = m_a[1]*p1;

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -146,6 +146,23 @@
 #  define BOOST_MATH_EXEC_COMPATIBLE
 #endif
 
+// Attributes from C++14 and newer
+#ifdef __has_cpp_attribute
+
+// C++17
+#if (__cplusplus >= 201703L || _MSVC_LANG >= 201703L)
+#  if __has_cpp_attribute(maybe_unused)
+#    define BOOST_MATH_MAYBE_UNUSED [[maybe_unused]]
+#  endif
+#endif
+
+#endif
+
+// If attributes are not defined make sure we don't have compiler errors
+#ifndef BOOST_MATH_MAYBE_UNUSED
+#  define BOOST_MATH_MAYBE_UNUSED 
+#endif
+
 #include <algorithm>  // for min and max
 #include <limits>
 #include <cmath>


### PR DESCRIPTION
Removes all Boost.Math warnings from "-Wall -Wextra -Wpedantic" on Apple Clang 14.
- Conditionally unused variable
- Fix operator precedence with parentheses