### PR TITLE
FIX: avoid overflow on overflow check for Mac M1

### DIFF
--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -1795,7 +1795,8 @@ T gamma_p_derivative_imp(T a, T x, const Policy& pol)
    //
    typedef typename lanczos::lanczos<T, Policy>::type lanczos_type;
    T f1 = detail::regularised_gamma_prefix(a, x, pol, lanczos_type());
-   if((x < 1) && (tools::max_value<T>() * x < f1))
+   static const T inv_max_value = 1.0 / tools::max_value<T>();
+   if((x < 1) && (x < inv_max_value * f1))
    {
       // overflow:
       return policies::raise_overflow_error<T>("boost::math::gamma_p_derivative<%1%>(%1%, %1%)", nullptr, pol);

--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -652,7 +652,9 @@ namespace detail {
          }
          else if (result > max)
          {
-            T diff = ((fabs(max) < 1) && (fabs(result) > 1) && (tools::max_value<T>() / fabs(result) < fabs(max))) ? T(1000) : T(result / max);
+            const T amax = fabs(max);
+            volatile const T aresult = fabs(result); // volatile: force compiler to honor data-dependency in chained bool exprs below
+            T diff = ((amax < 1) && (aresult > 1) && (tools::max_value<T>() / aresult < amax)) ? T(1000) : T(result / max);
             if (fabs(diff) < 1)
                diff = 1 / diff;
             if (!out_of_bounds_sentry && (diff > 0) && (diff < 3))

--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -354,7 +354,12 @@ namespace detail {
          BOOST_MATH_INSTRUMENT_VARIABLE(denom);
          BOOST_MATH_INSTRUMENT_VARIABLE(num);
 
-         if ((fabs(num) < 1) && (fabs(denom) >= fabs(num) * tools::max_value<T>()))
+         // denom/num overflows if:
+         //     |denom| >= |num| * max_value
+         // RHS may overflow on Apple M1, so rearrange:
+         //     |denom| * 1/max_value >= |num|
+         static const T inv_max_value = 1.0 / tools::max_value<T>();
+         if ((fabs(num) < 1) && (inv_max_value * fabs(denom) >= fabs(num)))
          {
             // possible overflow, use Newton step:
             delta = f0 / f1;

--- a/include/boost/math/tools/toms748_solve.hpp
+++ b/include/boost/math/tools/toms748_solve.hpp
@@ -160,7 +160,8 @@ inline T safe_div(T num, T denom, T r)
 
    if(fabs(denom) < 1)
    {
-      if(fabs(denom * tools::max_value<T>()) <= fabs(num))
+      static const T inv_max_value = 1.0 / tools::max_value<T>();
+      if(fabs(denom) <= inv_max_value * fabs(num))
          return r;
    }
    return num / denom;


### PR DESCRIPTION
- x-ref https://github.com/scipy/scipy/pull/17432
- avoid calculating `[number]*tools::max_value<T>()` to prevent overflows on Apple M1 processors