### PR TITLE
Conditionally Disable MP Testing 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: ./config_info_travis
         working-directory: ../boost-root/libs/config/test
       - name: Test
-        run: ../../../b2 toolset=$TOOLSET ${{ matrix.suite }} define=CI_SUPPRESS_KNOWN_ISSUES define=SLOW_COMPILER
+        run: ../../../b2 toolset=$TOOLSET ${{ matrix.suite }} define=CI_SUPPRESS_KNOWN_ISSUES define=SLOW_COMPILER define=BOOST_MATH_RUN_MP_TESTS
         working-directory: ../boost-root/libs/math/test
   ubuntu-focal-no-eh:
     runs-on: ubuntu-20.04

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -843,9 +843,6 @@ test-suite distribution_tests :
    [ run test_rayleigh.cpp ../../test/build//boost_unit_test_framework  ]
    [ run test_students_t.cpp ../../test/build//boost_unit_test_framework  ]
    [ run test_skew_normal.cpp ../../test/build//boost_unit_test_framework  ]
-   [ run test_trapezoidal.cpp ../../test/build//boost_unit_test_framework : : :
-         release [ requires cxx11_lambdas cxx11_auto_declarations cxx11_decltype cxx11_unified_initialization_syntax cxx11_variadic_templates ]
-         [ check-target-builds ../config//has_float128 "GCC libquadmath and __float128 support" : <linkflags>"-Bstatic -lquadmath -Bdynamic" ] ]
    [ run test_triangular.cpp pch ../../test/build//boost_unit_test_framework  ]
    [ run test_uniform.cpp pch ../../test/build//boost_unit_test_framework  ]
    [ run test_weibull.cpp ../../test/build//boost_unit_test_framework  ]
@@ -1470,6 +1467,10 @@ test-suite quadrature :
    [ compile compile_test/gauss_concept_test.cpp : [ requires cxx11_auto_declarations cxx11_lambdas cxx11_smart_ptr cxx11_unified_initialization_syntax ] [ check-target-builds ../config//is_ci_sanitizer_run "Sanitizer CI run" : <build>no ] ]
    [ compile compile_test/gauss_kronrod_concept_test.cpp : [ requires cxx11_auto_declarations cxx11_lambdas cxx11_smart_ptr cxx11_unified_initialization_syntax ] [ check-target-builds ../config//is_ci_sanitizer_run "Sanitizer CI run" : <build>no ] ]
    [ run git_issue_898.cpp ]
+
+   [ run test_trapezoidal.cpp ../../test/build//boost_unit_test_framework : : :
+      release [ requires cxx11_lambdas cxx11_auto_declarations cxx11_decltype cxx11_unified_initialization_syntax cxx11_variadic_templates ]
+      [ check-target-builds ../config//has_float128 "GCC libquadmath and __float128 support" : <linkflags>"-Bstatic -lquadmath -Bdynamic" ] ]
 ;
 
 test-suite autodiff :

--- a/test/compile_test/diff_lanczos_smoothing_incl_test.cpp
+++ b/test/compile_test/diff_lanczos_smoothing_incl_test.cpp
@@ -14,16 +14,16 @@
 
 void compile_and_link_test()
 {
-    float f_temp;
+    float f_temp = 1;
     boost::math::differentiation::discrete_lanczos_derivative f_lanczos(f_temp);
     check_result<float>(f_lanczos.get_spacing());
 
-    double d_temp;
+    double d_temp = 1;
     boost::math::differentiation::discrete_lanczos_derivative d_lanczos(d_temp);
     check_result<double>(d_lanczos.get_spacing());
     
     #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-    long double ld_temp;
+    long double ld_temp = 1;
     boost::math::differentiation::discrete_lanczos_derivative ld_lanczos(ld_temp);
     check_result<long double>(ld_lanczos.get_spacing());
     #endif

--- a/test/exp_sinh_quadrature_test.cpp
+++ b/test/exp_sinh_quadrature_test.cpp
@@ -607,7 +607,7 @@ BOOST_AUTO_TEST_CASE(exp_sinh_quadrature_test)
 #endif
 #endif
 #endif
-#if defined(TEST4) && !defined(BOOST_MATH_NO_MP_TESTS)
+#if defined(TEST4) && defined(BOOST_MATH_RUN_MP_TESTS)
     test_left_limit_infinite<cpp_bin_float_quad>();
     test_right_limit_infinite<cpp_bin_float_quad>();
     test_nr_examples<cpp_bin_float_quad>();
@@ -622,13 +622,13 @@ BOOST_AUTO_TEST_CASE(exp_sinh_quadrature_test)
     test_crc<boost::math::concepts::real_concept>();
 #endif
 #endif
-#if defined(TEST6) && !defined(BOOST_MATH_NO_MP_TESTS)
+#if defined(TEST6) && defined(BOOST_MATH_RUN_MP_TESTS)
     test_left_limit_infinite<boost::multiprecision::cpp_bin_float_50>();
     test_right_limit_infinite<boost::multiprecision::cpp_bin_float_50>();
     test_nr_examples<boost::multiprecision::cpp_bin_float_50>();
     test_crc<boost::multiprecision::cpp_bin_float_50>();
 #endif
-#if defined(TEST7) && !defined(BOOST_MATH_NO_MP_TESTS)
+#if defined(TEST7) && defined(BOOST_MATH_RUN_MP_TESTS)
     test_left_limit_infinite<boost::multiprecision::cpp_dec_float_50>();
     test_right_limit_infinite<boost::multiprecision::cpp_dec_float_50>();
     test_nr_examples<boost::multiprecision::cpp_dec_float_50>();
@@ -636,7 +636,7 @@ BOOST_AUTO_TEST_CASE(exp_sinh_quadrature_test)
     // This one causes stack overflows on the CI machine, but not locally,
     // assume it's due to restricted resources on the server, and <shrug> for now...
     //
-#if ! BOOST_WORKAROUND(BOOST_MSVC, == 1900) && !defined(BOOST_MATH_NO_MP_TESTS)
+#if ! BOOST_WORKAROUND(BOOST_MSVC, == 1900) && defined(BOOST_MATH_RUN_MP_TESTS)
     test_crc<boost::multiprecision::cpp_dec_float_50>();
 #endif
 #endif
@@ -656,7 +656,7 @@ BOOST_AUTO_TEST_CASE(exp_sinh_quadrature_test)
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
     test_complex_exponential_integral_E1<std::complex<long double>>();
 #endif
-#ifndef BOOST_MATH_NO_MP_TESTS
+#if defined(BOOST_MATH_RUN_MP_TESTS)
     test_complex_exponential_integral_E1<boost::multiprecision::cpp_complex_quad>();
 #endif
 #endif

--- a/test/gauss_kronrod_quadrature_test.cpp
+++ b/test/gauss_kronrod_quadrature_test.cpp
@@ -477,7 +477,7 @@ BOOST_AUTO_TEST_CASE(gauss_quadrature_test)
     test_complex_lambert_w<std::complex<long double>>();
 #endif
 #ifdef TEST1A
-#if LDBL_MANT_DIG < 100 // If we have too many digits in a long double, we get build errors due to a constexpr issue.
+#if LDBL_MANT_DIG < 100 && defined(BOOST_MATH_RUN_MP_TESTS) // If we have too many digits in a long double, we get build errors due to a constexpr issue.
     std::cout << "Testing 21 point approximation:\n";
     test_linear<cpp_bin_float_quad, 21>();
     test_quadratic<cpp_bin_float_quad, 21>();
@@ -498,7 +498,7 @@ BOOST_AUTO_TEST_CASE(gauss_quadrature_test)
 #endif
 #endif
 #ifdef TEST2
-#if LDBL_MANT_DIG < 100 // If we have too many digits in a long double, we get build errors due to a constexpr issue.
+#if LDBL_MANT_DIG < 100 && defined(BOOST_MATH_RUN_MP_TESTS) // If we have too many digits in a long double, we get build errors due to a constexpr issue.
     std::cout << "Testing 41 point approximation:\n";
     test_linear<cpp_bin_float_quad, 41>();
     test_quadratic<cpp_bin_float_quad, 41>();
@@ -518,7 +518,7 @@ BOOST_AUTO_TEST_CASE(gauss_quadrature_test)
     test_left_limit_infinite<cpp_bin_float_quad, 51>();
 #endif
 #endif
-#ifdef TEST3
+#if defined(TEST3) && defined(BOOST_MATH_RUN_MP_TESTS)
     // Need at least one set of tests with expression templates turned on:
     std::cout << "Testing 61 point approximation:\n";
     test_linear<cpp_dec_float_50, 61>();

--- a/test/gauss_quadrature_test.cpp
+++ b/test/gauss_quadrature_test.cpp
@@ -461,7 +461,7 @@ BOOST_AUTO_TEST_CASE(gauss_quadrature_test)
     test_right_limit_infinite<double, 9>();
     test_left_limit_infinite<double, 9>();
 
-#if LDBL_MANT_DIG < 100
+#if LDBL_MANT_DIG < 100 && defined(BOOST_MATH_RUN_MP_TESTS)
     test_linear<cpp_bin_float_quad, 10>();
     test_quadratic<cpp_bin_float_quad, 10>();
     test_ca<cpp_bin_float_quad, 10>();
@@ -472,7 +472,7 @@ BOOST_AUTO_TEST_CASE(gauss_quadrature_test)
 #endif
 #endif
 #ifdef TEST2
-#if LDBL_MANT_DIG < 100
+#if LDBL_MANT_DIG < 100 && defined(BOOST_MATH_RUN_MP_TESTS)
     test_linear<cpp_bin_float_quad, 15>();
     test_quadratic<cpp_bin_float_quad, 15>();
     test_ca<cpp_bin_float_quad, 15>();
@@ -508,7 +508,7 @@ BOOST_AUTO_TEST_CASE(gauss_quadrature_test)
 #endif
 #endif
 #ifdef TEST3
-#if LDBL_MANT_DIG < 100
+#if LDBL_MANT_DIG < 100 && defined(BOOST_MATH_RUN_MP_TESTS)
     test_left_limit_infinite<cpp_bin_float_quad, 30>();
 #endif
     test_complex_lambert_w<std::complex<double>>();
@@ -517,7 +517,7 @@ BOOST_AUTO_TEST_CASE(gauss_quadrature_test)
     test_left_limit_infinite<boost::multiprecision::float128, 30>();
     test_complex_lambert_w<boost::multiprecision::complex128>();
 #endif
-#if LDBL_MANT_DIG < 100
+#if LDBL_MANT_DIG < 100 && defined(BOOST_MATH_RUN_MP_TESTS)
     test_complex_lambert_w<boost::multiprecision::cpp_complex_quad>();
 #endif
 #endif

--- a/test/multiprc_concept_check_1.cpp
+++ b/test/multiprc_concept_check_1.cpp
@@ -12,6 +12,8 @@
 #define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
 #define TEST_GROUP_1
 
+#ifdef BOOST_MATH_RUN_MP_TESTS
+
 #ifdef _MSC_VER
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4512)
@@ -38,4 +40,12 @@ int main()
    //BOOST_CONCEPT_ASSERT((boost::math::concepts::RealTypeConcept<test_type>));
 }
 
+#else 
+
+int main()
+{
+   return 0;
+}
+
+#endif
 

--- a/test/multiprc_concept_check_10.cpp
+++ b/test/multiprc_concept_check_10.cpp
@@ -12,6 +12,8 @@
 #define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
 #define TEST_GROUP_15
 
+#ifdef BOOST_MATH_RUN_MP_TESTS
+
 #ifdef _MSC_VER
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4512)
@@ -44,4 +46,11 @@ int main()
    //BOOST_CONCEPT_ASSERT((boost::math::concepts::RealTypeConcept<test_type>));
 }
 
+#else
 
+int main()
+{
+   return 0;
+}
+
+#endif

--- a/test/multiprc_concept_check_2.cpp
+++ b/test/multiprc_concept_check_2.cpp
@@ -12,6 +12,8 @@
 #define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
 #define TEST_GROUP_9
 
+#ifdef BOOST_MATH_RUN_MP_TESTS
+
 #ifdef _MSC_VER
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4512)
@@ -39,4 +41,11 @@ int main()
    checker.constraints();
 }
 
+#else
 
+int main()
+{
+   return 0;
+}
+
+#endif

--- a/test/multiprc_concept_check_3.cpp
+++ b/test/multiprc_concept_check_3.cpp
@@ -11,6 +11,9 @@
 //
 #define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
 #define TEST_GROUP_4
+
+#ifdef BOOST_MATH_RUN_MP_TESTS
+
 #ifdef _MSC_VER
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4512)
@@ -40,4 +43,11 @@ int main()
    //BOOST_CONCEPT_ASSERT((boost::math::concepts::RealTypeConcept<test_type>));
 }
 
+#else
 
+int main()
+{
+   return 0;
+}
+
+#endif

--- a/test/multiprc_concept_check_4.cpp
+++ b/test/multiprc_concept_check_4.cpp
@@ -12,6 +12,8 @@
 #define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
 #define TEST_GROUP_5
 
+#ifdef BOOST_MATH_RUN_MP_TESTS
+
 #ifdef _MSC_VER
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4512)
@@ -44,4 +46,11 @@ int main()
    //BOOST_CONCEPT_ASSERT((boost::math::concepts::RealTypeConcept<test_type>));
 }
 
+#else
 
+int main()
+{
+   return 0;
+}
+
+#endif

--- a/test/multiprc_concept_check_5.cpp
+++ b/test/multiprc_concept_check_5.cpp
@@ -12,6 +12,8 @@
 #define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
 #define TEST_GROUP_6
 
+#ifdef BOOST_MATH_RUN_MP_TESTS
+
 #ifdef _MSC_VER
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4512)
@@ -44,4 +46,11 @@ int main()
    //BOOST_CONCEPT_ASSERT((boost::math::concepts::RealTypeConcept<test_type>));
 }
 
+#else
 
+int main()
+{
+   return 0;
+}
+
+#endif

--- a/test/multiprc_concept_check_6.cpp
+++ b/test/multiprc_concept_check_6.cpp
@@ -12,6 +12,8 @@
 #define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
 #define TEST_GROUP_7
 
+#ifdef BOOST_MATH_RUN_MP_TESTS
+
 #ifdef _MSC_VER
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4512)
@@ -44,4 +46,11 @@ int main()
    //BOOST_CONCEPT_ASSERT((boost::math::concepts::RealTypeConcept<test_type>));
 }
 
+#else
 
+int main()
+{
+   return 0;
+}
+
+#endif

--- a/test/multiprc_concept_check_7.cpp
+++ b/test/multiprc_concept_check_7.cpp
@@ -12,6 +12,8 @@
 #define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
 #define TEST_GROUP_12
 
+#ifdef BOOST_MATH_RUN_MP_TESTS
+
 #ifdef _MSC_VER
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4512)
@@ -44,4 +46,11 @@ int main()
    //BOOST_CONCEPT_ASSERT((boost::math::concepts::RealTypeConcept<test_type>));
 }
 
