### PR TITLE
update beta error messages and checks

### DIFF
--- a/include/boost/math/special_functions/beta.hpp
+++ b/include/boost/math/special_functions/beta.hpp
@@ -1021,17 +1021,14 @@ T ibeta_imp(T a, T b, T x, const Policy& pol, bool inv, bool normalised, T* p_de
    BOOST_MATH_ASSERT((p_derivative == 0) || normalised);
 
    if(!(boost::math::isfinite)(a))
-      return policies::raise_domain_error<T>(function, "The argument a to the incomplete beta function must be >= zero (got a=%1%).", a, pol);
+      return policies::raise_domain_error<T>(function, "The argument a to the incomplete beta function must be finite (got a=%1%).", a, pol);
    if(!(boost::math::isfinite)(b))
-      return policies::raise_domain_error<T>(function, "The argument b to the incomplete beta function must be >= zero (got b=%1%).", b, pol);
-   if(!(boost::math::isfinite)(x))
+      return policies::raise_domain_error<T>(function, "The argument b to the incomplete beta function must be finite (got b=%1%).", b, pol);
+   if (!(0 <= x && x <= 1))
       return policies::raise_domain_error<T>(function, "The argument x to the incomplete beta function must be in [0,1] (got x=%1%).", x, pol);
 
    if(p_derivative)
       *p_derivative = -1; // value not set.
-
-   if((x < 0) || (x > 1))
-      return policies::raise_domain_error<T>(function, "Parameter x outside the range [0,1] in the incomplete beta function (got x=%1%).", x, pol);
 
    if(normalised)
    {
@@ -1422,18 +1419,16 @@ T ibeta_derivative_imp(T a, T b, T x, const Policy& pol)
    // start with the usual error checks:
    //
    if (!(boost::math::isfinite)(a))
-      return policies::raise_domain_error<T>(function, "The argument a to the incomplete beta function must be >= zero (got a=%1%).", a, pol);
+      return policies::raise_domain_error<T>(function, "The argument a to the incomplete beta function must be finite (got a=%1%).", a, pol);
    if (!(boost::math::isfinite)(b))
-      return policies::raise_domain_error<T>(function, "The argument b to the incomplete beta function must be >= zero (got b=%1%).", b, pol);
-   if (!(boost::math::isfinite)(x))
+      return policies::raise_domain_error<T>(function, "The argument b to the incomplete beta function must be finite (got b=%1%).", b, pol);
+   if (!(0 <= x && x <= 1))
       return policies::raise_domain_error<T>(function, "The argument x to the incomplete beta function must be in [0,1] (got x=%1%).", x, pol);
 
    if(a <= 0)
       return policies::raise_domain_error<T>(function, "The argument a to the incomplete beta function must be greater than zero (got a=%1%).", a, pol);
    if(b <= 0)
       return policies::raise_domain_error<T>(function, "The argument b to the incomplete beta function must be greater than zero (got b=%1%).", b, pol);
-   if((x < 0) || (x > 1))
-      return policies::raise_domain_error<T>(function, "Parameter x outside the range [0,1] in the incomplete beta function (got x=%1%).", x, pol);
    //
    // Now the corner cases:
    //


### PR DESCRIPTION
This is chunk 2 for #1000.

**Runtime errors**
One approach to run-time errors takes the form:
```
if(!(boost::math::isfinite)(a))
   return policies::raise_domain_error<T>(function, "a is bad because reason (got a=%1%).", a, pol);
```
When using this approach, it's understood that the error message should agree with the check that is actually being performed.

**This PR**
This PR fixes 6 places where the check and stated error message lacked agreement in the `beta.hpp` file. These incorrect error messages make debugging the Newton solver take longer than it would have otherwise.

**Ideas about future solutions**
Disagreement between the check and the error message are too easy to make. I think a better solution on a high level would to be able to use the BOOST_TEST types macros for run-time checks. I don't know if this kind of thing is possible. But either way, that's out of the scope of this PR.