### PR TITLE
Fix for scipy issues 18506 and 18511

### DIFF
--- a/doc/distributions/hypergeometric.qbk
+++ b/doc/distributions/hypergeometric.qbk
@@ -15,11 +15,11 @@
       typedef RealType value_type;
       typedef Policy   policy_type;
       // Construct:
-      hypergeometric_distribution(unsigned r, unsigned n, unsigned N); // r=defective/failures/success, n=trials/draws, N=total population.
+      hypergeometric_distribution(uint64_t r, uint64_t n, uint64_t N); // r=defective/failures/success, n=trials/draws, N=total population.
       // Accessors:
-      unsigned total()const;
-      unsigned defective()const;
-      unsigned sample_count()const;
+      uint64_t total()const;
+      uint64_t defective()const;
+      uint64_t sample_count()const;
    };
 
    typedef hypergeometric_distribution<> hypergeometric;
@@ -56,20 +56,20 @@ then we obtain basically the same graphs:
 
 [h4 Member Functions]
 
-   hypergeometric_distribution(unsigned r, unsigned n, unsigned N);
+   hypergeometric_distribution(uint64_t r, uint64_t n, uint64_t N);
 
 Constructs a hypergeometric distribution with a population of /N/ objects,
 of which /r/ are defective, and from which /n/ are sampled.
 
-   unsigned total()const;
+   uint64_t total()const;
 
 Returns the total number of objects /N/.
 
-   unsigned defective()const;
+   uint64_t defective()const;
 
 Returns the number of objects /r/ in population /N/ which are defective.
 
-   unsigned sample_count()const;
+   uint64_t sample_count()const;
 
 Returns the number of objects /n/ which are sampled from the population /N/.
 
@@ -87,7 +87,7 @@ and Python
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
 
-The domain of the random variable is the unsigned integers in the range
+The domain of the random variable are the 64-bit unsigned integers in the range
 \[max(0, n + r - N), min(n, r)\].  A __domain_error is raised if the
 random variable is outside this range, or is not an integral value.
 

--- a/include/boost/math/distributions/detail/hypergeometric_cdf.hpp
+++ b/include/boost/math/distributions/detail/hypergeometric_cdf.hpp
@@ -10,11 +10,12 @@
 
 #include <boost/math/policies/error_handling.hpp>
 #include <boost/math/distributions/detail/hypergeometric_pdf.hpp>
