### PR TITLE
 FIX: avoid overflow on overflow check in toms748_solve safe_div

### DIFF
--- a/include/boost/math/tools/toms748_solve.hpp
+++ b/include/boost/math/tools/toms748_solve.hpp
@@ -160,7 +160,8 @@ inline T safe_div(T num, T denom, T r)
 
    if(fabs(denom) < 1)
    {
-      if(fabs(denom * tools::max_value<T>()) <= fabs(num))
+      static const T inv_max_value = 1.0 / tools::max_value<T>();
+      if(fabs(denom) <= inv_max_value * fabs(num))
          return r;
    }
    return num / denom;


### PR DESCRIPTION
- x-ref https://github.com/scipy/scipy/pull/17432
- Same rationale/fix as https://github.com/boostorg/math/pull/937
- avoid calculating `[number]*tools::max_value<T>()` to prevent overflows on Apple M1 processors