### PR TITLE
Fix hopefully the last Clang-Tidy suggestions

### DIFF
--- a/example/hyperexponential_more_snips.cpp
+++ b/example/hyperexponential_more_snips.cpp
@@ -130,7 +130,7 @@ void print_fitted(ds_info const& ds)
    std::cout << "* Fitted Request Interarrival Time" << std::endl;
    std::cout << " - Mean (SD): " << boost::math::mean(ds.iat_he) << " (" << boost::math::standard_deviation(ds.iat_he) << ") seconds." << std::endl;
    std::cout << " - 99th Percentile: " << boost::math::quantile(ds.iat_he, 0.99) << " seconds." << std::endl;
-   std::cout << " - Probability that a VM will arrive within 30 minutes: " << boost::math::cdf(ds.iat_he, secs_in_a_hour / 2.0) << std::endl;
+   std::cout << " - Probability that a VM will arrive within 30 minutes: " << boost::math::cdf(ds.iat_he, secs_in_a_hour * 0.5) << std::endl;
    std::cout << " - Probability that a VM will arrive after 1 hour: " << boost::math::cdf(boost::math::complement(ds.iat_he, secs_in_a_hour)) << std::endl;
    std::cout << "* Fitted Multi-core VM Lifetime" << std::endl;
    std::cout << " - Mean (SD): " << boost::math::mean(ds.multi_lt_he) << " (" << boost::math::standard_deviation(ds.multi_lt_he) << ") seconds." << std::endl;

--- a/example/naive_monte_carlo_example.cpp
+++ b/example/naive_monte_carlo_example.cpp
@@ -63,7 +63,7 @@ int main()
 
     auto task = mc.integrate();
 
