### PR TITLE
Use Dijkstra identities for 0(0th) Fibonacci convention

### DIFF
--- a/include/boost/math/special_functions/fibonacci.hpp
+++ b/include/boost/math/special_functions/fibonacci.hpp
@@ -32,8 +32,8 @@ inline BOOST_CXX14_CONSTEXPR T unchecked_fibonacci(unsigned long long n) noexcep
     if (n <= 2) return n == 0 ? 0 : 1;
     /* 
      * This is based on the following identities by Dijkstra:
-     *   F(2*n)   = F(n)^2 + F(n+1)^2
-     *   F(2*n+1) = (2 * F(n) + F(n+1)) * F(n+1)
+     *   F(2*n-1) = F(n-1)^2 + F(n)^2
+     *   F(2*n)   = (2*F(n-1) + F(n)) * F(n)
      * The implementation is iterative and is unrolled version of trivial recursive implementation.
      */
     unsigned long long mask = 1;


### PR DESCRIPTION
Dijkstra's note "In honour of Fibonacci" provides identities for the convention where 0 is the 1st Fibonacci number. Boost Math uses the convention that 0 is the 0th Fibonacci number. This PR updates these identities to follow the 0 is the 0th convention.