+#else
 
+int main()
+{
+   return 0;
+}
+
+#endif

--- a/test/multiprc_concept_check_8.cpp
+++ b/test/multiprc_concept_check_8.cpp
@@ -12,6 +12,8 @@
 #define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
 #define TEST_GROUP_13
 
+#ifdef BOOST_MATH_RUN_MP_TESTS
+
 #ifdef _MSC_VER
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4512)
@@ -44,4 +46,11 @@ int main()
    //BOOST_CONCEPT_ASSERT((boost::math::concepts::RealTypeConcept<test_type>));
 }
 
+#else
 
+int main()
+{
+   return 0;
+}
+
+#endif

--- a/test/multiprc_concept_check_9.cpp
+++ b/test/multiprc_concept_check_9.cpp
@@ -12,6 +12,8 @@
 #define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
 #define TEST_GROUP_14
 
+#ifdef BOOST_MATH_RUN_MP_TESTS
+
 #ifdef _MSC_VER
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4512)
@@ -44,4 +46,11 @@ int main()
    //BOOST_CONCEPT_ASSERT((boost::math::concepts::RealTypeConcept<test_type>));
 }
 
+#else
 
+int main()
+{
+   return 0;
+}
+
+#endif

--- a/test/sinh_sinh_quadrature_test.cpp
+++ b/test/sinh_sinh_quadrature_test.cpp
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(sinh_sinh_quadrature_test)
 #if !defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS) && !defined(BOOST_MATH_NO_REAL_CONCEPT_TESTS)
     test_nr_examples<boost::math::concepts::real_concept>();
 #endif