-    int s = 0;
+    unsigned s = 0;
     std::cout << "Hit ctrl-c to cancel.\n";
     while (task.wait_for(std::chrono::seconds(1)) != std::future_status::ready)
     {

--- a/example/ooura_fourier_integrals_example.cpp
+++ b/example/ooura_fourier_integrals_example.cpp
@@ -18,7 +18,6 @@
 #include <cmath>
 #include <iostream>
 #include <limits>
-#include <iostream>
 
 int main()
 {

--- a/include/boost/math/ccmath/isnormal.hpp
+++ b/include/boost/math/ccmath/isnormal.hpp
@@ -20,11 +20,9 @@ template <typename T>
 inline constexpr bool isnormal(T x)
 {
     if(BOOST_MATH_IS_CONSTANT_EVALUATED(x))
-    {   
-        return x == T(0) ? false :
-               boost::math::ccmath::isinf(x) ? false :
-               boost::math::ccmath::isnan(x) ? false :
-               boost::math::ccmath::abs(x) < (std::numeric_limits<T>::min)() ? false : true;
+    {
+        return x != T(0) && !boost::math::ccmath::isinf(x) && !boost::math::ccmath::isnan(x) &&
+               boost::math::ccmath::abs(x) >= (std::numeric_limits<T>::min)();
     }
     else
     {

--- a/include/boost/math/constants/calculate_constants.hpp
+++ b/include/boost/math/constants/calculate_constants.hpp
@@ -628,20 +628,21 @@ inline T constant_zeta_three<T>::compute(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE_SPEC(
       // int nn = (2 * n + 1);
       // T d = factorial(nn); // inline factorial.
       T d = 1;
-      for(unsigned int i = 1; i <= (n+n + 1); ++i) // (2n + 1)
+      for(unsigned int i = 1; i <= (2 * n + 1); ++i) // (2n + 1)
       {
         d *= i;
       }
       T den = d * d * d * d * d; // [(2n+1)!]^5
       //cout << "den = " << den << endl;
       T term = num/den;
-      if (n % 2 != 0)
-      { //term *= -1;
-        sum -= term;
+      if ((n & 1) == 0)
+      { 
+        sum += term;
       }
       else
       {
-        sum += term;
+        //term *= -1;
+        sum -= term;
       }
       //cout << "term = " << term << endl;
       //cout << "sum/64  = " << sum/64 << endl;

--- a/include/boost/math/cstdfloat/cstdfloat_cmath.hpp
+++ b/include/boost/math/cstdfloat/cstdfloat_cmath.hpp
@@ -89,17 +89,17 @@ namespace boost {
                   else
                   {
                      // The variable xn stores the binary powers of x.
-                     float_type result(((p % integer_type(2)) != integer_type(0)) ? x : float_type(1));
+                     float_type result(((p & 1) == integer_type(1)) ? x : float_type(1));
                      float_type xn(x);
 
                      integer_type p2 = p;
 
-                     while (integer_type(p2 /= 2) != integer_type(0))
+                     while (integer_type(p2 >>= 1) != integer_type(0))
                      {
                         // Square xn for each binary power.
                         xn *= xn;
 
-                        const bool has_binary_power = (integer_type(p2 % integer_type(2)) != integer_type(0));
+                        const bool has_binary_power = (integer_type(p2 & 1) == integer_type(1));
 
                         if (has_binary_power)
                         {

--- a/include/boost/math/cstdfloat/cstdfloat_complex_std.hpp
+++ b/include/boost/math/cstdfloat/cstdfloat_complex_std.hpp
@@ -525,17 +525,17 @@
         else
         {
           // The variable xn stores the binary powers of x.
-          complex<BOOST_CSTDFLOAT_EXTENDED_COMPLEX_FLOAT_TYPE> result(((p % 2) != 0) ? x : complex<BOOST_CSTDFLOAT_EXTENDED_COMPLEX_FLOAT_TYPE>(BOOST_CSTDFLOAT_EXTENDED_COMPLEX_FLOAT_TYPE(1)));
+          complex<BOOST_CSTDFLOAT_EXTENDED_COMPLEX_FLOAT_TYPE> result(((p & 1) == 1) ? x : complex<BOOST_CSTDFLOAT_EXTENDED_COMPLEX_FLOAT_TYPE>(BOOST_CSTDFLOAT_EXTENDED_COMPLEX_FLOAT_TYPE(1)));
           complex<BOOST_CSTDFLOAT_EXTENDED_COMPLEX_FLOAT_TYPE> xn    (x);
 
           int p2 = p;
 
-          while((p2 /= 2) != 0)
+          while((p2 >>= 1) != 0)
           {
             // Square xn for each binary power.
             xn *= xn;
 
-            const bool has_binary_power = ((p2 % 2) != 0);
+            const bool has_binary_power = ((p2 & 1) == 1);
 
             if(has_binary_power)
             {
@@ -740,7 +740,7 @@
 
     inline complex<BOOST_CSTDFLOAT_EXTENDED_COMPLEX_FLOAT_TYPE> atanh(const complex<BOOST_CSTDFLOAT_EXTENDED_COMPLEX_FLOAT_TYPE>& x)
     {
-      return (std::log(BOOST_CSTDFLOAT_EXTENDED_COMPLEX_FLOAT_TYPE(1) + x) - std::log(BOOST_CSTDFLOAT_EXTENDED_COMPLEX_FLOAT_TYPE(1) - x)) / 2.0;
+      return (std::log(BOOST_CSTDFLOAT_EXTENDED_COMPLEX_FLOAT_TYPE(1) + x) - std::log(BOOST_CSTDFLOAT_EXTENDED_COMPLEX_FLOAT_TYPE(1) - x)) * 0.5;
     }
 
     template<class char_type, class traits_type>

--- a/include/boost/math/cstdfloat/cstdfloat_types.hpp
+++ b/include/boost/math/cstdfloat/cstdfloat_types.hpp
@@ -12,7 +12,7 @@
 #ifndef BOOST_MATH_CSTDFLOAT_TYPES_2014_01_09_HPP_
   #define BOOST_MATH_CSTDFLOAT_TYPES_2014_01_09_HPP_
 
-  #include <float.h>
+  #include <cfloat>
   #include <limits>
   #include <boost/math/tools/config.hpp>
 

--- a/include/boost/math/interpolators/detail/barycentric_rational_detail.hpp
+++ b/include/boost/math/interpolators/detail/barycentric_rational_detail.hpp
@@ -22,16 +22,16 @@ class barycentric_rational_imp
 {
 public:
     template <class InputIterator1, class InputIterator2>
-    barycentric_rational_imp(InputIterator1 start_x, InputIterator1 end_x, InputIterator2 start_y, size_t approximation_order = 3);
+    barycentric_rational_imp(InputIterator1 start_x, InputIterator1 end_x, InputIterator2 start_y, std::size_t approximation_order = 3);
 
-    barycentric_rational_imp(std::vector<Real>&& x, std::vector<Real>&& y, size_t approximation_order = 3);
+    barycentric_rational_imp(std::vector<Real>&& x, std::vector<Real>&& y, std::size_t approximation_order = 3);
 
     Real operator()(Real x) const;
 
     Real prime(Real x) const;
 
     // The barycentric weights are not really that interesting; except to the unit tests!
-    Real weight(size_t i) const { return m_w[i]; }
+    Real weight(std::size_t i) const { return m_w[i]; }
 
     std::vector<Real>&& return_x()
     {
@@ -45,7 +45,7 @@ public:
 
 private:
 
-    void calculate_weights(size_t approximation_order);
+    void calculate_weights(std::size_t approximation_order);
 
     std::vector<Real> m_x;
     std::vector<Real> m_y;
@@ -54,11 +54,11 @@ private:
 
 template <class Real>
 template <class InputIterator1, class InputIterator2>
-barycentric_rational_imp<Real>::barycentric_rational_imp(InputIterator1 start_x, InputIterator1 end_x, InputIterator2 start_y, size_t approximation_order)
+barycentric_rational_imp<Real>::barycentric_rational_imp(InputIterator1 start_x, InputIterator1 end_x, InputIterator2 start_y, std::size_t approximation_order)
 {
     std::ptrdiff_t n = std::distance(start_x, end_x);
 
-    if (approximation_order >= (std::size_t)n)
+    if (approximation_order >= static_cast<std::size_t>(n))
     {
         throw std::domain_error("Approximation order must be < data length.");
     }
@@ -66,7 +66,7 @@ barycentric_rational_imp<Real>::barycentric_rational_imp(InputIterator1 start_x,
     // Big sad memcpy.
     m_x.resize(n);
     m_y.resize(n);
-    for(unsigned i = 0; start_x != end_x; ++start_x, ++start_y, ++i)
+    for(std::size_t i = 0; start_x != end_x; ++start_x, ++start_y, ++i)
     {
         // But if we're going to do a memcpy, we can do some error checking which is inexpensive relative to the copy:
         if(boost::math::isnan(*start_x))
@@ -88,7 +88,7 @@ barycentric_rational_imp<Real>::barycentric_rational_imp(InputIterator1 start_x,
 }
 
 template <class Real>
-barycentric_rational_imp<Real>::barycentric_rational_imp(std::vector<Real>&& x, std::vector<Real>&& y,size_t approximation_order) : m_x(std::move(x)), m_y(std::move(y))
+barycentric_rational_imp<Real>::barycentric_rational_imp(std::vector<Real>&& x, std::vector<Real>&& y,std::size_t approximation_order) : m_x(std::move(x)), m_y(std::move(y))
 {
     BOOST_MATH_ASSERT_MSG(m_x.size() == m_y.size(), "There must be the same number of abscissas and ordinates.");
     BOOST_MATH_ASSERT_MSG(approximation_order < m_x.size(), "Approximation order must be < data length.");
@@ -97,7 +97,7 @@ barycentric_rational_imp<Real>::barycentric_rational_imp(std::vector<Real>&& x, 
 }
 
 template<class Real>
-void barycentric_rational_imp<Real>::calculate_weights(size_t approximation_order)
+void barycentric_rational_imp<Real>::calculate_weights(std::size_t approximation_order)
 {
     using std::abs;
     int64_t n = m_x.size();
@@ -106,7 +106,7 @@ void barycentric_rational_imp<Real>::calculate_weights(size_t approximation_orde
     {
         int64_t i_min = (std::max)(k - static_cast<int64_t>(approximation_order), static_cast<int64_t>(0));
         int64_t i_max = k;
-        if (k >= n - (std::ptrdiff_t)approximation_order)
+        if (k >= n - static_cast<std::ptrdiff_t>(approximation_order))
         {
             i_max = n - approximation_order - 1;
         }
@@ -135,7 +135,7 @@ void barycentric_rational_imp<Real>::calculate_weights(size_t approximation_orde
                 }
                 inv_product *= diff;
             }
-            if (i % 2 == 0)
+            if ((i & 1) == 0)
             {
                 m_w[k] += 1/inv_product;
             }
@@ -153,7 +153,7 @@ Real barycentric_rational_imp<Real>::operator()(Real x) const
 {
     Real numerator = 0;
     Real denominator = 0;
-    for(size_t i = 0; i < m_x.size(); ++i)
+    for(std::size_t i = 0; i < m_x.size(); ++i)
     {
         // Presumably we should see if the accuracy is improved by using ULP distance of say, 5 here, instead of testing for floating point equality.
         // However, it has been shown that if x approx x_i, but x != x_i, then inaccuracy in the numerator cancels the inaccuracy in the denominator,
@@ -187,12 +187,12 @@ Real barycentric_rational_imp<Real>::prime(Real x) const
     Real rx = this->operator()(x);
     Real numerator = 0;
     Real denominator = 0;
-    for(size_t i = 0; i < m_x.size(); ++i)
+    for(std::size_t i = 0; i < m_x.size(); ++i)
     {
         if (x == m_x[i])
         {
             Real sum = 0;
-            for (size_t j = 0; j < m_x.size(); ++j)
+            for (std::size_t j = 0; j < m_x.size(); ++j)
             {
                 if (j == i)
                 {

--- a/include/boost/math/interpolators/detail/cardinal_quintic_b_spline_detail.hpp
+++ b/include/boost/math/interpolators/detail/cardinal_quintic_b_spline_detail.hpp
@@ -157,10 +157,10 @@ public:
 
         m_alpha[n+3] = rhs[n+3]/diagonal[n+3];
         m_alpha[n+2] = rhs[n+2] - first_superdiagonal[n+2]*m_alpha[n+3];
-        for (int64_t i = int64_t(n+1); i >= 0; --i) {
-            m_alpha[i] = rhs[i] - first_superdiagonal[i]*m_alpha[i+1] - second_superdiagonal[i]*m_alpha[i+2];
+        for (size_t i = n + 2; i > 0; --i)
+        {
+            m_alpha[i - 1] = rhs[i - 1] - first_superdiagonal[i - 1] * m_alpha[i] - second_superdiagonal[i - 1] * m_alpha[i + 1];
         }
-
     }
 
     Real operator()(Real t) const {

--- a/include/boost/math/interpolators/detail/cardinal_trigonometric_detail.hpp
+++ b/include/boost/math/interpolators/detail/cardinal_trigonometric_detail.hpp
@@ -78,7 +78,7 @@ public:
       m_gamma[k][1] /= denom;
     }
 
-    if (length % 2 == 0)
+    if ((length & 1) == 0)
     {
       m_gamma[m_complex_vector_size -1][0] /= 2;
       // numerically, m_gamma[m_complex_vector_size -1][1] should be zero . . .
@@ -241,7 +241,7 @@ public:
       m_gamma[k][1] /= denom;
     }
 
-    if (length % 2 == 0)
+    if ((length & 1) == 0)
     {
       m_gamma[m_complex_vector_size -1][0] /= 2;
     }
@@ -399,7 +399,7 @@ public:
       m_gamma[k][1] /= denom;
     }
 
-    if (length % 2 == 0) {
+    if ((length & 1) == 0) {
       m_gamma[m_complex_vector_size -1][0] /= 2;
     }
   }
@@ -554,7 +554,7 @@ public:
       m_gamma[k][0] /= denom;
       m_gamma[k][1] /= denom;
     }
-    if (length % 2 == 0)
+    if ((length & 1) == 0)
     {
       m_gamma[m_complex_vector_size -1][0] /= 2;
     }

--- a/include/boost/math/interpolators/detail/whittaker_shannon_detail.hpp
+++ b/include/boost/math/interpolators/detail/whittaker_shannon_detail.hpp
@@ -48,7 +48,7 @@ public:
         {
             BOOST_MATH_ASSERT_MSG(floor(x) == ceil(x), "Floor and ceiling should be equal.\n");
             auto i = static_cast<size_t>(floor(x));
-            if (i & 1)
+            if ((i & 1) == 1)
             {
                 return -m_y[i];
             }
@@ -75,7 +75,7 @@ public:
                 }
                 // else derivative of sinc at zero is zero.
             }
-            if (j & 1) {
+            if ((j & 1) == 1) {
                 s /= -m_h;
             } else {
                 s /= m_h;
@@ -101,7 +101,7 @@ public:
 
 
     Real operator[](size_t i) const {
-        if (i & 1)
+        if ((i & 1) == 1)
         {
             return -m_y[i];
         }

--- a/include/boost/math/interpolators/vector_barycentric_rational.hpp
+++ b/include/boost/math/interpolators/vector_barycentric_rational.hpp
@@ -25,7 +25,7 @@ public:
     using Point = typename SpaceContainer::value_type;
     vector_barycentric_rational(TimeContainer&& times, SpaceContainer&& points, size_t approximation_order = 3);
 
-    void operator()(Point& x, Real t) const;
+    void operator()(Point& p, Real t) const;
 
     // I have validated using google benchmark that returning a value is no more expensive populating it,
     // at least for Eigen vectors with known size at compile-time.

--- a/include/boost/math/quadrature/gauss.hpp
+++ b/include/boost/math/quadrature/gauss.hpp
@@ -47,7 +47,7 @@ class gauss_detail
    static std::vector<Real> calculate_weights()
    {
       std::vector<Real> result(abscissa().size(), 0);
-      for (unsigned i = 0; i < abscissa().size(); ++i)
+      for (decltype(abscissa().size()) i = 0; i < abscissa().size(); ++i)
       {
          Real x = abscissa()[i];
          Real p = boost::math::legendre_p_prime(N, x);
@@ -1182,17 +1182,18 @@ public:
       static_assert(!std::is_integral<K>::value,
                    "The return type cannot be integral, it must be either a real or complex floating point type.");
       using std::abs;
-      unsigned non_zero_start = 1;
+      unsigned non_zero_start;
       K result = Real(0);
-      if (N & 1) {
+      if ((N & 1) == 1) {
          result = f(Real(0)) * base::weights()[0];
+         non_zero_start = 1;
       }
       else {
          result = 0;
          non_zero_start = 0;
       }
       Real L1 = abs(result);
-      for (unsigned i = non_zero_start; i < base::abscissa().size(); ++i)
+      for (decltype(base::abscissa().size()) i = non_zero_start; i < base::abscissa().size(); ++i)
       {
          K fp = f(base::abscissa()[i]);
          K fm = f(-base::abscissa()[i]);

--- a/include/boost/math/quadrature/gauss_kronrod.hpp
+++ b/include/boost/math/quadrature/gauss_kronrod.hpp
@@ -45,17 +45,17 @@ class gauss_kronrod_detail
    {
       std::vector<Real> result(abscissa().size(), 0);
       unsigned gauss_order = (N - 1) / 2;
-      unsigned gauss_start = gauss_order & 1 ? 0 : 1;
+      unsigned gauss_start = (gauss_order & 1) ^ 1;
       const legendre_stieltjes<Real>& E = get_legendre_stieltjes();
 
-      for (unsigned i = gauss_start; i < abscissa().size(); i += 2)
+      for (decltype(abscissa().size()) i = gauss_start; i < abscissa().size(); i += 2)
       {
          Real x = abscissa()[i];
          Real p = boost::math::legendre_p_prime(gauss_order, x);
          Real gauss_weight = 2 / ((1 - x * x) * p * p);
          result[i] = gauss_weight + static_cast<Real>(2) / (static_cast<Real>(gauss_order + 1) * legendre_p_prime(gauss_order, x) * E(x));
       }
-      for (unsigned i = gauss_start ? 0 : 1; i < abscissa().size(); i += 2)
+      for (decltype(abscissa().size()) i = gauss_start ^ 1; i < abscissa().size(); i += 2)
       {
          Real x = abscissa()[i];
          result[i] = static_cast<Real>(2) / (static_cast<Real>(gauss_order + 1) * legendre_p(gauss_order, x) * E.prime(x));
@@ -1784,7 +1784,7 @@ private:
       K kronrod_result = 0;
       K gauss_result = 0;
       K fp, fm;
-      if (gauss_order & 1)
+      if ((gauss_order & 1) == 1)
       {
          fp = f(value_type(0));
          kronrod_result = fp * base::weights()[0];
@@ -1798,7 +1798,7 @@ private:
          kronrod_start = 2;
       }
       Real L1 = abs(kronrod_result);
-      for (unsigned i = gauss_start; i < base::abscissa().size(); i += 2)
+      for (decltype(base::abscissa().size()) i = gauss_start; i < base::abscissa().size(); i += 2)
       {
          fp = f(base::abscissa()[i]);
          fm = f(-base::abscissa()[i]);
@@ -1806,7 +1806,7 @@ private:
          L1 += (abs(fp) + abs(fm)) *  base::weights()[i];
          gauss_result += (fp + fm) * gauss<Real, (N - 1) / 2>::weights()[i / 2];
       }
-      for (unsigned i = kronrod_start; i < base::abscissa().size(); i += 2)
+      for (decltype(base::abscissa().size()) i = kronrod_start; i < base::abscissa().size(); i += 2)
       {
          fp = f(base::abscissa()[i]);
          fm = f(-base::abscissa()[i]);

--- a/include/boost/math/quadrature/naive_monte_carlo.hpp
+++ b/include/boost/math/quadrature/naive_monte_carlo.hpp
@@ -45,13 +45,12 @@ public:
     {
         using std::numeric_limits;
         using std::sqrt;
-        uint64_t n = bounds.size();
+        size_t n = bounds.size();
         m_lbs.resize(n);
         m_dxs.resize(n);
         m_limit_types.resize(n);
-
         static const char* function = "boost::math::quadrature::naive_monte_carlo<%1%>";
-        for (uint64_t i = 0; i < n; ++i)
+        for (size_t i = 0; i < n; ++i)
         {
             if (bounds[i].second <= bounds[i].first)
             {
@@ -115,7 +114,7 @@ public:
         m_integrand = [this, &integrand](std::vector<Real> & x)->Real
         {
             Real coeff = m_volume;
-            for (uint64_t i = 0; i < x.size(); ++i)
+            for (size_t i = 0; i < x.size(); ++i)
             {
                 // Variable transformation are listed at:
                 // https://en.wikipedia.org/wiki/Numerical_integration
@@ -171,7 +170,7 @@ public:
         Real avg = 0;
         for (uint64_t i = 0; i < m_num_threads; ++i)
         {
-            for (uint64_t j = 0; j < m_lbs.size(); ++j)
+            for (size_t j = 0; j < m_lbs.size(); ++j)
             {
                 x[j] = (gen()-(gen.min)())*inv_denom;
             }
@@ -277,10 +276,10 @@ private:
          seed = m_seed;
       }
       RandomNumberGenerator gen(seed);
-      int max_repeat_tries = 5;
+      unsigned max_repeat_tries = 6;
       do{
 
-         if (max_repeat_tries < 5)
+         if (max_repeat_tries < 6)
          {
             m_done = false;
 
@@ -300,7 +299,7 @@ private:
          }
 
          std::vector<std::thread> threads(m_num_threads);
-         for (uint64_t i = 0; i < threads.size(); ++i)
+         for (size_t i = 0; i < threads.size(); ++i)
          {
             threads[i] = std::thread(&naive_monte_carlo::m_thread_monte, this, i, gen());
          }
@@ -363,7 +362,7 @@ private:
          // Then the threads proceed to find the variance is much greater by the time they hear the message to stop.
          // This *WOULD* make sure that the final error estimate is within the error bounds.
       }
-      while ((--max_repeat_tries >= 0) && (this->current_error_estimate() > m_error_goal));
+      while ((--max_repeat_tries != 0) && (this->current_error_estimate() > m_error_goal));
 
       return m_avg.load(std::memory_order_consume);
     }
@@ -386,15 +385,15 @@ private:
             uint64_t k = m_thread_calls[thread_index].load(std::memory_order_consume);
             while (!m_done) // relaxed load
             {
-                int j = 0;
+                unsigned int j = 0;
                 // If we don't have a certain number of calls before an update, we can easily terminate prematurely
                 // because the variance estimate is way too low. This magic number is a reasonable compromise, as 1/sqrt(2048) = 0.02,
                 // so it should recover 2 digits if the integrand isn't poorly behaved, and if it is, it should discover that before premature termination.
                 // Of course if the user has 64 threads, then this number is probably excessive.
-                int magic_calls_before_update = 2048;
+                const unsigned int magic_calls_before_update = 2048;
                 while (j++ < magic_calls_before_update)
                 {
-                    for (uint64_t i = 0; i < m_lbs.size(); ++i)
+                    for (size_t i = 0; i < m_lbs.size(); ++i)
                     {
                         x[i] = (gen() - (gen.min)())*inv_denom;
                     }
@@ -405,7 +404,7 @@ private:
                         // The call to m_integrand transform x, so this error message states the correct node.
                         std::stringstream os;
                         os << "Your integrand was evaluated at {";
-                        for (uint64_t i = 0; i < x.size() -1; ++i)
+                        for (size_t i = 0; i < x.size() -1; ++i)
                         {
                              os << x[i] << ", ";
                         }

--- a/include/boost/math/special_functions/bernoulli.hpp
+++ b/include/boost/math/special_functions/bernoulli.hpp
@@ -31,7 +31,7 @@ OutputIterator bernoulli_number_imp(OutputIterator out, std::size_t start, std::
    for(std::size_t i = (std::max)(static_cast<std::size_t>(max_bernoulli_b2n<T>::value + 1), start); i < start + n; ++i)
    {
       // We must overflow:
-      *out = (i & 1 ? 1 : -1) * policies::raise_overflow_error<T>("boost::math::bernoulli_b2n<%1%>(n)", nullptr, T(i), pol);
+      *out = (((i & 1) == 1) ? 1 : -1) * policies::raise_overflow_error<T>("boost::math::bernoulli_b2n<%1%>(n)", nullptr, T(i), pol);
       ++out;
    }
    return out;

--- a/include/boost/math/special_functions/bessel_prime.hpp
+++ b/include/boost/math/special_functions/bessel_prime.hpp
@@ -61,7 +61,7 @@ inline T cyl_bessel_j_prime_imp(T v, T x, const Policy& pol)
       if (floor(v) == v && v < 0)
       {
          v = -v;
-         if (itrunc(v, pol) & 1)
+         if ((itrunc(v, pol) & 1) == 1)
             inversed = true;
       }
       T r = boost::math::detail::bessel_j_derivative_small_z_series(v, x, pol);

--- a/include/boost/math/special_functions/beta.hpp
+++ b/include/boost/math/special_functions/beta.hpp
@@ -101,7 +101,7 @@ T beta_imp(T a, T b, const Lanczos&, const Policy& pol)
    }
    else
    {
-      result *= pow(agh / cgh, a - T(0.5) - b);
+      result *= pow(agh / cgh, a - static_cast<T>(0.5) - b);
    }
    if(cgh > 1e10f)
       // this avoids possible overflow, but appears to be marginally less accurate:
@@ -947,7 +947,7 @@ T binomial_ccdf(T n, T k, T x, T y, const Policy& pol)
    if(result > tools::min_value<T>())
    {
       T term = result;
-      for(unsigned i = itrunc(T(n - 1)); i > k; --i)
+      for(auto i = itrunc(T(n - 1)); i > k; --i)
       {
          term *= ((i + 1) * y) / ((n - i) * x);
          result += term;
@@ -965,22 +965,22 @@ T binomial_ccdf(T n, T k, T x, T y, const Policy& pol)
       {
          // OK, starting slightly above the mode didn't work,
          // we'll have to sum the terms the old fashioned way:
-         for(unsigned i = start - 1; i > k; --i)
+         for(auto i = start - 1; i > k; --i)
          {
-            result += pow(x, (int)i) * pow(y, n - i) * boost::math::binomial_coefficient<T>(itrunc(n), itrunc(i), pol);
+            result += pow(x, i) * pow(y, n - i) * boost::math::binomial_coefficient<T>(itrunc(n), itrunc(i), pol);
          }
       }
       else
       {
          T term = result;
          T start_term = result;
-         for(unsigned i = start - 1; i > k; --i)
+         for(auto i = start - 1; i > k; --i)
          {
             term *= ((i + 1) * y) / ((n - i) * x);
             result += term;
          }
          term = start_term;
-         for(unsigned i = start + 1; i <= n; ++i)
+         for(auto i = start + 1; i <= n; ++i)
          {
             term *= (n - i + 1) * x / (i * y);
             result += term;

--- a/include/boost/math/special_functions/chebyshev.hpp
+++ b/include/boost/math/special_functions/chebyshev.hpp
@@ -63,7 +63,7 @@ inline Real chebyshev_imp(unsigned n, Real const & x, const Policy&)
         }
         if (x < -1)
         {
-            if (n & 1)
+            if ((n & 1) == 1)
             {
                 return -cosh(n*acosh(-x BOOST_MATH_ACOSH_POLICY));
             }

--- a/include/boost/math/special_functions/daubechies_wavelet.hpp
+++ b/include/boost/math/special_functions/daubechies_wavelet.hpp
@@ -38,13 +38,13 @@ namespace boost::math {
       for (size_t i = 0; i < d.size(); ++i)
       {
          d[i] *= scale;
-         if (!(i & 1))
+         if ((i & 1) == 0)
          {
             d[i] = -d[i];
          }
       }
 
-      std::vector<Real> v(2 * p + (2 * p - 1) * ((int64_t(1) << j_max) - 1), std::numeric_limits<Real>::quiet_NaN());
+      std::vector<Real> v(2 * p + (2 * p - 1) * ((static_cast<int64_t>(1) << j_max) - 1), std::numeric_limits<Real>::quiet_NaN());
       v[0] = 0;
       v[v.size() - 1] = 0;
 
@@ -53,7 +53,7 @@ namespace boost::math {
          Real term = 0;
          for (int64_t k = 0; k < static_cast<int64_t>(d.size()); ++k)
          {
-            int64_t idx = (int64_t(1) << (j_max - 1)) * (1 - 2 * p + k) + l;
+            int64_t idx = (static_cast<int64_t>(1) << (j_max - 1)) * (1 - 2 * p + k) + l;
             if (idx < 0 || idx >= static_cast<int64_t>(phijk.size()))
             {
                continue;

--- a/include/boost/math/special_functions/detail/bessel_jn.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jn.hpp
@@ -35,7 +35,7 @@ T bessel_jn(int n, T x, const Policy& pol)
     //
     if (n < 0)
     {
-        factor = static_cast<T>((n & 0x1) ? -1 : 1);  // J_{-n}(z) = (-1)^n J_n(z)
+        factor = static_cast<T>(((n & 1) == 1) ? -1 : 1);  // J_{-n}(z) = (-1)^n J_n(z)
         n = -n;
     }
     else
@@ -44,7 +44,7 @@ T bessel_jn(int n, T x, const Policy& pol)
     }
     if(x < 0)
     {
-        factor *= (n & 0x1) ? -1 : 1;  // J_{n}(-z) = (-1)^n J_n(z)
+        factor *= ((n & 1) == 1) ? -1 : 1;  // J_{n}(-z) = (-1)^n J_n(z)
         x = -x;
     }
     //

--- a/include/boost/math/special_functions/detail/bessel_yn.hpp
+++ b/include/boost/math/special_functions/detail/bessel_yn.hpp
@@ -45,7 +45,7 @@ T bessel_yn(int n, T x, const Policy& pol)
     //
     if (n < 0)
     {
-        factor = static_cast<T>((n & 0x1) ? -1 : 1);  // Y_{-n}(z) = (-1)^n Y_n(z)
+        factor = static_cast<T>(((n & 1) == 1) ? -1 : 1);  // Y_{-n}(z) = (-1)^n Y_n(z)
         n = -n;
     }
     else

--- a/include/boost/math/special_functions/detail/daubechies_scaling_integer_grid.hpp
+++ b/include/boost/math/special_functions/detail/daubechies_scaling_integer_grid.hpp
@@ -9,7 +9,7 @@
 #ifndef BOOST_MATH_DAUBECHIES_SCALING_INTEGER_GRID_HPP
 #define BOOST_MATH_DAUBECHIES_SCALING_INTEGER_GRID_HPP
 #include <array>
-#include <float.h>
+#include <cfloat>
 #include <boost/math/tools/config.hpp>
 /*
 In order to keep the character count as small as possible and speed up

--- a/include/boost/math/special_functions/detail/hypergeometric_pFq_checked_series.hpp
+++ b/include/boost/math/special_functions/detail/hypergeometric_pFq_checked_series.hpp
@@ -359,8 +359,8 @@
               //
               loop_error_scale /= tools::epsilon<Real>();
 
-              if (z < 0)
-                 s1 *= (s & 1 ? -1 : 1);
+              if (z < 0 && ((s & 1) == 1))
+                 s1 = -s1;
 
               if (term <= tools::log_min_value<Real>())
               {

--- a/include/boost/math/special_functions/detail/hypergeometric_series.hpp
+++ b/include/boost/math/special_functions/detail/hypergeometric_series.hpp
@@ -219,7 +219,7 @@
         if (n < -z)
         {
            if(s)
-            *s = (n & 1 ? -1 : 1);
+            *s = ((n & 1) == 1) ? -1 : 1;
            return log_pochhammer(T(-z + (1 - (int)n)), n, pol);
         }
         else
@@ -234,8 +234,8 @@
         if (z + n < 0)
         {
            T r = log_pochhammer(T(-z - n + 1), n, pol, s);
-           if (s)
-              *s *= (n & 1 ? -1 : 1);
+           if (s && ((n & 1) == 1))
+              *s *= -1;
            return r;
         }
         int s1, s2;

--- a/include/boost/math/special_functions/detail/igamma_inverse.hpp
+++ b/include/boost/math/special_functions/detail/igamma_inverse.hpp
@@ -529,12 +529,12 @@ inline typename tools::promote_args<T1, T2>::type
 
 template <class T1, class T2, class Policy>
 inline typename tools::promote_args<T1, T2>::type
-   gamma_q_inv(T1 a, T2 p, const Policy& pol)
+   gamma_q_inv(T1 a, T2 q, const Policy& pol)
 {
    typedef typename tools::promote_args<T1, T2>::type result_type;
    return detail::gamma_q_inv_imp(
       static_cast<result_type>(a),
-      static_cast<result_type>(p), pol);
+      static_cast<result_type>(q), pol);
 }
 
 template <class T1, class T2>
@@ -546,9 +546,9 @@ inline typename tools::promote_args<T1, T2>::type
 
 template <class T1, class T2>
 inline typename tools::promote_args<T1, T2>::type
-   gamma_q_inv(T1 a, T2 p)
+   gamma_q_inv(T1 a, T2 q)
 {
-   return gamma_q_inv(a, p, policies::policy<>());
+   return gamma_q_inv(a, q, policies::policy<>());
 }
 
 } // namespace math

--- a/include/boost/math/special_functions/detail/polygamma.hpp
+++ b/include/boost/math/special_functions/detail/polygamma.hpp
@@ -52,7 +52,7 @@ namespace boost { namespace math { namespace detail{
         // x is crazy large, just concentrate on the first part of the expression and use logs:
         if(n == 1) return 1 / x;
         T nlx = n * log(x);
-        if((nlx < tools::log_max_value<T>()) && (n < (int)max_factorial<T>::value))
+        if((nlx < tools::log_max_value<T>()) && (n < static_cast<int>(max_factorial<T>::value)))
            return ((n & 1) ? 1 : -1) * boost::math::factorial<T>(n - 1, pol) * pow(x, -n);
         else
          return ((n & 1) ? 1 : -1) * exp(boost::math::lgamma(T(n), pol) - n * log(x));
@@ -102,7 +102,7 @@ namespace boost { namespace math { namespace detail{
      if(sum == 0)
         return sum;
 
-     for(unsigned k = 1;;)
+     for(int k = 1;;)
      {
         term = part_term * boost::math::bernoulli_b2n<T>(k, pol);
         sum += term;
@@ -121,13 +121,13 @@ namespace boost { namespace math { namespace detail{
         //
         // Emergency get out termination condition:
         //
-        if(k > policies::get_max_series_iterations<Policy>())
+        if(k > static_cast<int>(policies::get_max_series_iterations<Policy>()))
         {
            return policies::raise_evaluation_error(function, "Series did not converge, closest value was %1%", sum, pol);
         }
      }
 
-     if((n - 1) & 1)
+     if((n & 1) == 0)
         sum = -sum;
 
      return sum;
@@ -174,7 +174,7 @@ namespace boost { namespace math { namespace detail{
           z += 1;
        }
     }
-    if((n - 1) & 1)
+    if((n & 1) == 0)
        sum0 = -sum0;
 
     return sum0 + polygamma_atinfinityplus(n, z, pol, function);
@@ -212,7 +212,7 @@ namespace boost { namespace math { namespace detail{
      // ignore the sum if it will have no effect on the result anyway:
      //
      if(prefix > 2 / policies::get_epsilon<T, Policy>())
-        return ((n & 1) ? 1 : -1) *
+        return (((n & 1) == 1) ? 1 : -1) *
          (tools::max_value<T>() / prefix < scale ? policies::raise_overflow_error<T>(function, nullptr, pol) : prefix * scale);
      //
      // As this is an alternating series we could accelerate it using
@@ -222,7 +222,7 @@ namespace boost { namespace math { namespace detail{
      // required except in some edge cases which are filtered out anyway before we get here.
      //
      T sum = prefix;
-     for(unsigned k = 0;;)
+     for(int k = 0;;)
      {
         // Get the k'th term:
         T term = factorial_part * boost::math::zeta(T(k + n + 1), pol);
@@ -238,7 +238,7 @@ namespace boost { namespace math { namespace detail{
         //
         // Last chance exit:
         //
-        if(k > policies::get_max_series_iterations<Policy>())
+        if(k > static_cast<int>(policies::get_max_series_iterations<Policy>()))
            return policies::raise_evaluation_error<T>(function, "Series did not converge, best value is %1%", sum, pol);
      }
      //
@@ -247,7 +247,7 @@ namespace boost { namespace math { namespace detail{
      if(boost::math::tools::max_value<T>() / scale < sum)
         return boost::math::policies::raise_overflow_error<T>(function, nullptr, pol);
      sum *= scale;
-     return n & 1 ? sum : T(-sum);
+     return ((n & 1) == 1) ? sum : T(-sum);
   }
 
   //
@@ -449,7 +449,7 @@ namespace boost { namespace math { namespace detail{
 
      }
      T sum = boost::math::tools::evaluate_even_polynomial(&table[index][0], c, table[index].size());
-     if(index & 1)
+     if((index & 1) == 1)
         sum *= c;  // First coefficient is order 1, and really an odd polynomial.
      if(sum == 0)
         return sum;
@@ -467,7 +467,7 @@ namespace boost { namespace math { namespace detail{
      if(power_terms > boost::math::tools::log_max_value<T>())
         return sum * boost::math::policies::raise_overflow_error<T>(function, nullptr, pol);
 
-     return exp(power_terms) * ((s < 0) && ((n + 1) & 1) ? -1 : 1) * boost::math::sign(sum);
+     return exp(power_terms) * (((s < 0) && ((n & 1) == 0)) ? -1 : 1) * boost::math::sign(sum);
   }
 
   template <class T, class Policy>
@@ -514,7 +514,7 @@ namespace boost { namespace math { namespace detail{
        }
        T z = 1 - x;
        T result = polygamma_imp(n, z, pol) + constants::pi<T, Policy>() * poly_cot_pi(n, z, x, pol, function);
-       return n & 1 ? T(-result) : result;
+       return ((n & 1) == 1) ? T(-result) : result;
     }
     //
     // Limit for use of small-x-series is chosen
@@ -534,11 +534,11 @@ namespace boost { namespace math { namespace detail{
     }
     else if(x == 1)
     {
-       return (n & 1 ? 1 : -1) * boost::math::factorial<T>(n, pol) * boost::math::zeta(T(n + 1), pol);
+       return (((n & 1) == 1) ? 1 : -1) * boost::math::factorial<T>(n, pol) * boost::math::zeta(T(n + 1), pol);
     }
     else if(x == 0.5f)
     {
-       T result = (n & 1 ? 1 : -1) * boost::math::factorial<T>(n, pol) * boost::math::zeta(T(n + 1), pol);
+       T result = (((n & 1) == 1) ? 1 : -1) * boost::math::factorial<T>(n, pol) * boost::math::zeta(T(n + 1), pol);
        if(fabs(result) >= ldexp(tools::max_value<T>(), -n - 1))
           return boost::math::sign(result) * policies::raise_overflow_error<T>(function, nullptr, pol);
        result *= ldexp(T(1), n + 1) - 1;

--- a/include/boost/math/special_functions/detail/unchecked_factorial.hpp
+++ b/include/boost/math/special_functions/detail/unchecked_factorial.hpp
@@ -947,7 +947,7 @@ inline T unchecked_factorial_imp(unsigned i, const std::integral_constant<int, 0
       if(digits != current_digits)
       {
          digits = current_digits;
-         for(unsigned k = 0; k < sizeof(factorials) / sizeof(factorials[0]); ++k)
+         for(std::size_t k = 0; k < sizeof(factorials) / sizeof(factorials[0]); ++k)
             factorials[k] = static_cast<T>(boost::math::tools::convert_from_string<T>(factorial_strings[k]));
       }
 

--- a/include/boost/math/special_functions/ellint_rd.hpp
+++ b/include/boost/math/special_functions/ellint_rd.hpp
@@ -135,10 +135,10 @@ T ellint_rd_imp(T x, T y, T z, const Policy& pol)
    T Q = pow(tools::epsilon<T>() / 4, -T(1) / 8) * (std::max)((std::max)(An - x, An - y), An - z) * 1.2f;
    BOOST_MATH_INSTRUMENT_VARIABLE(Q);
    T lambda, rx, ry, rz;
-   unsigned k = 0;
    T fn = 1;
    T RD_sum = 0;
 
+   decltype(policies::get_max_series_iterations<Policy>()) k = 0;
    for(; k < policies::get_max_series_iterations<Policy>(); ++k)
    {
       rx = sqrt(xn);

--- a/include/boost/math/special_functions/ellint_rf.hpp
+++ b/include/boost/math/special_functions/ellint_rf.hpp
@@ -116,7 +116,7 @@ namespace boost { namespace math { namespace detail{
 
 
       // duplication
-      unsigned k = 1;
+      decltype(boost::math::policies::get_max_series_iterations<Policy>()) k = 1;
       for(; k < boost::math::policies::get_max_series_iterations<Policy>(); ++k)
       {
          T root_x = sqrt(xn);

--- a/include/boost/math/special_functions/factorials.hpp
+++ b/include/boost/math/special_functions/factorials.hpp
@@ -76,13 +76,13 @@ T double_factorial(unsigned i, const Policy& pol)
 {
    static_assert(!std::is_integral<T>::value, "Type T must not be an integral type");
    BOOST_MATH_STD_USING  // ADL lookup of std names
-   if(i & 1)
+   if((i & 1) == 1)
    {
       // odd i:
       if(i < max_factorial<T>::value)
       {
          unsigned n = (i - 1) / 2;
-         return ceil(unchecked_factorial<T>(i) / (ldexp(T(1), (int)n) * unchecked_factorial<T>(n)) - 0.5f);
+         return ceil(unchecked_factorial<T>(i) / (ldexp(T(1), static_cast<int>(n)) * unchecked_factorial<T>(n)) - 0.5f);
       }
       //
       // Fallthrough: i is too large to use table lookup, try the
@@ -97,8 +97,8 @@ T double_factorial(unsigned i, const Policy& pol)
       // even i:
       unsigned n = i / 2;
       T result = factorial<T>(n, pol);
-      if(ldexp(tools::max_value<T>(), -(int)n) > result)
-         return result * ldexp(T(1), (int)n);
+      if(ldexp(tools::max_value<T>(), -static_cast<int>(n)) > result)
+         return result * ldexp(T(1), static_cast<int>(n));
    }
    //
    // If we fall through to here then the result is infinite:
@@ -152,7 +152,7 @@ T rising_factorial_imp(T x, int n, const Policy& pol)
    if((x < 1) && (x + n < 0))
    {
       T val = boost::math::tgamma_delta_ratio(1 - x, static_cast<T>(-n), pol);
-      return (n & 1) ? T(-val) : val;
+      return ((n & 1) == 1) ? T(-val) : val;
    }
    //
    // We don't optimise this for small n, because

--- a/include/boost/math/special_functions/fpclassify.hpp
+++ b/include/boost/math/special_functions/fpclassify.hpp
@@ -77,7 +77,7 @@ is used.
 */
 
 #if defined(_MSC_VER) || defined(BOOST_BORLANDC)
-#include <float.h>
+#include <cfloat>
 #endif
 #ifdef BOOST_MATH_USE_FLOAT128
 #ifdef __has_include
@@ -115,7 +115,7 @@ inline bool is_nan_helper(T t, const std::true_type&)
    (void)t;
    return false;
 #else // BOOST_HAS_FPCLASSIFY
-   return (BOOST_FPCLASSIFY_PREFIX fpclassify(t) == (int)FP_NAN);
+   return (BOOST_FPCLASSIFY_PREFIX fpclassify(t) == FP_NAN);
 #endif
 }
 

--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -59,7 +59,7 @@ template <class T>
 inline bool is_odd(T v, const std::true_type&)
 {
    int i = static_cast<int>(v);
-   return i&1;
+   return (i & 1) == 1;
 }
 template <class T>
 inline bool is_odd(T v, const std::false_type&)
@@ -67,7 +67,7 @@ inline bool is_odd(T v, const std::false_type&)
    // Oh dear can't cast T to int!
    BOOST_MATH_STD_USING
    T modulus = v - 2 * floor(v/2);
-   return static_cast<bool>(modulus != 0);
+   return modulus != 0;
 }
 template <class T>
 inline bool is_odd(T v)
@@ -137,7 +137,7 @@ T gamma_imp(T z, const Policy& pol, const Lanczos& l)
          result = -boost::math::constants::pi<T>() / result;
          if(result == 0)
             return policies::raise_underflow_error<T>(function, "Result of tgamma is too small to represent.", pol);
-         if((boost::math::fpclassify)(result) == (int)FP_SUBNORMAL)
+         if((boost::math::fpclassify)(result) == FP_SUBNORMAL)
             return policies::raise_denorm_error<T>(function, "Result of tgamma is denormalized.", result, pol);
          BOOST_MATH_INSTRUMENT_VARIABLE(result);
          return result;
@@ -370,7 +370,7 @@ int minimum_argument_for_bernoulli_recursion()
                                     ? (float) std::numeric_limits<T>::digits10
                                     : (float) (boost::math::tools::digits<T>() * 0.301F));
 
-   int min_arg = (int) (digits10_of_type * 1.7F);
+   int min_arg = static_cast<int>(digits10_of_type * 1.7F);
 
    if(digits10_of_type < 50.0F)
    {
@@ -389,7 +389,7 @@ int minimum_argument_for_bernoulli_recursion()
       const float d2_minus_one = ((digits10_of_type / 0.301F) - 1.0F);
       const float limit        = ceil(exp((d2_minus_one * log(2.0F)) / 20.0F));
 
-      min_arg = (int) ((std::min)(digits10_of_type * 1.7F, limit));
+      min_arg = static_cast<int>((std::min)(digits10_of_type * 1.7F, limit));
    }
 
    return min_arg;
@@ -852,7 +852,7 @@ T full_igamma_prefix(T a, T z, const Policy& pol)
    // This error handling isn't very good: it happens after the fact
    // rather than before it...
    //
-   if((boost::math::fpclassify)(prefix) == (int)FP_INFINITE)
+   if((boost::math::fpclassify)(prefix) == FP_INFINITE)
       return policies::raise_overflow_error<T>("boost::math::detail::full_igamma_prefix<%1%>(%1%, %1%)", "Result of incomplete gamma function is too large to represent.", pol);
 
    return prefix;

--- a/include/boost/math/special_functions/hankel.hpp
+++ b/include/boost/math/special_functions/hankel.hpp
@@ -29,7 +29,7 @@ std::complex<T> hankel_imp(T v, T x, const bessel_no_int_tag&, const Policy& pol
       std::complex<T> j_result, y_result;
       if(isint_v)
       {
-         int s = (iround(v) & 1) ? -1 : 1;
+         int s = ((iround(v) & 1) == 1) ? -1 : 1;
          j_result = j * s;
          y_result = T(s) * (y - (2 / constants::pi<T>()) * (log(-x) - log(cx)) * j);
       }

--- a/include/boost/math/special_functions/jacobi_elliptic.hpp
+++ b/include/boost/math/special_functions/jacobi_elliptic.hpp
@@ -26,7 +26,7 @@ T jacobi_recurse(const T& x, const T& k, T anm1, T bnm1, unsigned N, T* pTn, con
    T an = (anm1 + bnm1) / 2;
    if(cn < policies::get_epsilon<T, Policy>())
    {
-      Tn = ldexp(T(1), (int)N) * x * an;
+      Tn = ldexp(T(1), static_cast<int>(N)) * x * an;
    }
    else
       Tn = jacobi_recurse<T>(x, k, an, sqrt(anm1 * bnm1), N, 0, pol);

--- a/include/boost/math/special_functions/legendre.hpp
+++ b/include/boost/math/special_functions/legendre.hpp
@@ -61,13 +61,10 @@ T legendre_imp(unsigned l, T x, const Policy& pol, bool second = false)
    if(l == 0)
       return p0;
 
-   unsigned n = 1;
-
-   while(n < l)
+   for(unsigned n = 1; n < l; ++n)
    {
       std::swap(p0, p1);
       p1 = boost::math::legendre_next(n, x, p0, p1);
-      ++n;
    }
    return p1;
 }
@@ -170,8 +167,8 @@ std::vector<T> legendre_p_zeros_imp(int n, const Policy& pol)
         // There are no zeros of P_0(x) = 1.
         return zeros;
     }
-    int k;
-    if (n & 1)
+    decltype(zeros.size()) k;
+    if ((n & 1) == 1)
     {
         zeros.resize((n-1)/2 + 1, std::numeric_limits<T>::quiet_NaN());
         zeros[0] = 0;
@@ -184,7 +181,7 @@ std::vector<T> legendre_p_zeros_imp(int n, const Policy& pol)
     }
     T half_n = ceil(n*half<T>());
 
-    while (k < (int)zeros.size())
+    while (k < zeros.size())
     {
         // Bracket the root: Szego:
         // Gabriel Szego, Inequalities for the Zeros of Legendre Polynomials and Related Functions, Transactions of the American Mathematical Society, Vol. 39, No. 1 (1936)
@@ -326,8 +323,7 @@ T legendre_p_imp(int l, int m, T x, T sin_theta_power, const Policy& pol)
    }
    if(m < 0)
    {
-      int sign = (m&1) ? -1 : 1;
-      return sign * boost::math::tgamma_ratio(static_cast<T>(l+m+1), static_cast<T>(l+1-m), pol) * legendre_p_imp(l, -m, x, sin_theta_power, pol);
+      return (((m & 1) == 1) ? -1 : 1) * boost::math::tgamma_ratio(static_cast<T>(l+m+1), static_cast<T>(l+1-m), pol) * legendre_p_imp(l, -m, x, sin_theta_power, pol);
    }
    // Special cases:
    if(m > l)
@@ -337,7 +333,7 @@ T legendre_p_imp(int l, int m, T x, T sin_theta_power, const Policy& pol)
 
    T p0 = boost::math::double_factorial<T>(2 * m - 1, pol) * sin_theta_power;
 
-   if(m&1)
+   if ((m & 1) == 1)
       p0 *= -1;
    if(m == l)
       return p0;

--- a/include/boost/math/special_functions/legendre_stieltjes.hpp
+++ b/include/boost/math/special_functions/legendre_stieltjes.hpp
@@ -138,7 +138,7 @@ public:
 
         for (size_t i = 1; i < m_a.size(); ++i)
         {
-            if(m_m & 1)
+            if((m_m & 1) == 1)
             {
                 Em_prime += m_a[i]*detail::legendre_p_prime_imp(static_cast<unsigned>(2*i - 1), x, policies::policy<>());
             }
@@ -156,8 +156,9 @@ public:
 
         std::vector<Real> stieltjes_zeros;
         std::vector<Real> legendre_zeros = legendre_p_zeros<Real>(m_m - 1);
-        int k;
-        if (m_m & 1)
+        decltype(stieltjes_zeros.size()) k;
+        bool odd = (m_m & 1) == 1;
+        if (odd)
         {
             stieltjes_zeros.resize(legendre_zeros.size() + 1, std::numeric_limits<Real>::quiet_NaN());
             stieltjes_zeros[0] = 0;
@@ -169,14 +170,14 @@ public:
             k = 0;
         }
 
-        while (k < (int)stieltjes_zeros.size())
+        while (k < stieltjes_zeros.size())
         {
             Real lower_bound;
             Real upper_bound;
-            if (m_m & 1)
+            if (odd)
             {
                 lower_bound = legendre_zeros[k - 1];
-                if (k == (int)legendre_zeros.size())
+                if (k == legendre_zeros.size())
                 {
                     upper_bound = 1;
                 }
@@ -188,7 +189,7 @@ public:
             else
             {
                 lower_bound = legendre_zeros[k];
-                if (k == (int)legendre_zeros.size() - 1)
+                if (k == legendre_zeros.size() - 1)
                 {
                     upper_bound = 1;
                 }

--- a/include/boost/math/special_functions/next.hpp
+++ b/include/boost/math/special_functions/next.hpp
@@ -193,7 +193,7 @@ T float_next_imp(const T& val, const std::true_type&, const Policy& pol)
 
    int fpclass = (boost::math::fpclassify)(val);
 
-   if((fpclass == (int)FP_NAN) || (fpclass == (int)FP_INFINITE))
+   if((fpclass == FP_NAN) || (fpclass == FP_INFINITE))
    {
       if(val < 0)
          return -tools::max_value<T>();
@@ -208,7 +208,7 @@ T float_next_imp(const T& val, const std::true_type&, const Policy& pol)
    if(val == 0)
       return detail::get_smallest_value<T>();
 
-   if((fpclass != (int)FP_SUBNORMAL) && (fpclass != (int)FP_ZERO) && (fabs(val) < detail::get_min_shift_value<T>()) && (val != -tools::min_value<T>()))
+   if((fpclass != FP_SUBNORMAL) && (fpclass != FP_ZERO) && (fabs(val) < detail::get_min_shift_value<T>()) && (val != -tools::min_value<T>()))
    {
       //
       // Special case: if the value of the least significant bit is a denorm, and the result
@@ -242,7 +242,7 @@ T float_next_imp(const T& val, const std::false_type&, const Policy& pol)
 
    int fpclass = (boost::math::fpclassify)(val);
 
-   if((fpclass == (int)FP_NAN) || (fpclass == (int)FP_INFINITE))
+   if((fpclass == FP_NAN) || (fpclass == FP_INFINITE))
    {
       if(val < 0)
          return -tools::max_value<T>();
@@ -257,7 +257,7 @@ T float_next_imp(const T& val, const std::false_type&, const Policy& pol)
    if(val == 0)
       return detail::get_smallest_value<T>();
 
-   if((fpclass != (int)FP_SUBNORMAL) && (fpclass != (int)FP_ZERO) && (fabs(val) < detail::get_min_shift_value<T>()) && (val != -tools::min_value<T>()))
+   if((fpclass != FP_SUBNORMAL) && (fpclass != FP_ZERO) && (fabs(val) < detail::get_min_shift_value<T>()) && (val != -tools::min_value<T>()))
    {
       //
       // Special case: if the value of the least significant bit is a denorm, and the result
@@ -327,7 +327,7 @@ T float_prior_imp(const T& val, const std::true_type&, const Policy& pol)
 
    int fpclass = (boost::math::fpclassify)(val);
 
-   if((fpclass == (int)FP_NAN) || (fpclass == (int)FP_INFINITE))
+   if((fpclass == FP_NAN) || (fpclass == FP_INFINITE))
    {
       if(val > 0)
          return tools::max_value<T>();
@@ -342,7 +342,7 @@ T float_prior_imp(const T& val, const std::true_type&, const Policy& pol)
    if(val == 0)
       return -detail::get_smallest_value<T>();
 
-   if((fpclass != (int)FP_SUBNORMAL) && (fpclass != (int)FP_ZERO) && (fabs(val) < detail::get_min_shift_value<T>()) && (val != tools::min_value<T>()))
+   if((fpclass != FP_SUBNORMAL) && (fpclass != FP_ZERO) && (fabs(val) < detail::get_min_shift_value<T>()) && (val != tools::min_value<T>()))
    {
       //
       // Special case: if the value of the least significant bit is a denorm, and the result
@@ -377,7 +377,7 @@ T float_prior_imp(const T& val, const std::false_type&, const Policy& pol)
 
    int fpclass = (boost::math::fpclassify)(val);
 
-   if((fpclass == (int)FP_NAN) || (fpclass == (int)FP_INFINITE))
+   if((fpclass == FP_NAN) || (fpclass == FP_INFINITE))
    {
       if(val > 0)
          return tools::max_value<T>();
@@ -392,7 +392,7 @@ T float_prior_imp(const T& val, const std::false_type&, const Policy& pol)
    if(val == 0)
       return -detail::get_smallest_value<T>();
 
-   if((fpclass != (int)FP_SUBNORMAL) && (fpclass != (int)FP_ZERO) && (fabs(val) < detail::get_min_shift_value<T>()) && (val != tools::min_value<T>()))
+   if((fpclass != FP_SUBNORMAL) && (fpclass != FP_ZERO) && (fabs(val) < detail::get_min_shift_value<T>()) && (val != tools::min_value<T>()))
    {
       //
       // Special case: if the value of the least significant bit is a denorm, and the result
@@ -511,7 +511,7 @@ T float_distance_imp(const T& a, const T& b, const std::true_type&, const Policy
    // because we actually have fewer than tools::digits<T>()
    // significant bits in the representation:
    //
-   (void)frexp(((boost::math::fpclassify)(a) == (int)FP_SUBNORMAL) ? tools::min_value<T>() : a, &expon);
+   (void)frexp(((boost::math::fpclassify)(a) == FP_SUBNORMAL) ? tools::min_value<T>() : a, &expon);
    T upper = ldexp(T(1), expon);
    T result = T(0);
    //
@@ -532,7 +532,7 @@ T float_distance_imp(const T& a, const T& b, const std::true_type&, const Policy
    //
    expon = tools::digits<T>() - expon;
    T mb, x, y, z;
-   if(((boost::math::fpclassify)(a) == (int)FP_SUBNORMAL) || (b - a < tools::min_value<T>()))
+   if(((boost::math::fpclassify)(a) == FP_SUBNORMAL) || (b - a < tools::min_value<T>()))
    {
       //
       // Special case - either one end of the range is a denormal, or else the difference is.
@@ -619,7 +619,7 @@ T float_distance_imp(const T& a, const T& b, const std::false_type&, const Polic
    // because we actually have fewer than tools::digits<T>()
    // significant bits in the representation:
    //
-   expon = 1 + ilogb(((boost::math::fpclassify)(a) == (int)FP_SUBNORMAL) ? tools::min_value<T>() : a);
+   expon = 1 + ilogb(((boost::math::fpclassify)(a) == FP_SUBNORMAL) ? tools::min_value<T>() : a);
    T upper = scalbn(T(1), expon);
    T result = T(0);
    //
@@ -639,7 +639,7 @@ T float_distance_imp(const T& a, const T& b, const std::false_type&, const Polic
    //
    expon = std::numeric_limits<T>::digits - expon;
    T mb, x, y, z;
-   if(((boost::math::fpclassify)(a) == (int)FP_SUBNORMAL) || (b - a < tools::min_value<T>()))
+   if(((boost::math::fpclassify)(a) == FP_SUBNORMAL) || (b - a < tools::min_value<T>()))
    {
       //
       // Special case - either one end of the range is a denormal, or else the difference is.
@@ -730,7 +730,7 @@ T float_advance_imp(T val, int distance, const std::true_type&, const Policy& po
 
    int fpclass = (boost::math::fpclassify)(val);
 
-   if((fpclass == (int)FP_NAN) || (fpclass == (int)FP_INFINITE))
+   if((fpclass == FP_NAN) || (fpclass == FP_INFINITE))
       return policies::raise_domain_error<T>(
          function,
          "Argument val must be finite, but got %1%", val, pol);
@@ -816,7 +816,7 @@ T float_advance_imp(T val, int distance, const std::false_type&, const Policy& p
 
    int fpclass = (boost::math::fpclassify)(val);
 
-   if((fpclass == (int)FP_NAN) || (fpclass == (int)FP_INFINITE))
+   if((fpclass == FP_NAN) || (fpclass == FP_INFINITE))
       return policies::raise_domain_error<T>(
          function,
          "Argument val must be finite, but got %1%", val, pol);

--- a/include/boost/math/special_functions/relative_difference.hpp
+++ b/include/boost/math/special_functions/relative_difference.hpp
@@ -71,51 +71,49 @@ namespace boost{
 
 #if (defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)) && (LDBL_MAX_EXP <= DBL_MAX_EXP)
       template <>
-      inline boost::math::tools::promote_args<double, double>::type relative_difference(const double& arg_a, const double& arg_b)
+      inline boost::math::tools::promote_args<double, double>::type relative_difference(double arg_a, double arg_b)
       {
          BOOST_MATH_STD_USING
-         double a = arg_a;
-         double b = arg_b;
          //
          // On Mac OS X we evaluate "double" functions at "long double" precision,
          // but "long double" actually has a very slightly narrower range than "double"!  
          // Therefore use the range of "long double" as our limits since results outside
          // that range may have been truncated to 0 or INF:
          //
-         double min_val = (std::max)((double)tools::min_value<long double>(), tools::min_value<double>());
-         double max_val = (std::min)((double)tools::max_value<long double>(), tools::max_value<double>());
+         double min_val = (std::max)(static_cast<double>(tools::min_value<long double>()), tools::min_value<double>());
+         double max_val = (std::min)(static_cast<double>(tools::max_value<long double>()), tools::max_value<double>());
 
          // Screen out NaN's first, if either value is a NaN then the distance is "infinite":
-         if((boost::math::isnan)(a) || (boost::math::isnan)(b))
+         if((boost::math::isnan)(arg_a) || (boost::math::isnan)(arg_b))
             return max_val;
          // Screen out infinities:
-         if(fabs(b) > max_val)
+         if(fabs(arg_b) > max_val)
          {
-            if(fabs(a) > max_val)
+            if(fabs(arg_a) > max_val)
                return 0;  // one infinity is as good as another!
             else
                return max_val;  // one infinity and one finite value implies infinite difference
          }
-         else if(fabs(a) > max_val)
+         else if(fabs(arg_a) > max_val)
             return max_val;    // one infinity and one finite value implies infinite difference
 
          //
          // If the values have different signs, treat as infinite difference:
          //
-         if(((a < 0) != (b < 0)) && (a != 0) && (b != 0))
+         if(((arg_a < 0) != (arg_b < 0)) && (arg_a != 0) && (arg_b != 0))
             return max_val;
-         a = fabs(a);
-         b = fabs(b);
+         arg_a = fabs(arg_a);
+         arg_b = fabs(arg_b);
          //
          // Now deal with zero's, if one value is zero (or denorm) then treat it the same as
          // min_val for the purposes of the calculation that follows:
          //
-         if(a < min_val)
-            a = min_val;
-         if(b < min_val)
-            b = min_val;
+         if(arg_a < min_val)
+            arg_a = min_val;
+         if(arg_b < min_val)
+            arg_b = min_val;
 
-         return (std::max)(fabs((a - b) / a), fabs((a - b) / b));
+         return (std::max)(fabs((arg_a - arg_b) / arg_a), fabs((arg_a - arg_b) / arg_b));
       }
 #endif
 

--- a/include/boost/math/special_functions/spherical_harmonic.hpp
+++ b/include/boost/math/special_functions/spherical_harmonic.hpp
@@ -56,10 +56,10 @@ T spherical_harmonic_r(unsigned n, int m, T theta, T phi, const Policy& pol)
    if(m < 0)
    {
       // Reflect and adjust sign if m < 0:
-      sign = m&1;
-      m = abs(m);
+      sign = ((m & 1) == 1);
+      m = -m;
    }
-   if(m&1)
+   if((m & 1) == 1)
    {
       // Check phase if theta is outside [0, PI]:
       T mod = boost::math::tools::fmod_workaround(theta, T(2 * constants::pi<T>()));
@@ -83,10 +83,10 @@ T spherical_harmonic_i(unsigned n, int m, T theta, T phi, const Policy& pol)
    if(m < 0)
    {
       // Reflect and adjust sign if m < 0:
-      sign = !(m&1);
-      m = abs(m);
+      sign = ((m & 1) == 0);
+      m = -m;
    }
-   if(m&1)
+   if((m & 1) == 1)
    {
       // Check phase if theta is outside [0, PI]:
       T mod = boost::math::tools::fmod_workaround(theta, T(2 * constants::pi<T>()));
@@ -113,11 +113,11 @@ std::complex<T> spherical_harmonic(unsigned n, int m, U theta, U phi, const Poli
    if(m < 0)
    {
       // Reflect and adjust sign if m < 0:
-      r_sign = m&1;
-      i_sign = !(m&1);
-      m = abs(m);
+      r_sign = ((m & 1) == 1);
+      i_sign = !r_sign;
+      m = -m;
    }
-   if(m&1)
+   if((m & 1) == 1)
    {
       // Check phase if theta is outside [0, PI]:
       U mod = boost::math::tools::fmod_workaround(theta, U(2 * constants::pi<U>()));

--- a/include/boost/math/special_functions/ulp.hpp
+++ b/include/boost/math/special_functions/ulp.hpp
@@ -32,7 +32,7 @@ T ulp_imp(const T& val, const std::true_type&, const Policy& pol)
          function,
          "Argument must be finite, but got %1%", val, pol);
    }
-   else if((fpclass == (int)FP_INFINITE) || (fabs(val) >= tools::max_value<T>()))
+   else if((fpclass == FP_INFINITE) || (fabs(val) >= tools::max_value<T>()))
    {
       return (val < 0 ? -1 : 1) * policies::raise_overflow_error<T>(function, nullptr, pol);
    }
@@ -55,7 +55,6 @@ T ulp_imp(const T& val, const std::false_type&, const Policy& pol)
    static_assert(std::numeric_limits<T>::is_specialized, "Type T must be specialized.");
    static_assert(std::numeric_limits<T>::radix != 2, "Type T must be specialized.");
    BOOST_MATH_STD_USING
-   int expon;
    static const char* function = "ulp<%1%>(%1%)";
 
    int fpclass = (boost::math::fpclassify)(val);
@@ -76,7 +75,7 @@ T ulp_imp(const T& val, const std::false_type&, const Policy& pol)
    // This code is almost the same as that for float_next, except for negative integers,
    // where we preserve the relation ulp(x) == ulp(-x) as does Java:
    //
-   expon = 1 + ilogb(fabs(val));
+   int expon = 1 + ilogb(fabs(val));
    T diff = scalbn(T(1), expon - std::numeric_limits<T>::digits);
    if(diff == 0)
       diff = detail::get_smallest_value<T>();

--- a/include/boost/math/special_functions/zeta.hpp
+++ b/include/boost/math/special_functions/zeta.hpp
@@ -904,14 +904,14 @@ T zeta_imp_odd_integer(int s, const T& sc, const Policy& pol, const std::false_t
    {
       is_init = true;
       digits = current_digits;
-      for(unsigned k = 0; k < sizeof(results) / sizeof(results[0]); ++k)
+      for(std::size_t k = 0; k < sizeof(results) / sizeof(results[0]); ++k)
       {
          T arg = k * 2 + 3;
          T c_arg = 1 - arg;
          results[k] = zeta_polynomial_series(arg, c_arg, pol);
       }
    }
-   unsigned index = (s - 3) / 2;
+   unsigned index = static_cast<unsigned>((s - 3) / 2);
    return index >= sizeof(results) / sizeof(results[0]) ? zeta_polynomial_series(T(s), sc, pol): results[index];
 }
 
@@ -950,15 +950,15 @@ T zeta_imp(T s, T sc, const Policy& pol, const Tag& tag)
                if(((-v) & 1) == 0)
                   return 0;
                int n = (-v + 1) / 2;
-               if(n <= (int)boost::math::max_bernoulli_b2n<T>::value)
-                  return T((-v & 1) ? -1 : 1) * boost::math::unchecked_bernoulli_b2n<T>(n) / (1 - v);
+               if(n <= static_cast<int>(boost::math::max_bernoulli_b2n<T>::value))
+                  return T(((-v & 1) == 1) ? -1 : 1) * boost::math::unchecked_bernoulli_b2n<T>(n) / (1 - v);
             }
             else if((v & 1) == 0)
             {
-               if(((v / 2) <= (int)boost::math::max_bernoulli_b2n<T>::value) && (v <= (int)boost::math::max_factorial<T>::value))
-                  return T(((v / 2 - 1) & 1) ? -1 : 1) * ldexp(T(1), v - 1) * pow(constants::pi<T, Policy>(), v) *
+               if(((v / 2) <= static_cast<int>(boost::math::max_bernoulli_b2n<T>::value)) && (v <= static_cast<int>(boost::math::max_bernoulli_b2n<T>::value)))
+                  return T(((v & 2) == 0) ? -1 : 1) * ldexp(T(1), v - 1) * pow(constants::pi<T, Policy>(), v) *
                      boost::math::unchecked_bernoulli_b2n<T>(v / 2) / boost::math::unchecked_factorial<T>(v);
-               return T(((v / 2 - 1) & 1) ? -1 : 1) * ldexp(T(1), v - 1) * pow(constants::pi<T, Policy>(), v) *
+               return T(((v & 2) == 0) ? -1 : 1) * ldexp(T(1), v - 1) * pow(constants::pi<T, Policy>(), v) *
                   boost::math::bernoulli_b2n<T>(v / 2) / boost::math::factorial<T>(v, pol);
             }
             else

--- a/include/boost/math/statistics/univariate_statistics.hpp
+++ b/include/boost/math/statistics/univariate_statistics.hpp
@@ -377,7 +377,7 @@ auto median(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIter
 {
     const auto num_elems = std::distance(first, last);
     BOOST_MATH_ASSERT_MSG(num_elems > 0, "The median of a zero length vector is undefined.");
-    if (num_elems & 1)
+    if ((num_elems & 1) == 1)
     {
         auto middle = first + (num_elems - 1)/2;
         std::nth_element(exec, first, middle, last);
@@ -501,7 +501,7 @@ auto median_absolute_deviation(ExecutionPolicy&& exec, RandomAccessIterator firs
     const auto num_elems = std::distance(first, last);
     BOOST_MATH_ASSERT_MSG(num_elems > 0, "The median of a zero-length vector is undefined.");
     auto comparator = [&center](Real a, Real b) { return abs(a-center) < abs(b-center);};
-    if (num_elems & 1)
+    if ((num_elems & 1) == 1)
     {
         auto middle = first + (num_elems - 1)/2;
         std::nth_element(exec, first, middle, last, comparator);
@@ -937,7 +937,7 @@ Real median(RandomAccessIterator first, RandomAccessIterator last)
 {
     const auto num_elems = std::distance(first, last);
     BOOST_MATH_ASSERT_MSG(num_elems > 0, "The median of a zero length vector is undefined.");
-    if (num_elems & 1)
+    if ((num_elems & 1) == 1)
     {
         auto middle = first + (num_elems - 1)/2;
         std::nth_element(first, middle, last);
@@ -1039,7 +1039,7 @@ Real median_absolute_deviation(RandomAccessIterator first, RandomAccessIterator 
     const auto num_elems = std::distance(first, last);
     BOOST_MATH_ASSERT_MSG(num_elems > 0, "The median of a zero-length vector is undefined.");
     auto comparator = [&center](Real a, Real b) { return abs(a-center) < abs(b-center);};
-    if (num_elems & 1)
+    if ((num_elems & 1) == 1)
     {
         auto middle = first + (num_elems - 1)/2;
         std::nth_element(first, middle, last, comparator);

--- a/include/boost/math/tools/centered_continued_fraction.hpp
+++ b/include/boost/math/tools/centered_continued_fraction.hpp
@@ -54,8 +54,7 @@ public:
         }
         Real C = f;
         Real D = 0;
-        int i = 0;
-        while (abs(f - x_) >= (1 + i++)*std::numeric_limits<Real>::epsilon()*abs(x_))
+        for (int i = 0; abs(f - x_) >= (1 + i)*std::numeric_limits<Real>::epsilon()*abs(x_); i++)
         {
             bj = round(x);
             b_.push_back(static_cast<Z>(bj));

--- a/include/boost/math/tools/mp.hpp
+++ b/include/boost/math/tools/mp.hpp
@@ -400,8 +400,8 @@ class make_integer_sequence_impl_
 private:
     static_assert(N >= 0, "N must not be negative");
 
-    static constexpr T M = N / 2;
-    static constexpr T R = N % 2;
+    static constexpr T M = N >> 1;
+    static constexpr T R = N & 1;
 
     using seq1 = typename make_integer_sequence_impl<T, M>::type;
     using seq2 = typename append_integer_sequence<seq1, seq1>::type;

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -379,7 +379,7 @@ public:
 
    T operator()(T z) const
    {
-      return m_data.size() > 0 ? boost::math::tools::evaluate_polynomial((m_data).data(), z, m_data.size()) : T(0);
+      return m_data.size() > 0 ? boost::math::tools::evaluate_polynomial(m_data.data(), z, m_data.size()) : T(0);
    }
    std::vector<T> chebyshev() const
    {

--- a/include/boost/math/tools/rational.hpp
+++ b/include/boost/math/tools/rational.hpp
@@ -188,12 +188,12 @@ inline V evaluate_polynomial_c_imp(const T* a, const V& val, const Tag*) BOOST_M
 template <class T, class U>
 inline U evaluate_polynomial(const T* poly, U const& z, std::size_t count) BOOST_MATH_NOEXCEPT(U)
 {
-   BOOST_MATH_ASSERT(count > 0);
-   U sum = static_cast<U>(poly[count - 1]);
-   for(int i = static_cast<int>(count) - 2; i >= 0; --i)
+   BOOST_MATH_ASSERT(count != 0);
+   U sum = static_cast<U>(poly[--count]);
+   while (count)
    {
       sum *= z;
-      sum += static_cast<U>(poly[i]);
+      sum += static_cast<U>(poly[--count]);
    }
    return sum;
 }
@@ -240,6 +240,7 @@ inline V evaluate_even_polynomial(const std::array<T,N>& a, const V& z) BOOST_MA
 template <class T, class U>
 inline U evaluate_odd_polynomial(const T* poly, U z, std::size_t count) BOOST_MATH_NOEXCEPT(U)
 {
+   BOOST_MATH_ASSERT(count != 0);
    return poly[0] + z * evaluate_polynomial(poly+1, U(z*z), count-1);
 }
 
@@ -284,14 +285,17 @@ V evaluate_rational(const T* num, const U* denom, const V& z_, std::size_t count
    V s1, s2;
    if(z <= 1)
    {
-      s1 = static_cast<V>(num[count-1]);
-      s2 = static_cast<V>(denom[count-1]);
-      for(int i = (int)count - 2; i >= 0; --i)
+      BOOST_MATH_ASSERT(count != 0);
+      count--;
+      s1 = static_cast<V>(num[count]);
+      s2 = static_cast<V>(denom[count]);
+      while (count)
       {
+         count--;
          s1 *= z;
          s2 *= z;
-         s1 += num[i];
-         s2 += denom[i];
+         s1 += num[count];
+         s2 += denom[count];
       }
    }
    else
@@ -299,7 +303,7 @@ V evaluate_rational(const T* num, const U* denom, const V& z_, std::size_t count
       z = 1 / z;
       s1 = static_cast<V>(num[0]);
       s2 = static_cast<V>(denom[0]);
-      for(unsigned i = 1; i < count; ++i)
+      for(std::size_t i = 1; i < count; ++i)
       {
          s1 *= z;
          s2 *= z;

--- a/include/boost/math/tools/univariate_statistics.hpp
+++ b/include/boost/math/tools/univariate_statistics.hpp
@@ -301,7 +301,7 @@ auto median(RandomAccessIterator first, RandomAccessIterator last)
 {
     size_t num_elems = std::distance(first, last);
     BOOST_MATH_ASSERT_MSG(num_elems > 0, "The median of a zero length vector is undefined.");
-    if (num_elems & 1)
+    if ((num_elems & 1) == 1)
     {
         auto middle = first + (num_elems - 1)/2;
         std::nth_element(first, middle, last);
@@ -404,7 +404,7 @@ auto median_absolute_deviation(RandomAccessIterator first, RandomAccessIterator 
     size_t num_elems = std::distance(first, last);
     BOOST_MATH_ASSERT_MSG(num_elems > 0, "The median of a zero-length vector is undefined.");
     auto comparator = [&center](Real a, Real b) { return abs(a-center) < abs(b-center);};
-    if (num_elems & 1)
+    if ((num_elems & 1) == 1)
     {
         auto middle = first + (num_elems - 1)/2;
         std::nth_element(first, middle, last, comparator);

--- a/include_private/boost/math/tools/remez.hpp
+++ b/include_private/boost/math/tools/remez.hpp
@@ -156,9 +156,9 @@ public:
    void rescale(T a, T b)
    {
       T scale = (b - a) / (max - min);
-      for(unsigned i = 0; i < control_points.size(); ++i)
+      for(auto& i : control_points)
       {
-         control_points[i] = (control_points[i] - min) * scale + a;
+         i = (i - min) * scale + a;
       }
       min = a;
       max = b;
@@ -222,7 +222,7 @@ void remez_minimax<T>::init_chebyshev()
    matrix_type A(terms, terms);
    vector_type b(terms);
    // fill in the y values:
-   for(unsigned i = 0; i < b.size(); ++i)
+   for(decltype(b.size()) i = 0; i < b.size(); ++i)
    {
       b[i] = func(zeros[i+1]);
    }
@@ -230,13 +230,13 @@ void remez_minimax<T>::init_chebyshev()
    unsigned offsetN = pinned ? 0 : 1;
    unsigned offsetD = offsetN + orderN;
    unsigned maxorder = (std::max)(orderN, orderD);
-   for(unsigned i = 0; i < b.size(); ++i)
+   for(decltype(b.size()) i = 0; i < b.size(); ++i)
    {
       T x0 = zeros[i+1];
       T x = x0;
       if(!pinned)
          A(i, 0) = 1;
-      for(unsigned j = 0; j < maxorder; ++j)
+      for(decltype(b.size()) j = 0; j < maxorder; ++j)
       {
          if(j < orderN)
             A(i, j + offsetN) = x;
@@ -305,7 +305,7 @@ void remez_minimax<T>::reset(
    control_points[unknowns - 1] = max;
    T interval = (max - min) / (unknowns - 1);
    T spot = min + interval;
-   for(unsigned i = 1; i < control_points.size(); ++i)
+   for(decltype(control_points.size()) i = 1; i < control_points.size(); ++i)
    {
       control_points[i] = spot;
       spot += interval;
@@ -414,7 +414,7 @@ T remez_minimax<T>::iterate()
    vector_type b(unknowns);
 
    // fill in evaluation of f(x) at each of the control points:
-   for(unsigned i = 0; i < b.size(); ++i)
+   for(decltype(b.size()) i = 0; i < b.size(); ++i)
    {
       // take care that none of our control points are at the origin:
       if(pinned && (control_points[i] == 0))
@@ -437,13 +437,13 @@ T remez_minimax<T>::iterate()
       unsigned maxorder = (std::max)(orderN, orderD);
       T Elast = solution[unknowns - 1];
 
-      for(unsigned i = 0; i < b.size(); ++i)
+      for(decltype(b.size()) i = 0; i < b.size(); ++i)
       {
          T x0 = control_points[i];
          T x = x0;
          if(!pinned)
             A(i, 0) = 1;
-         for(unsigned j = 0; j < maxorder; ++j)
+         for(decltype(b.size()) j = 0; j < maxorder; ++j)
          {
             if(j < orderN)
                A(i, j + offsetN) = x;
@@ -462,12 +462,12 @@ T remez_minimax<T>::iterate()
       }
 
    #ifdef BOOST_MATH_INSTRUMENT
-      for(unsigned i = 0; i < b.size(); ++i)
-         std::cout << b[i] << " ";
+      for(const auto& i : b)
+         std::cout << i << " ";
       std::cout << "\n\n";
-      for(unsigned i = 0; i < b.size(); ++i)
+      for(decltype(b.size()) i = 0; i < b.size(); ++i)
       {
-         for(unsigned j = 0; j < b.size(); ++ j)
+         for(decltype(b.size()) j = 0; j < b.size(); ++ j)
             std::cout << A(i, j) << " ";
          std::cout << "\n";
       }
@@ -487,7 +487,7 @@ T remez_minimax<T>::iterate()
    // be very close to singular, so this can be a real problem.
    //
    vector_type sanity = prod(A, solution);
-   for(unsigned i = 0; i < b.size(); ++i)
+   for(decltype(b.size()) i = 0; i < b.size(); ++i)
    {
       T err = fabs((b[i] - sanity[i]) / fabs(b[i]));
       if(err > sqrt(epsilon<T>()))
@@ -510,7 +510,7 @@ T remez_minimax<T>::iterate()
 #ifdef BOOST_MATH_INSTRUMENT
    std::cout << e1;
 #endif
-   for(unsigned i = 1; i < b.size(); ++i)
+   for(size_t i = 1; i < b.size(); ++i)
    {
       T e2 = b[i] - num.evaluate(control_points[i]) / denom.evaluate(control_points[i]);
 #ifdef BOOST_MATH_INSTRUMENT
@@ -551,8 +551,8 @@ T remez_minimax<T>::iterate()
    }
 
 #ifdef BOOST_MATH_INSTRUMENT
-   for(unsigned i = 0; i < solution.size(); ++i)
-      std::cout << solution[i] << " ";
+   for(const auto& i : solution)
+      std::cout << i << " ";
    std::cout << std::endl << this->numerator() << std::endl;
    std::cout << this->denominator() << std::endl;
    std::cout << std::endl;
@@ -565,7 +565,7 @@ T remez_minimax<T>::iterate()
    detail::remez_error_function<T> Err(func, this->numerator(), this->denominator(), rel_error);
    zeros[0] = min;
    zeros[unknowns] = max;
-   for(unsigned i = 1; i < control_points.size(); ++i)
+   for(decltype(control_points.size()) i = 1; i < control_points.size(); ++i)
    {
       eps_tolerance<T> tol(m_precision);
       std::uintmax_t max_iter = 1000;
@@ -584,7 +584,7 @@ T remez_minimax<T>::iterate()
    detail::remez_max_error_function<T> Ex(Err);
    m_max_error = 0;
    //int max_err_location = 0;
-   for(unsigned i = 0; i < unknowns; ++i)
+   for(decltype(unknowns) i = 0; i < unknowns; ++i)
    {
       std::pair<T, T> r = brent_find_minima(Ex, zeros[i], zeros[i+1], m_precision);
       maxima[i] = r.first;
@@ -603,7 +603,7 @@ T remez_minimax<T>::iterate()
    swap(control_points, maxima);
    m_max_change = 0;
    //int max_change_location = 0;
-   for(unsigned i = 0; i < unknowns; ++i)
+   for(decltype(unknowns) i = 0; i < unknowns; ++i)
    {
       control_points[i] = (control_points[i] * (100 - m_brake) + maxima[i] * m_brake) / 100;
       T change = fabs((control_points[i] - maxima[i]) / control_points[i]);

--- a/include_private/boost/math/tools/solve.hpp
+++ b/include_private/boost/math/tools/solve.hpp
@@ -51,24 +51,22 @@ boost::numeric::ublas::vector<T> solve(
    // iterate to reduce error:
    //
    boost::numeric::ublas::vector<T> delta(b.size());
-   for(unsigned k = 0; k < 1; ++k)
+
+   noalias(delta) = prod(A_, b);
+   delta -= b_;
+   lu_substitute(A, piv, delta);
+   b -= delta;
+
+   T max_error = 0;
+
+   for (std::size_t i = 0; i < delta.size(); ++i)
    {
-      noalias(delta) = prod(A_, b);
-      delta -= b_;
-      lu_substitute(A, piv, delta);
-      b -= delta;
-
-      T max_error = 0;
-
-      for(unsigned i = 0; i < delta.size(); ++i)
-      {
-         using std::abs;
-         T err = abs(delta[i] / b[i]);
-         if(err > max_error)
-            max_error = err;
-      }
-      //std::cout << "Max change in LU error correction: " << max_error << std::endl;
+      using std::abs;
+      T err = abs(delta[i] / b[i]);
+      if (err > max_error)
+         max_error = err;
    }
+   // std::cout << "Max change in LU error correction: " << max_error << std::endl;
 
    return b;
 }

--- a/include_private/boost/math/tools/test.hpp
+++ b/include_private/boost/math/tools/test.hpp
@@ -90,7 +90,7 @@ void print_row(const Seq& row, std::ostream& os = std::cout)
 {
    try {
       set_output_precision(row[0], os);
-      for (unsigned i = 0; i < row.size(); ++i)
+      for (decltype(row.size()) i = 0; i < row.size(); ++i)
       {
          if (i)
             os << ", ";
@@ -116,7 +116,7 @@ test_result<typename calculate_result_type<A>::value_type> test(const A& a, F1 t
 
    test_result<value_type> result;
 
-   for(unsigned i = 0; i < a.size(); ++i)
+   for(decltype(a.size()) i = 0; i < a.size(); ++i)
    {
       const row_type& row = a[i];
       value_type point;
@@ -188,7 +188,7 @@ test_result<Real> test_hetero(const A& a, F1 test_func, F2 expect_func)
 
    test_result<value_type> result;
 
-   for(unsigned i = 0; i < a.size(); ++i)
+   for(decltype(a.size()) i = 0; i < a.size(); ++i)
    {
       const row_type& row = a[i];
       value_type point;

--- a/src/tr1/assoc_legendre.cpp
+++ b/src/tr1/assoc_legendre.cpp
@@ -13,7 +13,7 @@
 
 extern "C" double BOOST_MATH_TR1_DECL boost_assoc_legendre BOOST_PREVENT_MACRO_SUBSTITUTION(unsigned l, unsigned m, double x) BOOST_MATH_C99_THROW_SPEC
 {
-   return (m&1 ? -1 : 1) * c_policies::legendre_p BOOST_PREVENT_MACRO_SUBSTITUTION(l, m, x);
+   return ((m & 1 == 1) ? -1 : 1) * c_policies::legendre_p BOOST_PREVENT_MACRO_SUBSTITUTION(l, m, x);
 }
 
 

--- a/src/tr1/assoc_legendref.cpp
+++ b/src/tr1/assoc_legendref.cpp
@@ -13,7 +13,7 @@
 
 extern "C" float BOOST_MATH_TR1_DECL boost_assoc_legendref BOOST_PREVENT_MACRO_SUBSTITUTION(unsigned l, unsigned m, float x) BOOST_MATH_C99_THROW_SPEC
 {
-   return (m&1 ? -1 : 1) * c_policies::legendre_p BOOST_PREVENT_MACRO_SUBSTITUTION(l, m, x);
+   return ((m & 1 == 1) ? -1 : 1) * c_policies::legendre_p BOOST_PREVENT_MACRO_SUBSTITUTION(l, m, x);
 }
 
 

--- a/src/tr1/assoc_legendrel.cpp
+++ b/src/tr1/assoc_legendrel.cpp
@@ -13,7 +13,7 @@
 
 extern "C" long double BOOST_MATH_TR1_DECL boost_assoc_legendrel BOOST_PREVENT_MACRO_SUBSTITUTION(unsigned l, unsigned m, long double x) BOOST_MATH_C99_THROW_SPEC
 {
-   return (m&1 ? -1 : 1) * c_policies::legendre_p BOOST_PREVENT_MACRO_SUBSTITUTION(l, m, x);
+   return ((m & 1 == 1) ? -1 : 1) * c_policies::legendre_p BOOST_PREVENT_MACRO_SUBSTITUTION(l, m, x);
 }
 
 

--- a/src/tr1/fpclassify.cpp
+++ b/src/tr1/fpclassify.cpp
@@ -12,16 +12,11 @@
 #include <boost/math/special_functions/sign.hpp>
 #include "c_policy.hpp"
 
-#if defined (_MSC_VER)
-#  pragma warning(push)
-#  pragma warning (disable: 4800) // 'int' : forcing value to bool 'true' or 'false' (performance warning)
-#endif
-
 namespace boost{ namespace math{ namespace tr1{
 
 template<> bool BOOST_MATH_TR1_DECL signbit<double> BOOST_PREVENT_MACRO_SUBSTITUTION(double x)
 {
-   return static_cast<bool>((boost::math::signbit)(x));
+   return (boost::math::signbit)(x) != 0;
 }
 
 template<> int BOOST_MATH_TR1_DECL fpclassify<double> BOOST_PREVENT_MACRO_SUBSTITUTION(double x)

--- a/src/tr1/fpclassifyf.cpp
+++ b/src/tr1/fpclassifyf.cpp
@@ -12,16 +12,11 @@
 #include <boost/math/special_functions/sign.hpp>
 #include "c_policy.hpp"
 
-#if defined (_MSC_VER)
-#  pragma warning(push)
-#  pragma warning (disable: 4800) // 'int' : forcing value to bool 'true' or 'false' (performance warning)
-#endif
-
 namespace boost{ namespace math{ namespace tr1{
 
 template<> bool BOOST_MATH_TR1_DECL signbit<float> BOOST_PREVENT_MACRO_SUBSTITUTION(float x)
 {
-   return static_cast<bool>((boost::math::signbit)(x));
+   return (boost::math::signbit)(x) != 0;
 }
 
 template<> int BOOST_MATH_TR1_DECL fpclassify<float> BOOST_PREVENT_MACRO_SUBSTITUTION(float x)

--- a/src/tr1/fpclassifyl.cpp
+++ b/src/tr1/fpclassifyl.cpp
@@ -12,16 +12,11 @@
 #include <boost/math/special_functions/sign.hpp>
 #include "c_policy.hpp"
 
-#if defined (_MSC_VER)
-#  pragma warning(push)
-#  pragma warning (disable: 4800) // 'int' : forcing value to bool 'true' or 'false' (performance warning)
-#endif
-
 namespace boost{ namespace math{ namespace tr1{
 
 template<> bool BOOST_MATH_TR1_DECL signbit<long double> BOOST_PREVENT_MACRO_SUBSTITUTION(long double x)
 {
-   return static_cast<bool>((boost::math::signbit)(x));
+   return (boost::math::signbit)(x) != 0;
 }
 
 template<> int BOOST_MATH_TR1_DECL fpclassify<long double> BOOST_PREVENT_MACRO_SUBSTITUTION(long double x)

--- a/src/tr1/sph_legendre.cpp
+++ b/src/tr1/sph_legendre.cpp
@@ -13,7 +13,7 @@
 
 extern "C" double BOOST_MATH_TR1_DECL boost_sph_legendre BOOST_PREVENT_MACRO_SUBSTITUTION(unsigned n, unsigned m, double x) BOOST_MATH_C99_THROW_SPEC
 {
-   return  (m & 1 ? -1 : 1) * c_policies::spherical_harmonic_r BOOST_PREVENT_MACRO_SUBSTITUTION(n, m, x, 0.0);
+   return  (((m & 1) == 1) ? -1 : 1) * c_policies::spherical_harmonic_r BOOST_PREVENT_MACRO_SUBSTITUTION(n, m, x, 0.0);
 }
 
 

--- a/src/tr1/sph_legendref.cpp
+++ b/src/tr1/sph_legendref.cpp
@@ -13,7 +13,7 @@
 
 extern "C" float BOOST_MATH_TR1_DECL boost_sph_legendref BOOST_PREVENT_MACRO_SUBSTITUTION(unsigned n, unsigned m, float x) BOOST_MATH_C99_THROW_SPEC
 {
-   return  (m & 1 ? -1 : 1) * c_policies::spherical_harmonic_r BOOST_PREVENT_MACRO_SUBSTITUTION(n, m, x, 0.0f);
+   return  (((m & 1) == 1) ? -1 : 1) * c_policies::spherical_harmonic_r BOOST_PREVENT_MACRO_SUBSTITUTION(n, m, x, 0.0f);
 }
 
 

--- a/src/tr1/sph_legendrel.cpp
+++ b/src/tr1/sph_legendrel.cpp
@@ -13,7 +13,7 @@
 
 extern "C" long double BOOST_MATH_TR1_DECL boost_sph_legendrel BOOST_PREVENT_MACRO_SUBSTITUTION(unsigned n, unsigned m, long double x) BOOST_MATH_C99_THROW_SPEC
 {
-   return  (m & 1 ? -1 : 1) * c_policies::spherical_harmonic_r BOOST_PREVENT_MACRO_SUBSTITUTION(n, m, x, 0.0L);
+   return  (((m & 1) == 1) ? -1 : 1) * c_policies::spherical_harmonic_r BOOST_PREVENT_MACRO_SUBSTITUTION(n, m, x, 0.0L);
 }
 
 

--- a/test/test_ldouble_simple.cpp
+++ b/test/test_ldouble_simple.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE( test_main )
    BOOST_CHECK_EQUAL((boost::math::changesign)(1.0L), -1.0L);
    BOOST_CHECK_EQUAL((boost::math::changesign)(-1.0L), 1.0L);
 
-   BOOST_CHECK_EQUAL((boost::math::fpclassify)(1.0L), (int)FP_NORMAL);
+   BOOST_CHECK_EQUAL((boost::math::fpclassify)(1.0L), FP_NORMAL);
    BOOST_CHECK_EQUAL((boost::math::isnan)(1.0L), false);
    BOOST_CHECK_EQUAL((boost::math::isinf)(1.0L), false);
    BOOST_CHECK_EQUAL((boost::math::isnormal)(1.0L), true);

--- a/tools/bessel_data.cpp
+++ b/tools/bessel_data.cpp
@@ -123,7 +123,7 @@ int bessel_jy_bare(T v, T x, T* J, T* Y, int kind = need_j|need_y)
 
     if (reflect)
     {
-        T z = (u + n % 2) * pi<T>();
+        T z = (u + (n & 1)) * pi<T>();
         *J = cos(z) * Jv - sin(z) * Yv;     // reflection formula
         *Y = sin(z) * Jv + cos(z) * Yv;
     }

--- a/tools/lanczos_generator.cpp
+++ b/tools/lanczos_generator.cpp
@@ -4311,7 +4311,7 @@ mp_t factorial(unsigned n)
 }
 
 template <class T>
-T binomial(int n, int k, T)
+T binomial(unsigned n, unsigned k, T)
 {
    T result;
    if(k < 0) 
@@ -4686,12 +4686,12 @@ struct lanczos_rational
       {
          s1 = num[N-1];
          s2 = denom[N-1];
-         for(unsigned i = N-2; i >= 0; --i)
+         for(int i = N-2; i >= 0; --i)
          {
             s1 *= z;
             s2 *= z;
             s1 += num[i];
-            s2 += num[i];
+            s2 += denom[i];
          }
          s1 /= s2;
          return prefix * s1;
@@ -5055,7 +5055,7 @@ void find_best_lanczos(const char* name, T eps, int max_scan = 100)
 
       std::cout << std::setw(20) << std::right << "N" << std::setw(20) << std::right << "g" << std::setw(20) << std::right << "eps" << std::setw(20) << std::right << "c at 1" << std::setw(20) << std::right << "c at 2" << std::setw(20) << std::right << "time (ms)\n";
 
-      for (int i = 0; i < sizeof(sweet_spots) / sizeof(sweet_spots[0]); ++i)
+      for (size_t i = 0; i < sizeof(sweet_spots) / sizeof(sweet_spots[0]); ++i)
       {
          if ((sweet_spots[i].err < eps * 10) && (sweet_spots[i].N < max_scan))
          {
@@ -5065,8 +5065,8 @@ void find_best_lanczos(const char* name, T eps, int max_scan = 100)
             {
                std::cout << std::setprecision(14) << std::fixed << std::setw(20) << std::right << sweet_spots[i].N
                   << std::setw(20) << std::right << sweet_spots[i].g << std::setw(20) << std::right << static_cast<int>(err / eps)
-                  << std::setw(20) << std::right << (unsigned)lanczos_conditioning_near_1(info) << std::setw(20) << std::right << (unsigned)lanczos_conditioning_near_2(info)
-                  << std::setw(20) << std::right << (int)(exec_time * 1000) << std::endl;
+                  << std::setw(20) << std::right << static_cast<unsigned>lanczos_conditioning_near_1(info) << std::setw(20) << std::right << static_cast<unsigned>lanczos_conditioning_near_2(info)
+                  << std::setw(20) << std::right << static_cast<int>(exec_time * 1000) << std::endl;
             }
             else
                std::cout << "Skipping spot with error: " << std::setprecision(5) << err << std::endl;
@@ -5103,7 +5103,7 @@ void find_best_lanczos(const char* name, T eps, int max_scan = 100)
    }
 }
 
-void scan_for_sweet_spots(int N)
+void scan_for_sweet_spots(unsigned N)
 {
    mp_t r = N * 0.66;
    lanczos_info<mp_t> lower, upper(generate_lanczos(N + 1, r));


### PR DESCRIPTION
There were some last second things I missed.

Among these warnings were "redundant static casts" and "deprecated C-headers"

There were others too but those warnings were false flags so I kept the ones that actually made sense.