### PR TITLE
Update tanh_sinh handling of boundaries.

### DIFF
--- a/include/boost/math/quadrature/tanh_sinh.hpp
+++ b/include/boost/math/quadrature/tanh_sinh.hpp
@@ -169,7 +169,7 @@ auto tanh_sinh<Real, Policy>::integrate(const F f, Real a, Real b, Real toleranc
           bool have_small_left = fabs(a) < 0.5f;
           bool have_small_right = fabs(b) < 0.5f;
           Real left_min_complement = float_next(avg_over_diff_m1) - avg_over_diff_m1;
-          Real min_complement_limit = (std::max)(tools::min_value<Real>(), Real(tools::min_value<Real>() / diff));
+          Real min_complement_limit = (std::max)(tools::min_value<Real>(), float_next(Real(tools::min_value<Real>() / diff)));
           if (left_min_complement < min_complement_limit)
              left_min_complement = min_complement_limit;
           Real right_min_complement = avg_over_diff_p1 - float_prior(avg_over_diff_p1);

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -918,6 +918,7 @@ test-suite mp :
    [ compile ntl_concept_check.cpp : [ check-target-builds ../config//has_ntl_rr : : <build>no ] <debug-symbols>off [ check-target-builds ../config//is_ci_sanitizer_run "Sanitizer CI run" : <build>no ] ]
    [ compile mpfr_concept_check.cpp : [ check-target-builds ../config//has_mpfr_class : : <build>no ] <debug-symbols>off [ check-target-builds ../config//is_ci_sanitizer_run "Sanitizer CI run" : <build>no ] ]
    [ compile mpreal_concept_check.cpp : [ check-target-builds ../config//has_mpreal : : <build>no ] <debug-symbols>off [ check-target-builds ../config//is_ci_sanitizer_run "Sanitizer CI run" : <build>no ] ]
+   [ run issue893.cpp ]
 ;
 
 test-suite misc :

--- a/test/issue893.cpp
+++ b/test/issue893.cpp
@@ -1,0 +1,27 @@
+
+#define BOOST_TEST_MODULE issue893
+
+#include <iostream>
+#include <sstream>
+#include <boost/test/included/unit_test.hpp>
+#include <boost/multiprecision/cpp_bin_float.hpp>
+#include <boost/math/quadrature/tanh_sinh.hpp>
+
+using boost::math::quadrature::tanh_sinh;
+
+#include <iostream>
+
+BOOST_AUTO_TEST_CASE(issue893) {
+	typedef boost::multiprecision::cpp_bin_float_100 real;
+
+	auto fun = [](real x) -> real {
+		return 1.0;
+	};
+
+	tanh_sinh<real> integrator;
+	const real a = 0.0;
+	const real b = -0.9999995515592481132478776023609116290187750667053638330158486516399489191171270344610533516275817076;
+	real y = integrator.integrate(fun, -b, a);
+	
+	BOOST_CHECK(y < 1);
+}

--- a/test/issue893.cpp
+++ b/test/issue893.cpp
@@ -1,3 +1,8 @@
+// Copyright John Maddock, 2022
+// Use, modification and distribution are subject to the
+// Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_TEST_MODULE issue893
 

--- a/test/issue893.cpp
+++ b/test/issue893.cpp
@@ -17,16 +17,16 @@ using boost::math::quadrature::tanh_sinh;
 #include <iostream>
 
 BOOST_AUTO_TEST_CASE(issue893) {
-	typedef boost::multiprecision::cpp_bin_float_100 real;
+   typedef boost::multiprecision::cpp_bin_float_100 real;
 
-	auto fun = [](real x) -> real {
-		return 1.0;
-	};
+   auto fun = [](real x) -> real {
+      return 1.0;
+   };
 
-	tanh_sinh<real> integrator;
-	const real a = 0.0;
-	const real b = -0.9999995515592481132478776023609116290187750667053638330158486516399489191171270344610533516275817076;
-	real y = integrator.integrate(fun, -b, a);
-	
-	BOOST_CHECK(y < 1);
+   tanh_sinh<real> integrator;
+   const real a = 0.0;
+   const real b = -0.9999995515592481132478776023609116290187750667053638330158486516399489191171270344610533516275817076;
+   real y = integrator.integrate(fun, -b, a);
+   
+   BOOST_CHECK(y < 1);
 }


### PR DESCRIPTION
So that we don't accidentality end up at an end point, even when arithmetic is inexact, and the FP type has no denomrms.
Fixes: https://github.com/boostorg/math/issues/893