-#if !BOOST_WORKAROUND(BOOST_MSVC, < 1900)
+#if !BOOST_WORKAROUND(BOOST_MSVC, < 1900) && defined(BOOST_MATH_RUN_MP_TESTS)
     test_nr_examples<boost::multiprecision::cpp_dec_float_50>();
 #endif
 
@@ -297,12 +297,14 @@ BOOST_AUTO_TEST_CASE(sinh_sinh_quadrature_test)
     test_crc<long double>();
     test_dirichlet_eta<std::complex<long double>>();
 #endif
+#ifdef BOOST_MATH_RUN_MP_TESTS
     test_crc<cpp_bin_float_quad>();
     test_dirichlet_eta<boost::multiprecision::cpp_complex_quad>();
+#endif
 #if !defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS) && !defined(BOOST_MATH_NO_REAL_CONCEPT_TESTS)
     test_crc<boost::math::concepts::real_concept>();
 #endif
-#if !BOOST_WORKAROUND(BOOST_MSVC, < 1900)
+#if !BOOST_WORKAROUND(BOOST_MSVC, < 1900) && defined(BOOST_MATH_RUN_MP_TESTS)
     test_crc<boost::multiprecision::cpp_dec_float_50>();
 #endif
 

--- a/test/tanh_sinh_mpfr.cpp
+++ b/test/tanh_sinh_mpfr.cpp
@@ -16,6 +16,8 @@ using boost::multiprecision::mpfr_float;
 using boost::math::constants::pi;
 using boost::math::constants::zeta_three;
 
