### PR TITLE
Use 64-bit RNG for types that are 64 bits

### DIFF
--- a/include/boost/math/tools/random_vector.hpp
+++ b/include/boost/math/tools/random_vector.hpp
@@ -4,10 +4,10 @@
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <vector>
+#include <cstddef>
 #include <random>
 #include <type_traits>
-#include <cstddef>
+#include <vector>
 
 namespace boost { namespace math {
 
@@ -25,12 +25,12 @@ std::vector<T> generate_random_vector(std::size_t size, std::size_t seed)
     }
     std::vector<T> v(size);
 
-    std::mt19937 gen(seed);
+    std::mt19937_64 gen(seed);
 
     std::normal_distribution<T> dis(0, 1);
-    for(std::size_t i = 0; i < v.size(); ++i)
+    for (auto& x : v)
     {
-        v[i] = dis(gen);
+        x = dis(gen);
     }
     return v;
 }
@@ -49,9 +49,9 @@ std::vector<T> generate_random_uniform_vector(std::size_t size, std::size_t seed
 
     std::uniform_real_distribution<T> dis(lower_bound, upper_bound);
 
-    for (auto& i : v)
+    for (auto& x : v)
     {
-        i = dis(gen);
+        x = dis(gen);
     }
     
     return v;
@@ -70,9 +70,9 @@ std::vector<T> generate_random_vector(std::size_t size, std::size_t seed, T mean
     std::mt19937 gen(seed);
 
     std::normal_distribution<T> dis(mean, stddev);
-    for (std::size_t i = 0; i < v.size(); ++i)
+    for (auto& x : v)
     {
-        v[i] = dis(gen);
+        x = dis(gen);
     }
     return v;
 }
@@ -87,13 +87,13 @@ std::vector<T> generate_random_vector(std::size_t size, std::size_t seed)
     }
     std::vector<T> v(size);
 
-    std::mt19937 gen(seed);
+    std::mt19937_64 gen(seed);
 
     // Rescaling by larger than 2 is UB!
     std::uniform_int_distribution<T> dis(std::numeric_limits<T>::lowest()/2, (std::numeric_limits<T>::max)()/2);
-    for (std::size_t i = 0; i < v.size(); ++i)
+    for (auto& x : v)
     {
-        v[i] = dis(gen);
+        x = dis(gen);
     }
     return v;
 }


### PR DESCRIPTION
Do this instead of casting down every time we do a normal distribution.