### PR TITLE
Fix out of date links in the distribution docs

### DIFF
--- a/doc/background/references.qbk
+++ b/doc/background/references.qbk
@@ -34,7 +34,7 @@ The Wolfram Research Documentation Center is a collection of online reference ma
 Statistical Distributions (Wiley Series in Probability & Statistics) (Paperback)
 by N.A.J. Hastings, Brian Peacock, Merran Evans, ISBN: 0471371246, Wiley 2000.
 
-[@http://www.worldscibooks.com/mathematics/p191.html Extreme Value Distributions, Theory and Applications]
+[@https://www.google.com/books/edition/Extreme_Value_Distributions/GwBqDQAAQBAJ?hl=en&gbpv=0 Extreme Value Distributions, Theory and Applications]
 Samuel Kotz & Saralees Nadarajah, ISBN 978-1-86094-224-2 & 1-86094-224-5 Oct 2000,
 Chapter 1.2 discusses the various extreme value distributions.
 

--- a/doc/distributions/exponential.qbk
+++ b/doc/distributions/exponential.qbk
@@ -93,7 +93,7 @@ In the following table [lambda] is the parameter lambda of the distribution,
 (See also the reference documentation for the related __extreme_distrib.)
 
 * 
-[@http://www.worldscibooks.com/mathematics/p191.html Extreme Value Distributions, Theory and Applications
+[@https://www.google.com/books/edition/Extreme_Value_Distributions/GwBqDQAAQBAJ?hl=en&gbpv=0 Extreme Value Distributions, Theory and Applications
 Samuel Kotz & Saralees Nadarajah]
 discuss the relationship of the types of extreme value distributions.
 

--- a/doc/distributions/extreme_value.qbk
+++ b/doc/distributions/extreme_value.qbk
@@ -38,7 +38,7 @@ websites.
 
 The relationship of the types of extreme value distributions, of which this is but one, is
 discussed by
-[@http://www.worldscibooks.com/mathematics/p191.html Extreme Value Distributions, Theory and Applications
+[@https://www.google.com/books/edition/Extreme_Value_Distributions/GwBqDQAAQBAJ?hl=en&gbpv=0 Extreme Value Distributions, Theory and Applications
 Samuel Kotz & Saralees Nadarajah].
 
 The distribution has a PDF given by:

--- a/doc/distributions/triangular.qbk
+++ b/doc/distributions/triangular.qbk
@@ -38,7 +38,7 @@ The triangular distribution is often used where the distribution is only vaguely
 but, like the [@http://en.wikipedia.org/wiki/Uniform_distribution_%28continuous%29 uniform distribution],
 upper and limits are 'known', but a 'best guess', the mode or center point, is also added.
 It has been recommended as a
-[@http://www.worldscibooks.com/mathematics/etextbook/5720/5720_chap1.pdf proxy for the beta distribution.]
+[@https://www.jstor.org/stable/2988573 proxy for the beta distribution.]
 The distribution is used in business decision making and project planning.
 
 The [@http://en.wikipedia.org/wiki/Triangular_distribution triangular distribution]

--- a/doc/distributions/weibull.qbk
+++ b/doc/distributions/weibull.qbk
@@ -59,7 +59,7 @@ When ['[alpha]] = 1, the Weibull distribution reduces to the
 [@http://en.wikipedia.org/wiki/Exponential_distribution exponential distribution].
 The relationship of the types of extreme value distributions, of which the Weibull is but one, is
 discussed by
-[@http://www.worldscibooks.com/mathematics/p191.html Extreme Value Distributions, Theory and Applications
+[@https://www.google.com/books/edition/Extreme_Value_Distributions/GwBqDQAAQBAJ?hl=en&gbpv=0 Extreme Value Distributions, Theory and Applications
 Samuel Kotz & Saralees Nadarajah].
 
    

--- a/doc/html/math_toolkit/dist_ref/dists/exp_dist.html
+++ b/doc/html/math_toolkit/dist_ref/dists/exp_dist.html
@@ -305,7 +305,7 @@
           Distributions</a>.)
         </p>
 <div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; "><li class="listitem">
-              <a href="http://www.worldscibooks.com/mathematics/p191.html" target="_top">Extreme
+              <a href="https://www.google.com/books/edition/Extreme_Value_Distributions/GwBqDQAAQBAJ?hl=en&gbpv=0" target="_top">Extreme
               Value Distributions, Theory and Applications Samuel Kotz &amp; Saralees
               Nadarajah</a> discuss the relationship of the types of extreme
               value distributions.

--- a/doc/html/math_toolkit/dist_ref/dists/extreme_dist.html
+++ b/doc/html/math_toolkit/dist_ref/dists/extreme_dist.html
@@ -65,7 +65,7 @@
         </p>
 <p>
           The relationship of the types of extreme value distributions, of which
-          this is but one, is discussed by <a href="http://www.worldscibooks.com/mathematics/p191.html" target="_top">Extreme
+          this is but one, is discussed by <a href="https://www.google.com/books/edition/Extreme_Value_Distributions/GwBqDQAAQBAJ?hl=en&gbpv=0" target="_top">Extreme
           Value Distributions, Theory and Applications Samuel Kotz &amp; Saralees
           Nadarajah</a>.
         </p>

--- a/doc/html/math_toolkit/dist_ref/dists/triangular_dist.html
+++ b/doc/html/math_toolkit/dist_ref/dists/triangular_dist.html
@@ -64,7 +64,7 @@
           vaguely known, but, like the <a href="http://en.wikipedia.org/wiki/Uniform_distribution_%28continuous%29" target="_top">uniform
           distribution</a>, upper and limits are 'known', but a 'best guess',
           the mode or center point, is also added. It has been recommended as a
-          <a href="http://www.worldscibooks.com/mathematics/etextbook/5720/5720_chap1.pdf" target="_top">proxy
+          <a href="https://www.jstor.org/stable/2988573" target="_top">proxy
           for the beta distribution.</a> The distribution is used in business
           decision making and project planning.
         </p>

--- a/doc/html/math_toolkit/dist_ref/dists/weibull_dist.html
+++ b/doc/html/math_toolkit/dist_ref/dists/weibull_dist.html
@@ -108,7 +108,7 @@
           distribution</a>. When <span class="emphasis"><em>α</em></span> = 1, the Weibull distribution
           reduces to the <a href="http://en.wikipedia.org/wiki/Exponential_distribution" target="_top">exponential
           distribution</a>. The relationship of the types of extreme value distributions,
-          of which the Weibull is but one, is discussed by <a href="http://www.worldscibooks.com/mathematics/p191.html" target="_top">Extreme
+          of which the Weibull is but one, is discussed by <a href="https://www.google.com/books/edition/Extreme_Value_Distributions/GwBqDQAAQBAJ?hl=en&gbpv=0" target="_top">Extreme
           Value Distributions, Theory and Applications Samuel Kotz &amp; Saralees
           Nadarajah</a>.
         </p>

--- a/doc/html/math_toolkit/refs.html
+++ b/doc/html/math_toolkit/refs.html
@@ -78,7 +78,7 @@
       by N.A.J. Hastings, Brian Peacock, Merran Evans, ISBN: 0471371246, Wiley 2000.
     </p>
 <p>
-      <a href="http://www.worldscibooks.com/mathematics/p191.html" target="_top">Extreme Value
+      <a href="https://www.google.com/books/edition/Extreme_Value_Distributions/GwBqDQAAQBAJ?hl=en&gbpv=0" target="_top">Extreme Value
       Distributions, Theory and Applications</a> Samuel Kotz &amp; Saralees Nadarajah,
       ISBN 978-1-86094-224-2 &amp; 1-86094-224-5 Oct 2000, Chapter 1.2 discusses
       the various extreme value distributions.


### PR DESCRIPTION
Use google books, and jstor as they should be stable.

Closes: #985 