### PR TITLE
Fix for issue #927

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -893,6 +893,7 @@ test-suite distribution_tests :
    [ compile test_dist_deduction_guides.cpp : [ requires cpp_deduction_guides cpp_variadic_templates ] ]
    [ run git_issue_800.cpp ../../test/build//boost_unit_test_framework  ]
    [ run git_issue_845.cpp ../../test/build//boost_unit_test_framework  ]
+   [ run git_issue_927.cpp ../../test/build//boost_unit_test_framework  ]
    [ run scipy_issue_14901.cpp ../../test/build//boost_unit_test_framework ]
    [ run scipy_issue_17146.cpp ../../test/build//boost_unit_test_framework  ]
    [ run scipy_issue_17388.cpp ../../test/build//boost_unit_test_framework  ]

--- a/test/git_issue_927.cpp
+++ b/test/git_issue_927.cpp
@@ -1,0 +1,30 @@
+//  (C) Copyright Matt Borland 2023.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "math_unit_test.hpp"
+#include <boost/math/special_functions/powm1.hpp>
+#include <limits>
+
+template <typename T>
+void test()
+{
+    using namespace boost::math::policies;
+    
+    constexpr T x = -std::numeric_limits<T>::infinity();
+    constexpr T y = T(3);
+
+    T p = boost::math::powm1(x, y, make_policy(overflow_error<errno_on_error>()));
+
+    CHECK_EQUAL(p, -std::numeric_limits<T>::infinity());
+}
+
+int main(void)
+{
+    test<float>();
+    test<double>();
+    test<long double>();
+
+    return boost::math::test::report_errors();
+}


### PR DESCRIPTION
Return `-INF` or `+INF` if the result is `INF` rather than throwing an overflow exception.