+#ifdef BOOST_MATH_RUN_MP_TESTS
+
 int main() {
     using Real = mpfr_float;
     int p = 100;
@@ -28,3 +30,12 @@ int main() {
     CHECK_ULP_CLOSE(expected, Q, 3);
     return boost::math::test::report_errors();
 }
+
+#else
+
+int main()
+{
+    return 0;
+}
+
+#endif

--- a/test/tanh_sinh_quadrature_test.cpp
+++ b/test/tanh_sinh_quadrature_test.cpp
@@ -953,7 +953,7 @@ BOOST_AUTO_TEST_CASE(tanh_sinh_quadrature_test)
 #endif
 
 #ifdef TEST4
-   #ifndef BOOST_MATH_NO_MP_TESTS
+   #ifdef BOOST_MATH_RUN_MP_TESTS
     test_right_limit_infinite<cpp_bin_float_quad>();
     test_left_limit_infinite<cpp_bin_float_quad>();
     test_linear<cpp_bin_float_quad>();
@@ -970,7 +970,7 @@ BOOST_AUTO_TEST_CASE(tanh_sinh_quadrature_test)
    #endif
 #endif
 #ifdef TEST5
-   #ifndef BOOST_MATH_NO_MP_TESTS
+   #ifdef BOOST_MATH_RUN_MP_TESTS
     test_sf<cpp_bin_float_50>();
     test_sf<cpp_bin_float_100>();
     test_sf<boost::multiprecision::number<boost::multiprecision::cpp_bin_float<150> > >();
@@ -1000,9 +1000,9 @@ BOOST_AUTO_TEST_CASE(tanh_sinh_quadrature_test)
 #endif
 #endif
 #ifdef TEST7
-    #ifndef BOOST_MATH_NO_MP_TESTS
+   #ifdef BOOST_MATH_RUN_MP_TESTS
     test_sf<cpp_dec_float_50>();
-    #endif
+   #endif
 #endif
 #if defined(TEST8) && defined(BOOST_HAS_FLOAT128) && !defined(BOOST_MATH_NO_MP_TESTS)
 

--- a/test/test_0F1.cpp
+++ b/test/test_0F1.cpp
@@ -81,11 +81,15 @@ BOOST_AUTO_TEST_CASE( test_main )
 #endif
 #endif
 #if !defined(TEST) || (TEST == 3)
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    test_spots(boost::multiprecision::cpp_bin_float_quad(), "cpp_bin_float_quad");
+   #endif
 #endif
 #if !defined(TEST) || (TEST == 4)
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    typedef boost::multiprecision::number<boost::multiprecision::cpp_dec_float<40> > dec_40;
    test_spots(dec_40(), "dec_40");
+   #endif
 #endif
 }
 

