### PR TITLE
Fix fisher_f mode

### DIFF
--- a/include/boost/math/distributions/fisher_f.hpp
+++ b/include/boost/math/distributions/fisher_f.hpp
@@ -309,7 +309,7 @@ inline RealType mode(const fisher_f_distribution<RealType, Policy>& dist)
    if(df1 <= 2)
    {
       return policies::raise_domain_error<RealType>(
-         function, "First degree of freedom was %1% but must be > 2 in order for the distribution to have a mode.", df2, Policy());
+         function, "First degree of freedom was %1% but must be > 2 in order for the distribution to have a mode.", df1, Policy());
    }
    return df2 * (df1 - 2) / (df1 * (df2 + 2));
 }

--- a/include/boost/math/distributions/fisher_f.hpp
+++ b/include/boost/math/distributions/fisher_f.hpp
@@ -306,10 +306,10 @@ inline RealType mode(const fisher_f_distribution<RealType, Policy>& dist)
          && detail::check_df(
             function, df2, &error_result, Policy()))
       return error_result;
-   if(df2 <= 2)
+   if(df1 <= 2)
    {
       return policies::raise_domain_error<RealType>(
-         function, "Second degree of freedom was %1% but must be > 2 in order for the distribution to have a mode.", df2, Policy());
+         function, "First degree of freedom was %1% but must be > 2 in order for the distribution to have a mode.", df2, Policy());
    }
    return df2 * (df1 - 2) / (df1 * (df2 + 2));
 }


### PR DESCRIPTION
The mode for F-distribution is defined when `df1 > 2` according to https://en.wikipedia.org/wiki/F-distribution. It is also reasonable since `df2 * (df1 - 2) / (df1 * (df2 + 2))` becomes zero or negative when `df1 <= 2`