### PR TITLE
Ignore warnings in distribution tests suite

### DIFF
--- a/test/compile_test/test_compile_result.hpp
+++ b/test/compile_test/test_compile_result.hpp
@@ -51,10 +51,15 @@ inline void check_result_imp(T1, T2)
 #if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#elif defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
     using static_assertion = int[local_is_same<T1, T2>::value ? 1 : 0];
 #if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)))
 #pragma GCC diagnostic pop
+#elif defined(__clang__)
+#pragma clang diagnostic pop
 #endif
 }
 

--- a/test/complex_test.cpp
+++ b/test/complex_test.cpp
@@ -26,6 +26,14 @@ namespace std{ using ::sqrt; using ::tan; using ::tanh; }
 #define BOOST_TEST_MESSAGE(x)
 #endif
 
+#ifdef _MSC_VER
+#pragma warning (disable:C4996)
+#elif __GNUC__ >= 5
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__clang__)
+#  pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 //
 // check_complex:
 // Verifies that expected value "a" and found value "b" have a relative error

--- a/test/test_hypergeometric_dist.cpp
+++ b/test/test_hypergeometric_dist.cpp
@@ -27,6 +27,14 @@
 #include "handle_test_result.hpp"
 #include "table_type.hpp"
 
+#ifdef _MSC_VER
+#pragma warning (disable:4127 4512)
+#elif __GNUC__ >= 5
+#  pragma GCC diagnostic ignored "-Woverflow"
+#elif defined(__clang__)
+#  pragma clang diagnostic ignored "-Wliteral-range"
+#endif
+
 #define BOOST_CHECK_EX(a) \
    {\
       unsigned int failures = boost::unit_test::results_collector.results( boost::unit_test::framework::current_test_case().p_id ).p_assertions_failed;\

--- a/test/test_nc_beta.cpp
+++ b/test/test_nc_beta.cpp
@@ -14,6 +14,10 @@
 
 #ifdef _MSC_VER
 #pragma warning (disable:4127 4512)
+#elif __GNUC__ >= 5
+#  pragma GCC diagnostic ignored "-Woverflow"
+#elif defined(__clang__)
+#  pragma clang diagnostic ignored "-Wliteral-range"
 #endif
 
 #if !defined(TEST_FLOAT) && !defined(TEST_DOUBLE) && !defined(TEST_LDOUBLE) && !defined(TEST_REAL_CONCEPT)

--- a/test/test_nc_chi_squared.cpp
+++ b/test/test_nc_chi_squared.cpp
@@ -11,6 +11,10 @@
 
 #ifdef _MSC_VER
 #pragma warning (disable:4127 4512)
+#elif __GNUC__ >= 5
+#  pragma GCC diagnostic ignored "-Woverflow"
+#elif defined(__clang__)
+#  pragma clang diagnostic ignored "-Wliteral-range"
 #endif
 
 #if !defined(TEST_FLOAT) && !defined(TEST_DOUBLE) && !defined(TEST_LDOUBLE) && !defined(TEST_REAL_CONCEPT)


### PR DESCRIPTION
Adds: 
`-Wunused-local-typedef` in compile tests for Clang to match GCC
`-Wdeprecated-declarations` for all compilers in complex tests that use the now deprecate complex functions
`-Wliteral-range` for tests that use table data that truncates to zero
