### PR TITLE
Update kolmogorov quantile newton ub to 1

### DIFF
--- a/include/boost/math/distributions/kolmogorov_smirnov.hpp
+++ b/include/boost/math/distributions/kolmogorov_smirnov.hpp
@@ -382,7 +382,7 @@ inline RealType quantile(const kolmogorov_smirnov_distribution<RealType, Policy>
    std::uintmax_t m = policies::get_max_root_iterations<Policy>(); // and max iterations.
 
    return tools::newton_raphson_iterate(detail::kolmogorov_smirnov_quantile_functor<RealType, Policy>(dist, p),
-           k, RealType(0), boost::math::tools::max_value<RealType>(), get_digits, m);
+           k, RealType(0), RealType(1), get_digits, m);
 } // quantile
 
 template <class RealType, class Policy>
@@ -407,7 +407,7 @@ inline RealType quantile(const complemented2_type<kolmogorov_smirnov_distributio
 
    return tools::newton_raphson_iterate(
            detail::kolmogorov_smirnov_complementary_quantile_functor<RealType, Policy>(dist, p),
-           k, RealType(0), boost::math::tools::max_value<RealType>(), get_digits, m);
+           k, RealType(0), RealType(1), get_digits, m);
 } // quantile (complemented)
 
 template <class RealType, class Policy>

--- a/include/boost/math/distributions/skew_normal.hpp
+++ b/include/boost/math/distributions/skew_normal.hpp
@@ -676,8 +676,8 @@ namespace boost{ namespace math{
 
     // refine the result by numerically searching the root of (p-cdf)
 
-    const RealType search_min = range(dist).first;
-    const RealType search_max = range(dist).second;
+    const RealType search_min = support(dist).first;
+    const RealType search_max = support(dist).second;
 
     const int get_digits = policies::digits<RealType, Policy>();// get digits from policy,
     std::uintmax_t m = policies::get_max_root_iterations<Policy>(); // and max iterations.

--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -275,14 +275,7 @@ T newton_raphson_iterate(F f, T guess, T min, T max, int digits, std::uintmax_t&
       if (fabs(delta * 2) > fabs(delta2))
       {
          // Last two steps haven't converged.
-         T shift = (delta > 0) ? (result - min) / 2 : (result - max) / 2;
-         if ((result != 0) && (fabs(shift) > fabs(result)))
-         {
-            delta = sign(delta) * fabs(result) * 1.1f; // Protect against huge jumps!
-            //delta = sign(delta) * result; // Protect against huge jumps! Failed for negative result. https://github.com/boostorg/math/issues/216
-         }
-         else
-            delta = shift;
+         delta = (delta > 0) ? (result - min) / 2 : (result - max) / 2;
          // reset delta1/2 so we don't take this branch next time round:
          delta1 = 3 * delta;
          delta2 = 3 * delta;

--- a/test/test_roots.cpp
+++ b/test/test_roots.cpp
@@ -654,6 +654,10 @@ BOOST_AUTO_TEST_CASE( test_main )
 
    test_beta(0.1, "double");
 
+   // bug reports:
+   boost::math::skew_normal_distribution<> dist(2.0, 1.0, -2.5);
+   BOOST_CHECK(boost::math::isfinite(quantile(dist, 0.075)));
+
 #if !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX) && !defined(BOOST_NO_CXX11_LAMBDAS)
    test_complex_newton<std::complex<float>>();
    test_complex_newton<std::complex<double>>();


### PR DESCRIPTION
This is chunk 1 for #1000

**Change search bound:**
This PR changes the kolmogorov_smirnov quantile search upper bound from `max_value<RealType>()` to `RealType(1)`. Quantiles appear to be defined on [0,1].

**Simplify Newton Solver**
The Newton solver previously had to evaluate the kolmogorov functor at `max_value<RealType>() / 2` during bisection, which would cause the program to hang. Newton bisection logic added to prevent this evaluation from happening. With the quantile upper bound changed to 1, this logic is no longer required.