### PR TITLE
Require C++14 support

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -17,9 +17,9 @@ def main(ctx):
 
   things_to_test = [ "special_fun", "distribution_tests", "mp", "misc", "interpolators", "quadrature", "autodiff", "long-running-tests", "float128_tests" ]
   sanitizer_test = [ "special_fun", "distribution_tests", "misc", "interpolators", "quadrature", "float128_tests" ]
-  gnu_5_stds = [ "gnu++11", "c++11", "gnu++14", "c++14" ]
-  gnu_6_stds = [ "gnu++11", "c++11", "gnu++14", "c++14", "gnu++17", "c++17" ]
-  clang_6_stds = [ "c++11", "c++14", "c++17" ]
+  gnu_5_stds = [ "gnu++14", "c++14" ]
+  gnu_6_stds = [ "gnu++14", "c++14", "gnu++17", "c++17" ]
+  clang_6_stds = [ "c++14", "c++17" ]
   gnu_9_stds = [ "gnu++14", "c++14", "gnu++17", "c++17", "gnu++2a", "c++2a" ]
   clang_10_stds = [ "c++14", "c++17", "c++2a" ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [ g++-9, g++-11, clang++-10 ]
-        standard: [ c++11, c++14, c++17, c++2a ]
+        standard: [ c++14, c++17, c++2a ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -136,7 +136,7 @@ jobs:
       fail-fast: false
       matrix:
         toolset: [ clang ]
-        standard: [ 11, 14, 17, 20 ]
+        standard: [ 14, 17, 20 ]
         suite: [ github_ci_block_1, github_ci_block_2 ]
     steps:
       - uses: actions/checkout@v3

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -74,6 +74,7 @@ project
       <search>$(mpfr_path)
       <search>$(mpfr_path)/build.vc10/lib/Win32/Debug
       [ requires cxx11_noexcept cxx11_rvalue_references sfinae_expr cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_tuple cxx11_hdr_initializer_list cxx11_hdr_chrono cxx11_thread_local cxx11_constexpr cxx11_nullptr cxx11_numeric_limits cxx11_decltype cxx11_hdr_array cxx11_hdr_atomic cxx11_hdr_type_traits cxx11_allocator cxx11_explicit_conversion_operators ]
+      [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction ]
     ;
 
 if $(ntl-path)


### PR DESCRIPTION
Since we have been messaging 1.82 will be the first version that requires C++14 start requiring it in the CI system.