### PR TITLE
Use `size_t` in `size_to_precision`

### DIFF
--- a/include/boost/math/special_functions/detail/fp_traits.hpp
+++ b/include/boost/math/special_functions/detail/fp_traits.hpp
@@ -493,7 +493,7 @@ private:
 // size_to_precision is a type switch for converting a C++ floating point type
 // to the corresponding precision type.
 
-template<int n, bool fp> struct size_to_precision
+template<size_t n, bool fp> struct size_to_precision
 {
    typedef unknown_precision type;
 };


### PR DESCRIPTION
As the trait is supposed to be called with `sizeof` the type should be `size_t`

This avoids a conversion warning on e.g. GCC until 10.4. See https://godbolt.org/z/6Pq38zYbW

Reported on Slack: https://cpplang.slack.com/archives/C27KZLB0X/p1672180776054099