+#include <cstdint>
 
 namespace boost{ namespace math{ namespace detail{
 
    template <class T, class Policy>
-   T hypergeometric_cdf_imp(unsigned x, unsigned r, unsigned n, unsigned N, bool invert, const Policy& pol)
+   T hypergeometric_cdf_imp(std::uint64_t x, std::uint64_t r, std::uint64_t n, std::uint64_t N, bool invert, const Policy& pol)
    {
 #ifdef _MSC_VER
 #  pragma warning(push)
@@ -27,7 +28,7 @@ namespace boost{ namespace math{ namespace detail{
       {
          result = hypergeometric_pdf<T>(x, r, n, N, pol);
          T diff = result;
-         unsigned lower_limit = static_cast<unsigned>((std::max)(0, static_cast<int>(n + r) - static_cast<int>(N)));
+         const auto lower_limit = static_cast<std::uint64_t>((std::max)(INT64_C(0), static_cast<std::int64_t>(n + r) - static_cast<std::int64_t>(N)));
          while(diff > (invert ? T(1) : result) * tools::epsilon<T>())
          {
             diff = T(x) * T((N + x) - n - r) * diff / (T(1 + n - x) * T(1 + r - x));
@@ -43,7 +44,7 @@ namespace boost{ namespace math{ namespace detail{
       else
       {
          invert = !invert;
-         unsigned upper_limit = (std::min)(r, n);
+         const auto upper_limit = (std::min)(r, n);
          if(x != upper_limit)
          {
             ++x;
@@ -69,7 +70,7 @@ namespace boost{ namespace math{ namespace detail{
    }
 
    template <class T, class Policy>
-   inline T hypergeometric_cdf(unsigned x, unsigned r, unsigned n, unsigned N, bool invert, const Policy&)
+   inline T hypergeometric_cdf(std::uint64_t x, std::uint64_t r, std::uint64_t n, std::uint64_t N, bool invert, const Policy&)
    {
       BOOST_FPU_EXCEPTION_GUARD
       typedef typename tools::promote_args<T>::type result_type;

--- a/include/boost/math/distributions/detail/hypergeometric_pdf.hpp
+++ b/include/boost/math/distributions/detail/hypergeometric_pdf.hpp
@@ -15,6 +15,8 @@
 #include <boost/math/special_functions/pow.hpp>
 #include <boost/math/special_functions/prime.hpp>
 #include <boost/math/policies/error_handling.hpp>
+#include <algorithm>
+#include <cstdint>
 
 #ifdef BOOST_MATH_INSTRUMENT
 #include <typeinfo>
@@ -40,7 +42,7 @@ template <class T>
 struct sort_functor
 {
    sort_functor(const T* exponents) : m_exponents(exponents){}
-   bool operator()(int i, int j)
+   bool operator()(std::size_t i, std::size_t j)
    {
       return m_exponents[i] > m_exponents[j];
    }
@@ -49,7 +51,7 @@ private:
 };
 
 template <class T, class Lanczos, class Policy>
-T hypergeometric_pdf_lanczos_imp(T /*dummy*/, unsigned x, unsigned r, unsigned n, unsigned N, const Lanczos&, const Policy&)
+T hypergeometric_pdf_lanczos_imp(T /*dummy*/, std::uint64_t x, std::uint64_t r, std::uint64_t n, std::uint64_t N, const Lanczos&, const Policy&)
 {
    BOOST_MATH_STD_USING
 
@@ -137,7 +139,7 @@ T hypergeometric_pdf_lanczos_imp(T /*dummy*/, unsigned x, unsigned r, unsigned n
    //
    // Combine equal powers:
    //
-   int j = 8;
+   std::size_t j = 8;
    while(exponents[sorted_indexes[j]] == 0) --j;
    while(j)
    {
@@ -184,7 +186,7 @@ T hypergeometric_pdf_lanczos_imp(T /*dummy*/, unsigned x, unsigned r, unsigned n
       result = pow(bases[sorted_indexes[0]] * exp(static_cast<T>(base_e_factors[sorted_indexes[0]])), exponents[sorted_indexes[0]]);
    }
    BOOST_MATH_INSTRUMENT_VARIABLE(result);
-   for(unsigned i = 1; (i < 9) && (exponents[sorted_indexes[i]] > 0); ++i)
+   for(std::size_t i = 1; (i < 9) && (exponents[sorted_indexes[i]] > 0); ++i)
    {
       BOOST_FPU_EXCEPTION_GUARD
       if(result < tools::min_value<T>())
@@ -215,7 +217,7 @@ T hypergeometric_pdf_lanczos_imp(T /*dummy*/, unsigned x, unsigned r, unsigned n
 }
 
 template <class T, class Policy>
-T hypergeometric_pdf_lanczos_imp(T /*dummy*/, unsigned x, unsigned r, unsigned n, unsigned N, const boost::math::lanczos::undefined_lanczos&, const Policy& pol)
+T hypergeometric_pdf_lanczos_imp(T /*dummy*/, std::uint64_t x, std::uint64_t r, std::uint64_t n, std::uint64_t N, const boost::math::lanczos::undefined_lanczos&, const Policy& pol)
 {
    BOOST_MATH_STD_USING
    return exp(
@@ -277,12 +279,12 @@ struct hypergeometric_pdf_prime_loop_result_entry
 
 struct hypergeometric_pdf_prime_loop_data
 {
-   const unsigned x;
-   const unsigned r;
-   const unsigned n;
-   const unsigned N;
-   unsigned prime_index;
-   unsigned current_prime;
+   const std::uint64_t x;
+   const std::uint64_t r;
+   const std::uint64_t n;
+   const std::uint64_t N;
+   std::size_t prime_index;
+   std::uint64_t current_prime;
 };
 
 #ifdef _MSC_VER
@@ -294,8 +296,8 @@ T hypergeometric_pdf_prime_loop_imp(hypergeometric_pdf_prime_loop_data& data, hy
 {
    while(data.current_prime <= data.N)
    {
-      unsigned base = data.current_prime;
-      int prime_powers = 0;
+      std::uint64_t base = data.current_prime;
+      std::int64_t prime_powers = 0;
       while(base <= data.N)
       {
          prime_powers += data.n / base;
@@ -381,7 +383,7 @@ T hypergeometric_pdf_prime_loop_imp(hypergeometric_pdf_prime_loop_data& data, hy
 }
 
 template <class T, class Policy>
-inline T hypergeometric_pdf_prime_imp(unsigned x, unsigned r, unsigned n, unsigned N, const Policy&)
+inline T hypergeometric_pdf_prime_imp(std::uint64_t x, std::uint64_t r, std::uint64_t n, std::uint64_t N, const Policy&)
 {
    hypergeometric_pdf_prime_loop_result_entry<T> result = { 1, 0 };
    hypergeometric_pdf_prime_loop_data data = { x, r, n, N, 0, prime(0) };
@@ -389,7 +391,7 @@ inline T hypergeometric_pdf_prime_imp(unsigned x, unsigned r, unsigned n, unsign
 }
 
 template <class T, class Policy>
-T hypergeometric_pdf_factorial_imp(unsigned x, unsigned r, unsigned n, unsigned N, const Policy&)
+T hypergeometric_pdf_factorial_imp(std::uint64_t x, std::uint64_t r, std::uint64_t n, std::uint64_t N, const Policy&)
 {
    BOOST_MATH_STD_USING
    BOOST_MATH_ASSERT(N <= boost::math::max_factorial<T>::value);
@@ -406,8 +408,8 @@ T hypergeometric_pdf_factorial_imp(unsigned x, unsigned r, unsigned n, unsigned 
       boost::math::unchecked_factorial<T>(r - x),
       boost::math::unchecked_factorial<T>(N - n - r + x)
    };
-   int i = 0;
-   int j = 0;
+   std::size_t i = 0;
+   std::size_t j = 0;
    while((i < 3) || (j < 5))
    {
       while((j < 5) && ((result >= 1) || (i >= 3)))
@@ -427,7 +429,7 @@ T hypergeometric_pdf_factorial_imp(unsigned x, unsigned r, unsigned n, unsigned 
 
 template <class T, class Policy>
 inline typename tools::promote_args<T>::type 
-   hypergeometric_pdf(unsigned x, unsigned r, unsigned n, unsigned N, const Policy&)
+   hypergeometric_pdf(std::uint64_t x, std::uint64_t r, std::uint64_t n, std::uint64_t N, const Policy&)
 {
    BOOST_FPU_EXCEPTION_GUARD
    typedef typename tools::promote_args<T>::type result_type;

--- a/include/boost/math/distributions/hypergeometric.hpp
+++ b/include/boost/math/distributions/hypergeometric.hpp
@@ -16,6 +16,7 @@
 #include <boost/math/distributions/detail/hypergeometric_cdf.hpp>
 #include <boost/math/distributions/detail/hypergeometric_quantile.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
+#include <cstdint>
 
 namespace boost { namespace math {
 
@@ -26,7 +27,7 @@ namespace boost { namespace math {
       typedef RealType value_type;
       typedef Policy policy_type;
 
-      hypergeometric_distribution(unsigned r, unsigned n, unsigned N) // Constructor. r=defective/failures/success, n=trials/draws, N=total population.
+      hypergeometric_distribution(std::uint64_t r, std::uint64_t n, std::uint64_t N) // Constructor. r=defective/failures/success, n=trials/draws, N=total population.
          : m_n(n), m_N(N), m_r(r)
       {
          static const char* function = "boost::math::hypergeometric_distribution<%1%>::hypergeometric_distribution";
@@ -34,17 +35,17 @@ namespace boost { namespace math {
          check_params(function, &ret);
       }
       // Accessor functions.
-      unsigned total()const
+      std::uint64_t total() const
       {
          return m_N;
       }
 
-      unsigned defective()const // successes/failures/events
+      std::uint64_t defective() const // successes/failures/events
       {
          return m_r;
       }
 
-      unsigned sample_count()const
+      std::uint64_t sample_count()const
       {
          return m_n;
       }
@@ -65,9 +66,9 @@ namespace boost { namespace math {
          }
          return true;
       }
-      bool check_x(unsigned x, const char* function, RealType* result)const
+      bool check_x(std::uint64_t x, const char* function, RealType* result)const
       {
-         if(x < static_cast<unsigned>((std::max)(0, static_cast<int>(m_n + m_r) - static_cast<int>(m_N))))
+         if(x < static_cast<std::uint64_t>((std::max)(INT64_C(0), static_cast<std::int64_t>(m_n + m_r) - static_cast<std::int64_t>(m_N))))
          {
             *result = boost::math::policies::raise_domain_error<RealType>(
                function, "Random variable out of range: must be > 0 and > m + r - N but got %1%", static_cast<RealType>(x), Policy());
@@ -84,40 +85,40 @@ namespace boost { namespace math {
 
    private:
       // Data members:
-      unsigned m_n;  // number of items picked or drawn.
-      unsigned m_N; // number of "total" items.
-      unsigned m_r; // number of "defective/successes/failures/events items.
+      std::uint64_t m_n;  // number of items picked or drawn.
+      std::uint64_t m_N; // number of "total" items.
+      std::uint64_t m_r; // number of "defective/successes/failures/events items.
 
    }; // class hypergeometric_distribution
 
    typedef hypergeometric_distribution<double> hypergeometric;
 
    template <class RealType, class Policy>
-   inline const std::pair<unsigned, unsigned> range(const hypergeometric_distribution<RealType, Policy>& dist)
+   inline const std::pair<std::uint64_t, std::uint64_t> range(const hypergeometric_distribution<RealType, Policy>& dist)
    { // Range of permissible values for random variable x.
 #ifdef _MSC_VER
 #  pragma warning(push)
 #  pragma warning(disable:4267)
 #endif
-      unsigned r = dist.defective();
-      unsigned n = dist.sample_count();
-      unsigned N = dist.total();
-      unsigned l = static_cast<unsigned>((std::max)(0, static_cast<int>(n + r) - static_cast<int>(N)));
-      unsigned u = (std::min)(r, n);
-      return std::pair<unsigned, unsigned>(l, u);
+      std::uint64_t r = dist.defective();
+      std::uint64_t n = dist.sample_count();
+      std::uint64_t N = dist.total();
+      std::uint64_t l = static_cast<std::uint64_t>((std::max)(INT64_C(0), static_cast<std::int64_t>(n + r) - static_cast<std::int64_t>(N)));
+      std::uint64_t u = (std::min)(r, n);
+      return std::pair<std::uint64_t, std::uint64_t>(l, u);
 #ifdef _MSC_VER
 #  pragma warning(pop)
 #endif
    }
 
    template <class RealType, class Policy>
-   inline const std::pair<unsigned, unsigned> support(const hypergeometric_distribution<RealType, Policy>& d)
+   inline const std::pair<std::uint64_t, std::uint64_t> support(const hypergeometric_distribution<RealType, Policy>& d)
    {
       return range(d);
    }
 
    template <class RealType, class Policy>
-   inline RealType pdf(const hypergeometric_distribution<RealType, Policy>& dist, const unsigned& x)
+   inline RealType pdf(const hypergeometric_distribution<RealType, Policy>& dist, const std::uint64_t& x)
    {
       static const char* function = "boost::math::pdf(const hypergeometric_distribution<%1%>&, const %1%&)";
       RealType result = 0;
@@ -136,7 +137,7 @@ namespace boost { namespace math {
       BOOST_MATH_STD_USING
       static const char* function = "boost::math::pdf(const hypergeometric_distribution<%1%>&, const %1%&)";
       RealType r = static_cast<RealType>(x);
-      unsigned u = itrunc(r, typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type());
+      auto u = lltrunc(r, typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type());
       if(u != r)
       {
          return boost::math::policies::raise_domain_error<RealType>(
@@ -146,7 +147,7 @@ namespace boost { namespace math {
    }
 
    template <class RealType, class Policy>
-   inline RealType cdf(const hypergeometric_distribution<RealType, Policy>& dist, const unsigned& x)
+   inline RealType cdf(const hypergeometric_distribution<RealType, Policy>& dist, const std::uint64_t& x)
    {
       static const char* function = "boost::math::cdf(const hypergeometric_distribution<%1%>&, const %1%&)";
       RealType result = 0;
@@ -165,7 +166,7 @@ namespace boost { namespace math {
       BOOST_MATH_STD_USING
       static const char* function = "boost::math::cdf(const hypergeometric_distribution<%1%>&, const %1%&)";
       RealType r = static_cast<RealType>(x);
-      unsigned u = itrunc(r, typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type());
+      auto u = lltrunc(r, typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type());
       if(u != r)
       {
          return boost::math::policies::raise_domain_error<RealType>(
@@ -175,7 +176,7 @@ namespace boost { namespace math {
    }
 
    template <class RealType, class Policy>
-   inline RealType cdf(const complemented2_type<hypergeometric_distribution<RealType, Policy>, unsigned>& c)
+   inline RealType cdf(const complemented2_type<hypergeometric_distribution<RealType, Policy>, std::uint64_t>& c)
    {
       static const char* function = "boost::math::cdf(const hypergeometric_distribution<%1%>&, const %1%&)";
       RealType result = 0;
@@ -194,7 +195,7 @@ namespace boost { namespace math {
       BOOST_MATH_STD_USING
       static const char* function = "boost::math::cdf(const hypergeometric_distribution<%1%>&, const %1%&)";
       RealType r = static_cast<RealType>(c.param);
-      unsigned u = itrunc(r, typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type());
+      std::uint64_t u = lltrunc(r, typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type());
       if(u != r)
       {
          return boost::math::policies::raise_domain_error<RealType>(
@@ -208,11 +209,14 @@ namespace boost { namespace math {
    {
       BOOST_MATH_STD_USING // for ADL of std functions
 
-         // Checking function argument
-         RealType result = 0;
+      // Checking function argument
+      RealType result = 0;
       const char* function = "boost::math::quantile(const hypergeometric_distribution<%1%>&, %1%)";
-      if (false == dist.check_params(function, &result)) return result;
-      if(false == detail::check_probability(function, p, &result, Policy())) return result;
+      if (false == dist.check_params(function, &result)) 
+         return result;
+
+      if(false == detail::check_probability(function, p, &result, Policy())) 
+         return result;
 
       return static_cast<RealType>(detail::hypergeometric_quantile(p, RealType(1 - p), dist.defective(), dist.sample_count(), dist.total(), Policy()));
    } // quantile
@@ -225,8 +229,10 @@ namespace boost { namespace math {
       // Checking function argument
       RealType result = 0;
       const char* function = "quantile(const complemented2_type<hypergeometric_distribution<%1%>, %1%>&)";
-      if (false == c.dist.check_params(function, &result)) return result;
-      if(false == detail::check_probability(function, c.param, &result, Policy())) return result;
+      if (false == c.dist.check_params(function, &result)) 
+         return result;
+      if (false == detail::check_probability(function, c.param, &result, Policy()))
+         return result;
 
       return static_cast<RealType>(detail::hypergeometric_quantile(RealType(1 - c.param), c.param, c.dist.defective(), c.dist.sample_count(), c.dist.total(), Policy()));
    } // quantile

--- a/include/boost/math/distributions/hypergeometric.hpp
+++ b/include/boost/math/distributions/hypergeometric.hpp
@@ -100,12 +100,12 @@ namespace boost { namespace math {
 #  pragma warning(push)
 #  pragma warning(disable:4267)
 #endif
-      std::uint64_t r = dist.defective();
-      std::uint64_t n = dist.sample_count();
-      std::uint64_t N = dist.total();
-      std::uint64_t l = static_cast<std::uint64_t>((std::max)(INT64_C(0), static_cast<std::int64_t>(n + r) - static_cast<std::int64_t>(N)));
-      std::uint64_t u = (std::min)(r, n);
-      return std::pair<std::uint64_t, std::uint64_t>(l, u);
+      const auto r = dist.defective();
+      const auto n = dist.sample_count();
+      const auto N = dist.total();
+      const auto l = static_cast<std::uint64_t>((std::max)(INT64_C(0), static_cast<std::int64_t>(n + r) - static_cast<std::int64_t>(N)));
+      const auto u = (std::min)(r, n);
+      return std::make_pair(l, u);
 #ifdef _MSC_VER
 #  pragma warning(pop)
 #endif
@@ -137,7 +137,7 @@ namespace boost { namespace math {
       BOOST_MATH_STD_USING
       static const char* function = "boost::math::pdf(const hypergeometric_distribution<%1%>&, const %1%&)";
       RealType r = static_cast<RealType>(x);
-      auto u = lltrunc(r, typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type());
+      auto u = static_cast<std::uint64_t>(lltrunc(r, typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type()));
       if(u != r)
       {
          return boost::math::policies::raise_domain_error<RealType>(
@@ -166,7 +166,7 @@ namespace boost { namespace math {
       BOOST_MATH_STD_USING
       static const char* function = "boost::math::cdf(const hypergeometric_distribution<%1%>&, const %1%&)";
       RealType r = static_cast<RealType>(x);
-      auto u = lltrunc(r, typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type());
+      auto u = static_cast<std::uint64_t>(lltrunc(r, typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type()));
       if(u != r)
       {
          return boost::math::policies::raise_domain_error<RealType>(
@@ -195,7 +195,7 @@ namespace boost { namespace math {
       BOOST_MATH_STD_USING
       static const char* function = "boost::math::cdf(const hypergeometric_distribution<%1%>&, const %1%&)";
       RealType r = static_cast<RealType>(c.param);
-      std::uint64_t u = lltrunc(r, typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type());
+      auto u = static_cast<std::uint64_t>(lltrunc(r, typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type()));
       if(u != r)
       {
          return boost::math::policies::raise_domain_error<RealType>(
@@ -248,9 +248,9 @@ namespace boost { namespace math {
    template <class RealType, class Policy>
    inline RealType variance(const hypergeometric_distribution<RealType, Policy>& dist)
    {
-      RealType r = static_cast<RealType>(dist.defective());
-      RealType n = static_cast<RealType>(dist.sample_count());
-      RealType N = static_cast<RealType>(dist.total());
+      const auto r = static_cast<RealType>(dist.defective());
+      const auto n = static_cast<RealType>(dist.sample_count());
+      const auto N = static_cast<RealType>(dist.total());
       return n * r  * (N - r) * (N - n) / (N * N * (N - 1));
    } // RealType variance(const hypergeometric_distribution<RealType, Policy>& dist)
 
@@ -258,9 +258,9 @@ namespace boost { namespace math {
    inline RealType mode(const hypergeometric_distribution<RealType, Policy>& dist)
    {
       BOOST_MATH_STD_USING
-      RealType r = static_cast<RealType>(dist.defective());
-      RealType n = static_cast<RealType>(dist.sample_count());
-      RealType N = static_cast<RealType>(dist.total());
+      const auto r = static_cast<RealType>(dist.defective());
+      const auto n = static_cast<RealType>(dist.sample_count());
+      const auto N = static_cast<RealType>(dist.total());
       return floor((r + 1) * (n + 1) / (N + 2));
    }
 
@@ -268,9 +268,9 @@ namespace boost { namespace math {
    inline RealType skewness(const hypergeometric_distribution<RealType, Policy>& dist)
    {
       BOOST_MATH_STD_USING
-      RealType r = static_cast<RealType>(dist.defective());
-      RealType n = static_cast<RealType>(dist.sample_count());
-      RealType N = static_cast<RealType>(dist.total());
+      const auto r = static_cast<RealType>(dist.defective());
+      const auto n = static_cast<RealType>(dist.sample_count());
+      const auto N = static_cast<RealType>(dist.total());
       return (N - 2 * r) * sqrt(N - 1) * (N - 2 * n) / (sqrt(n * r * (N - r) * (N - n)) * (N - 2));
    } // RealType skewness(const hypergeometric_distribution<RealType, Policy>& dist)
 
@@ -284,11 +284,11 @@ namespace boost { namespace math {
       //  skewness | (sqrt(N - 1) (N - 2 m) (N - 2 n))/((N - 2) sqrt(m n(N - m) (N - n)))
       //  kurtosis | ((N - 1) N^2 ((3 m(N - m) (n^2 (-N) + (n - 2) N^2 + 6 n(N - n)))/N^2 - 6 n(N - n) + N(N + 1)))/(m n(N - 3) (N - 2) (N - m) (N - n))
      // Kurtosis[HypergeometricDistribution[n, m, N]]
-      RealType m = static_cast<RealType>(dist.defective()); // Failures or success events. (Also symbols K or M are used).
-      RealType n = static_cast<RealType>(dist.sample_count()); // draws or trials.
-      RealType n2 = n * n; // n^2
-      RealType N = static_cast<RealType>(dist.total()); // Total population from which n draws or trials are made.
-      RealType N2 = N * N; // N^2
+      const auto m = static_cast<RealType>(dist.defective()); // Failures or success events. (Also symbols K or M are used).
+      const auto n = static_cast<RealType>(dist.sample_count()); // draws or trials.
+      const auto n2 = n * n; // n^2
+      const auto N = static_cast<RealType>(dist.total()); // Total population from which n draws or trials are made.
+      const auto N2 = N * N; // N^2
       // result = ((N - 1) N^2 ((3 m(N - m) (n^2 (-N) + (n - 2) N^2 + 6 n(N - n)))/N^2 - 6 n(N - n) + N(N + 1)))/(m n(N - 3) (N - 2) (N - m) (N - n));
       RealType result = ((N-1)*N2*((3*m*(N-m)*(n2*(-N)+(n-2)*N2+6*n*(N-n)))/N2-6*n*(N-n)+N*(N+1)))/(m*n*(N-3)*(N-2)*(N-m)*(N-n));
       // Agrees with kurtosis hypergeometric distribution(50,200,500) kurtosis = 2.96917

--- a/include/boost/math/distributions/hypergeometric.hpp
+++ b/include/boost/math/distributions/hypergeometric.hpp
@@ -248,9 +248,9 @@ namespace boost { namespace math {
    template <class RealType, class Policy>
    inline RealType variance(const hypergeometric_distribution<RealType, Policy>& dist)
    {
-      const auto r = static_cast<RealType>(dist.defective());
-      const auto n = static_cast<RealType>(dist.sample_count());
-      const auto N = static_cast<RealType>(dist.total());
+      RealType r = static_cast<RealType>(dist.defective());
+      RealType n = static_cast<RealType>(dist.sample_count());
+      RealType N = static_cast<RealType>(dist.total());
       return n * r  * (N - r) * (N - n) / (N * N * (N - 1));
    } // RealType variance(const hypergeometric_distribution<RealType, Policy>& dist)
 
@@ -258,9 +258,9 @@ namespace boost { namespace math {
    inline RealType mode(const hypergeometric_distribution<RealType, Policy>& dist)
    {
       BOOST_MATH_STD_USING
-      const auto r = static_cast<RealType>(dist.defective());
-      const auto n = static_cast<RealType>(dist.sample_count());
-      const auto N = static_cast<RealType>(dist.total());
+      RealType r = static_cast<RealType>(dist.defective());
+      RealType n = static_cast<RealType>(dist.sample_count());
+      RealType N = static_cast<RealType>(dist.total());
       return floor((r + 1) * (n + 1) / (N + 2));
    }
 
@@ -268,9 +268,9 @@ namespace boost { namespace math {
    inline RealType skewness(const hypergeometric_distribution<RealType, Policy>& dist)
    {
       BOOST_MATH_STD_USING
-      const auto r = static_cast<RealType>(dist.defective());
-      const auto n = static_cast<RealType>(dist.sample_count());
-      const auto N = static_cast<RealType>(dist.total());
+      RealType r = static_cast<RealType>(dist.defective());
+      RealType n = static_cast<RealType>(dist.sample_count());
+      RealType N = static_cast<RealType>(dist.total());
       return (N - 2 * r) * sqrt(N - 1) * (N - 2 * n) / (sqrt(n * r * (N - r) * (N - n)) * (N - 2));
    } // RealType skewness(const hypergeometric_distribution<RealType, Policy>& dist)
 
@@ -284,11 +284,11 @@ namespace boost { namespace math {
       //  skewness | (sqrt(N - 1) (N - 2 m) (N - 2 n))/((N - 2) sqrt(m n(N - m) (N - n)))
       //  kurtosis | ((N - 1) N^2 ((3 m(N - m) (n^2 (-N) + (n - 2) N^2 + 6 n(N - n)))/N^2 - 6 n(N - n) + N(N + 1)))/(m n(N - 3) (N - 2) (N - m) (N - n))
      // Kurtosis[HypergeometricDistribution[n, m, N]]
-      const auto m = static_cast<RealType>(dist.defective()); // Failures or success events. (Also symbols K or M are used).
-      const auto n = static_cast<RealType>(dist.sample_count()); // draws or trials.
-      const auto n2 = n * n; // n^2
-      const auto N = static_cast<RealType>(dist.total()); // Total population from which n draws or trials are made.
-      const auto N2 = N * N; // N^2
+      RealType m = static_cast<RealType>(dist.defective()); // Failures or success events. (Also symbols K or M are used).
+      RealType n = static_cast<RealType>(dist.sample_count()); // draws or trials.
+      RealType n2 = n * n; // n^2
+      RealType N = static_cast<RealType>(dist.total()); // Total population from which n draws or trials are made.
+      RealType N2 = N * N; // N^2
       // result = ((N - 1) N^2 ((3 m(N - m) (n^2 (-N) + (n - 2) N^2 + 6 n(N - n)))/N^2 - 6 n(N - n) + N(N + 1)))/(m n(N - 3) (N - 2) (N - m) (N - n));
       RealType result = ((N-1)*N2*((3*m*(N-m)*(n2*(-N)+(n-2)*N2+6*n*(N-n)))/N2-6*n*(N-n)+N*(N+1)))/(m*n*(N-3)*(N-2)*(N-m)*(N-n));
       // Agrees with kurtosis hypergeometric distribution(50,200,500) kurtosis = 2.96917

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -900,6 +900,7 @@ test-suite distribution_tests :
    [ run scipy_issue_17916.cpp ../../test/build//boost_unit_test_framework  ]
    [ run scipy_issue_17916_nct.cpp ../../test/build//boost_unit_test_framework  ]
    [ run scipy_issue_18302.cpp ../../test/build//boost_unit_test_framework  ]
+   [ run scipy_issue_18511.cpp ../../test/build//boost_unit_test_framework ]
 ;
 
 test-suite mp :

--- a/test/hypergeometric_dist_data2.ipp
+++ b/test/hypergeometric_dist_data2.ipp
@@ -8,6 +8,15 @@
 // (5) are commented out as they are too close to numeric_limits<double>::min(), to expect
 // our implementation to cope :-(
 //
+
+#ifdef _MSC_VER
+#pragma warning (disable:4127 4512)
+#elif __GNUC__ >= 5
+#  pragma GCC diagnostic ignored "-Woverflow"
+#elif defined(__clang__)
+#  pragma clang diagnostic ignored "-Wliteral-range"
+#endif
+
 #define SC_(x) static_cast<typename table_type<T>::type>(BOOST_JOIN(x, L))
    static const std::array<std::array<T, 7>, 1542-5> hypergeometric_dist_data2 = {{
       {{ SC_(3.0), SC_(3.0), SC_(4.0), SC_(3.0), SC_(0.25), SC_(1.0), SC_(0.0) }}, 

--- a/test/scipy_issue_18511.cpp
+++ b/test/scipy_issue_18511.cpp
@@ -1,0 +1,35 @@
+// Copyright Matt Borland, 2023
+// Use, modification and distribution are subject to the
+// Boost Software License, Version 1.0. (See accompanying file
+// LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// https://github.com/scipy/scipy/issues/18511
+
+#include <boost/math/distributions/hypergeometric.hpp>
+#include <boost/math/policies/policy.hpp>
+#include <limits>
+#include <cstdint>
+#include "math_unit_test.hpp"
+
+template <typename T>
+void test()
+{
+    //https://www.wolframalpha.com/input?i=%2812000+*+370000%29+%2F+390000
+    auto dist = boost::math::hypergeometric_distribution<T>(UINT64_C(12'000), UINT64_C(370'000), UINT64_C(390'000));
+    auto hm = boost::math::mean(dist);
+    CHECK_ULP_CLOSE(hm, static_cast<T>(11384.615384615384615384615384615384615384615384615384615384615384L), 1);
+
+    // Same result as above because both the numerator and denom have been multiplied by 100 (Exceeds UINT32_MAX)
+    auto dist2 = boost::math::hypergeometric_distribution<T>(UINT64_C(12'000), UINT64_C(37'000'000), UINT64_C(39'000'000)); 
+    auto hm2 = boost::math::mean(dist2);
+    CHECK_ULP_CLOSE(hm2, static_cast<T>(11384.615384615384615384615384615384615384615384615384615384615384L), 1);
+}
+
+int main()
+{
+    test<float>();
+    test<double>();
+    test<long double>();
+
+    return boost::math::test::report_errors();
+}

--- a/test/test_hypergeometric_dist.cpp
+++ b/test/test_hypergeometric_dist.cpp
@@ -26,6 +26,7 @@
 #include "functor.hpp"
 #include "handle_test_result.hpp"
 #include "table_type.hpp"
+#include <cstdint>
 
 #ifdef _MSC_VER
 #pragma warning (disable:4127 4512)
@@ -115,14 +116,14 @@ void expected_results()
 }
 
 template <class T>
-inline unsigned make_unsigned(T x)
+inline std::uint64_t make_unsigned(T x)
 {
-   return static_cast<unsigned>(x);
+   return static_cast<std::uint64_t>(x);
 }
 template<>
-inline unsigned make_unsigned(boost::math::concepts::real_concept x)
+inline std::uint64_t make_unsigned(boost::math::concepts::real_concept x)
 {
-   return static_cast<unsigned>(x.value());
+   return static_cast<std::uint64_t>(x.value());
 }
 
 template <class T>

--- a/test/test_hypergeometric_dist.cpp
+++ b/test/test_hypergeometric_dist.cpp
@@ -470,8 +470,8 @@ void test_spots(RealType /*T*/, const char* type_name)
    test_spot(40, 70, 89, 170, static_cast<T>(0.0721901023798991), static_cast<T>(0.885447799131944), static_cast<T>(1 - 0.885447799131944), tolerance);
 
    boost::math::hypergeometric_distribution<RealType> d(50, 200, 500);
-   BOOST_CHECK_EQUAL(range(d).first, 0u);
-   BOOST_CHECK_EQUAL(range(d).second, 50u);
+   BOOST_CHECK_EQUAL(range(d).first, UINT64_C(0));
+   BOOST_CHECK_EQUAL(range(d).second, UINT64_C(50));
    BOOST_CHECK_CLOSE(mean(d), static_cast<RealType>(20), tolerance);
    BOOST_CHECK_CLOSE(mode(d), static_cast<RealType>(20), tolerance);
    // Test values and code revised to correct kurtosis using Mathematica algorithm and test values.


### PR DESCRIPTION
All of the member variables of the hyper geometric distribution were of type `unsigned` leading to overflow when `n*N` exceeded `UINT_MAX`. Replace them with `std::uint64_t`. Similar to https://github.com/boostorg/math/pull/939

x-ref: https://github.com/scipy/scipy/issues/18506 and https://github.com/scipy/scipy/issues/18511