### PR TITLE
Allow use of ibm128 long doubles

### DIFF
--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -205,7 +205,7 @@
 //
 #  define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
 #endif
-#if !defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS) && (LDBL_MANT_DIG == 106) && (LDBL_MIN_EXP > DBL_MIN_EXP)
+#if !defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS) && (LDBL_MANT_DIG == 106) && (LDBL_MIN_EXP > DBL_MIN_EXP) && !(defined(__powerpc__) && defined(__LONG_DOUBLE_IBM128__))
 //
 // Generic catch all case for gcc's "double-double" long double type.
 // We do not support this as it's not even remotely IEEE conforming:


### PR DESCRIPTION
PPC64LE currently defaults to the ibm128 long double type instead of float128. It is not IEEE754 compliant because it pre-dates the addition of binary128, but it should have adequate precision to promote from a double.

See [here](https://reviews.llvm.org/D137513) for macro definitions.

Closes #988 

@jzmaddock since `LDBL_MANT_DIG` of ibm128 is 106 did you previously hit issues with it? I see a bunch of old comments, but nothing about the powerPC architectures.