--- a/test/test_1F0.cpp
+++ b/test/test_1F0.cpp
@@ -24,10 +24,14 @@ BOOST_AUTO_TEST_CASE( test_main )
 #endif
 #endif
 #if !defined(TEST) || (TEST == 2)
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    test_spots(boost::multiprecision::cpp_bin_float_quad());
+   #endif
 #endif
-#if !defined(TEST) || (TEST == 3)
+#if (!defined(TEST) || (TEST == 3))
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    test_spots(boost::multiprecision::cpp_dec_float_50());
+   #endif
 #endif
 }
 

--- a/test/test_1F1.cpp
+++ b/test/test_1F1.cpp
@@ -195,11 +195,15 @@ BOOST_AUTO_TEST_CASE( test_main )
    // These next 2 tests take effectively "forever" to compile with clang:
    //
 #if (!defined(TEST) || (TEST == 6)) && !defined(__clang__)
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    test_spots(boost::multiprecision::cpp_bin_float_quad(), "cpp_bin_float_quad");
+   #endif
 #endif
 #if (!defined(TEST) || (TEST == 7)) && !defined(__clang__)
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    typedef boost::multiprecision::number<boost::multiprecision::cpp_bin_float<40> > dec_40;
    test_spots(dec_40(), "dec_40");
