### PR TITLE
Remove redundant casts to bool

### DIFF
--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -58,7 +58,7 @@ template <class T>
 inline bool is_odd(T v, const std::true_type&)
 {
    int i = static_cast<int>(v);
-   return i&1;
+   return (i & 1) == 1;
 }
 template <class T>
 inline bool is_odd(T v, const std::false_type&)
@@ -66,7 +66,7 @@ inline bool is_odd(T v, const std::false_type&)
    // Oh dear can't cast T to int!
    BOOST_MATH_STD_USING
    T modulus = v - 2 * floor(v/2);
-   return static_cast<bool>(modulus != 0);
+   return modulus != 0;
 }
 template <class T>
 inline bool is_odd(T v)

--- a/src/tr1/fpclassify.cpp
+++ b/src/tr1/fpclassify.cpp
@@ -12,16 +12,11 @@
 #include <boost/math/special_functions/sign.hpp>
 #include "c_policy.hpp"
 
-#if defined (_MSC_VER)
-#  pragma warning(push)
-#  pragma warning (disable: 4800) // 'int' : forcing value to bool 'true' or 'false' (performance warning)
-#endif
-
 namespace boost{ namespace math{ namespace tr1{
 
 template<> bool BOOST_MATH_TR1_DECL signbit<double> BOOST_PREVENT_MACRO_SUBSTITUTION(double x)
 {
-   return static_cast<bool>((boost::math::signbit)(x));
+   return (boost::math::signbit)(x) != 0;
 }
 
 template<> int BOOST_MATH_TR1_DECL fpclassify<double> BOOST_PREVENT_MACRO_SUBSTITUTION(double x)

--- a/src/tr1/fpclassifyf.cpp
+++ b/src/tr1/fpclassifyf.cpp
@@ -12,16 +12,11 @@
 #include <boost/math/special_functions/sign.hpp>
 #include "c_policy.hpp"
 
-#if defined (_MSC_VER)
-#  pragma warning(push)
-#  pragma warning (disable: 4800) // 'int' : forcing value to bool 'true' or 'false' (performance warning)
-#endif
-
 namespace boost{ namespace math{ namespace tr1{
 
 template<> bool BOOST_MATH_TR1_DECL signbit<float> BOOST_PREVENT_MACRO_SUBSTITUTION(float x)
 {
-   return static_cast<bool>((boost::math::signbit)(x));
+   return (boost::math::signbit)(x) != 0;
 }
 
 template<> int BOOST_MATH_TR1_DECL fpclassify<float> BOOST_PREVENT_MACRO_SUBSTITUTION(float x)

--- a/src/tr1/fpclassifyl.cpp
+++ b/src/tr1/fpclassifyl.cpp
@@ -12,16 +12,11 @@
 #include <boost/math/special_functions/sign.hpp>
 #include "c_policy.hpp"
 
-#if defined (_MSC_VER)
-#  pragma warning(push)
-#  pragma warning (disable: 4800) // 'int' : forcing value to bool 'true' or 'false' (performance warning)
-#endif
-
 namespace boost{ namespace math{ namespace tr1{
 
 template<> bool BOOST_MATH_TR1_DECL signbit<long double> BOOST_PREVENT_MACRO_SUBSTITUTION(long double x)
 {
-   return static_cast<bool>((boost::math::signbit)(x));
+   return (boost::math::signbit)(x) != 0;
 }
 
 template<> int BOOST_MATH_TR1_DECL fpclassify<long double> BOOST_PREVENT_MACRO_SUBSTITUTION(long double x)


### PR DESCRIPTION
They are booleans already. Why do we need to static cast or implicitly cast?