+   #endif
 #endif
 }
 

--- a/test/test_1F1_log.cpp
+++ b/test/test_1F1_log.cpp
@@ -184,11 +184,15 @@ BOOST_AUTO_TEST_CASE( test_main )
 #endif
 #endif
 #if (!defined(TEST) || (TEST == 6)) && !defined(__clang__)
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    test_spots(boost::multiprecision::cpp_bin_float_quad(), "cpp_bin_float_quad");
+   #endif
 #endif
 #if (!defined(TEST) || (TEST == 7)) && !defined(__clang__)
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    typedef boost::multiprecision::number<boost::multiprecision::cpp_bin_float<40> > dec_40;
    test_spots(dec_40(), "dec_40");
+   #endif
 #endif
 }
 

--- a/test/test_1F1_regularized.cpp
+++ b/test/test_1F1_regularized.cpp
@@ -186,11 +186,15 @@ BOOST_AUTO_TEST_CASE( test_main )
 #endif
 #endif
 #if (!defined(TEST) || (TEST == 6)) && !defined(__clang__)
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    test_spots(boost::multiprecision::cpp_bin_float_quad(), "cpp_bin_float_quad");
+   #endif
 #endif
 #if (!defined(TEST) || (TEST == 7)) && !defined(__clang__)
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    typedef boost::multiprecision::number<boost::multiprecision::cpp_bin_float<40> > dec_40;
    test_spots(dec_40(), "dec_40");
+   #endif
 #endif
 }
 

--- a/test/test_2F0.cpp
+++ b/test/test_2F0.cpp
@@ -104,11 +104,15 @@ BOOST_AUTO_TEST_CASE( test_main )
 
 #ifndef BOOST_MATH_NO_MP_TESTS
 #if !defined(TEST) || (TEST == 3)
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    test_spots(boost::multiprecision::cpp_bin_float_quad(), "cpp_bin_float_quad");
+   #endif
 #endif
 #if !defined(TEST) || (TEST == 4)
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    using dec_40 = boost::multiprecision::number<boost::multiprecision::cpp_dec_float<40>>;
    test_spots(dec_40(), "dec_40");
+   #endif
 #endif
 #endif
 }

--- a/test/test_pFq.cpp
+++ b/test/test_pFq.cpp
@@ -35,11 +35,15 @@ BOOST_AUTO_TEST_CASE( test_main )
 #endif
 #endif
 #if (!defined(TEST) || (TEST == 6)) && !defined(__clang__)
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    test_spots(boost::multiprecision::cpp_bin_float_quad(), "cpp_bin_float_quad");
+   #endif
 #endif
 #if (!defined(TEST) || (TEST == 7)) && !defined(__clang__)
+   #if defined(BOOST_MATH_RUN_MP_TESTS)
    typedef boost::multiprecision::number<boost::multiprecision::cpp_bin_float<40> > dec_40;
    test_spots(dec_40(), "dec_40");
+   #endif
 #endif
 #endif
 }

--- a/test/test_trapezoidal.cpp
+++ b/test/test_trapezoidal.cpp
@@ -249,8 +249,11 @@ BOOST_AUTO_TEST_CASE(trapezoidal_quadrature)
 #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
     test_rational_periodic<boost::math::concepts::real_concept>();
 #endif
+
+    #ifdef BOOST_MATH_RUN_MP_TESTS
     test_rational_periodic<cpp_bin_float_50>();
     test_rational_periodic<cpp_bin_float_100>();
+    #endif
 
     test_bump_function<float>();
     test_bump_function<double>();
@@ -260,7 +263,10 @@ BOOST_AUTO_TEST_CASE(trapezoidal_quadrature)
 #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
     test_rational_periodic<boost::math::concepts::real_concept>();
 #endif
+
+    #ifdef BOOST_MATH_RUN_MP_TESTS
     test_rational_periodic<cpp_bin_float_50>();
+    #endif
 
     test_zero_function<float>();
     test_zero_function<double>();
@@ -270,8 +276,11 @@ BOOST_AUTO_TEST_CASE(trapezoidal_quadrature)
 #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
     test_zero_function<boost::math::concepts::real_concept>();
 #endif
+
+    #ifdef BOOST_MATH_RUN_MP_TESTS
     test_zero_function<cpp_bin_float_50>();
     test_zero_function<cpp_bin_float_100>();
+    #endif
 
     test_sinsq<float>();
     test_sinsq<double>();
@@ -281,8 +290,11 @@ BOOST_AUTO_TEST_CASE(trapezoidal_quadrature)
 #ifndef BOOST_MATH_NO_REAL_CONCEPT_TESTS
     test_sinsq<boost::math::concepts::real_concept>();
 #endif
+
+    #ifdef BOOST_MATH_RUN_MP_TESTS
     test_sinsq<cpp_bin_float_50>();
     test_sinsq<cpp_bin_float_100>();
+    #endif
 
     test_slowly_converging<float>();
     test_slowly_converging<double>();
@@ -299,7 +311,9 @@ BOOST_AUTO_TEST_CASE(trapezoidal_quadrature)
     test_rational_sin<long double>();
 #endif
     //test_rational_sin<boost::math::concepts::real_concept>();
+    #ifdef BOOST_MATH_RUN_MP_TESTS
     test_rational_sin<cpp_bin_float_50>();
+    #endif
 
     test_complex_bessel<std::complex<float>>();
     test_complex_bessel<std::complex<double>>();


### PR DESCRIPTION
Should significantly reduce resource usage. Changes a macro used for testing under standalone so now you have to explicitly enable MP testing.