### PR TITLE
Fix assertions and fenv errors in beta distribution

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -902,6 +902,7 @@ test-suite distribution_tests :
    [ run scipy_issue_17916_nct.cpp ../../test/build//boost_unit_test_framework  ]
    [ run scipy_issue_18302.cpp ../../test/build//boost_unit_test_framework  ]
    [ run scipy_issue_18511.cpp ../../test/build//boost_unit_test_framework ]
+   [ run git_issue_1006.cpp ../../test/build//boost_unit_test_framework ]
 ;
 
 test-suite new_floats : 

--- a/test/git_issue_1006.cpp
+++ b/test/git_issue_1006.cpp
@@ -1,0 +1,65 @@
+//  (C) Copyright Matt Borland 2023.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "math_unit_test.hpp"
+#include <cfenv>
+#include <iostream>
+#include <boost/math/distributions/beta.hpp>
+
+#pragma STDC FENV_ACCESS ON
+
+// Show and then clear the fenv flags
+void show_fpexcept_flags()
+{
+    bool fe = false;
+    
+    if (std::fetestexcept(FE_OVERFLOW))
+    {
+        fe = true;
+        std::cerr << "FE_OVERFLOW" << std::endl;
+    }
+    if (std::fetestexcept(FE_UNDERFLOW))
+    {
+        fe = true;
+        std::cerr << "FE_UNDERFLOW" << std::endl;
+    }
+    if (std::fetestexcept(FE_DIVBYZERO))
+    {
+        fe = true;
+        std::cerr << "FE_DIVBYZERO" << std::endl;
+    }
+    if (std::fetestexcept(FE_INVALID))
+    {
+        fe = true;
+        std::cerr << "FE_INVALID" << std::endl;
+    }
+
+    CHECK_EQUAL(fe, false);
+
+    std::feclearexcept(FE_ALL_EXCEPT);
+}
+
+int main()
+{
+    // Default Scipy policy
+    using my_policy = boost::math::policies::policy<boost::math::policies::promote_float<false>, boost::math::policies::default_policy, boost::math::policies::default_policy, boost::math::policies::default_policy, boost::math::policies::default_policy, boost::math::policies::default_policy, boost::math::policies::default_policy, boost::math::policies::default_policy, boost::math::policies::default_policy, boost::math::policies::default_policy, boost::math::policies::default_policy>;
+    
+    const auto dist_a = boost::math::beta_distribution<double, my_policy>(1e-308, 5.0);
+    const auto dist_a_ppf = boost::math::quantile(dist_a, 0.2);
+    show_fpexcept_flags();
+    CHECK_MOLLIFIED_CLOSE(dist_a_ppf, 0.0, 1e-10);
+
+    const auto dist_b = boost::math::beta_distribution<double, my_policy>(1e-309, 5.0);
+    const auto dist_b_ppf = boost::math::quantile(dist_b, 0.2);
+    show_fpexcept_flags();
+    CHECK_MOLLIFIED_CLOSE(dist_b_ppf, 0.0, 1e-10);
+
+    const auto dist_c = boost::math::beta_distribution<double, my_policy>(1e-323, 5.0);
+    const auto dist_c_ppf = boost::math::quantile(dist_c, 0.2);
+    show_fpexcept_flags();
+    CHECK_MOLLIFIED_CLOSE(dist_c_ppf, 0.0, 1e-10);
+
+    return boost::math::test::report_errors();
+}

--- a/test/git_issue_1006.py
+++ b/test/git_issue_1006.py
@@ -1,0 +1,10 @@
+import scipy.stats
+print([shape_param.domain for shape_param in scipy.stats.beta._shape_info()])
+# [[5e-324, inf], [5e-324, inf]]
+print(scipy.stats.beta(a=1e-308, b=5).ppf(.2))
+# 0.0
+#print(scipy.stats.beta(a=1e-309, b=5).ppf(.2))
+# OverflowError: Error in function boost::math::tgamma<d>(d): Overflow Error
+# (raises error, but kernel doesn't crash)
+print(scipy.stats.beta(a=1e-323, b=5).ppf(.2))
+# KERNEL CRASHES with message: `Assertion failed: *p_derivative >= 0, file ..\..\scipy\_lib\boost/boost/math/special_functions/beta.hpp, line 739`


### PR DESCRIPTION
I was able to reproduce the error in python using the script from #1006. The assertion was not triggered using the same template parameters in C++, but the fenv flags are being set. Below is the diagnostic data from `BOOST_MATH_INSTRUMENT`

```
====== BEGIN OUTPUT ======
lgamma_imp called with e N5boost4math7lanczos12lanczos17m64E
../../../boost/math/special_functions/erf.hpp:1226 result_type = e
../../../boost/math/special_functions/erf.hpp:1227 value_type = e
../../../boost/math/special_functions/erf.hpp:1228 precision_type = N5boost4math8policies7digits2ILi64EEE
../../../boost/math/special_functions/erf.hpp:1237 tag_type = St17integral_constantIiLi64EE
../../../boost/math/special_functions/erf.hpp:427 64-bit precision erf_imp called
../../../boost/math/special_functions/erf.hpp:1191 result_type = e
../../../boost/math/special_functions/erf.hpp:1192 value_type = e
../../../boost/math/special_functions/erf.hpp:1193 precision_type = N5boost4math8policies7digits2ILi64EEE
../../../boost/math/special_functions/erf.hpp:1202 tag_type = St17integral_constantIiLi64EE
../../../boost/math/special_functions/erf.hpp:427 64-bit precision erf_imp called
../../../boost/math/special_functions/erf.hpp:1191 result_type = e
../../../boost/math/special_functions/erf.hpp:1192 value_type = e
../../../boost/math/special_functions/erf.hpp:1193 precision_type = N5boost4math8policies7digits2ILi64EEE
../../../boost/math/special_functions/erf.hpp:1202 tag_type = St17integral_constantIiLi64EE
../../../boost/math/special_functions/erf.hpp:427 64-bit precision erf_imp called
../../../boost/math/special_functions/erf.hpp:1191 result_type = e
../../../boost/math/special_functions/erf.hpp:1192 value_type = e
../../../boost/math/special_functions/erf.hpp:1193 precision_type = N5boost4math8policies7digits2ILi64EEE
../../../boost/math/special_functions/erf.hpp:1202 tag_type = St17integral_constantIiLi64EE
../../../boost/math/special_functions/erf.hpp:427 64-bit precision erf_imp called
../../../boost/math/special_functions/erf.hpp:1191 result_type = e
../../../boost/math/special_functions/erf.hpp:1192 value_type = e
../../../boost/math/special_functions/erf.hpp:1193 precision_type = N5boost4math8policies7digits2ILi64EEE
../../../boost/math/special_functions/erf.hpp:1202 tag_type = St17integral_constantIiLi64EE
../../../boost/math/special_functions/erf.hpp:427 64-bit precision erf_imp called
../../../boost/math/special_functions/erf.hpp:1191 result_type = e
../../../boost/math/special_functions/erf.hpp:1192 value_type = e
../../../boost/math/special_functions/erf.hpp:1193 precision_type = N5boost4math8policies7digits2ILi64EEE
../../../boost/math/special_functions/erf.hpp:1202 tag_type = St17integral_constantIiLi64EE
../../../boost/math/special_functions/erf.hpp:427 64-bit precision erf_imp called
../../../boost/math/special_functions/erf.hpp:1191 result_type = e
../../../boost/math/special_functions/erf.hpp:1192 value_type = e
../../../boost/math/special_functions/erf.hpp:1193 precision_type = N5boost4math8policies7digits2ILi64EEE
../../../boost/math/special_functions/erf.hpp:1202 tag_type = St17integral_constantIiLi64EE
../../../boost/math/special_functions/erf.hpp:427 64-bit precision erf_imp called
Second order root iteration, guess = 3.3621031431120935062626778173217526e-4932, min = 3.3621031431120935062626778173217526e-4932, max = 1, digits = 48, max_iter = 200
Second order root iteration, limit = 7.10542735760100185871124267578125e-15
../../../boost/math/special_functions/beta.hpp:1011 a = 9.99999999999999909326625337248462e-309
../../../boost/math/special_functions/beta.hpp:1012 b = 5
../../../boost/math/special_functions/beta.hpp:1013 x = 3.3621031431120935062626778173217526e-4932
../../../boost/math/special_functions/beta.hpp:1014 inv = 0
../../../boost/math/special_functions/beta.hpp:1015 normalised = 1
../../../boost/math/special_functions/beta.hpp:745 k = 20
../../../boost/math/special_functions/beta.hpp:264 result = 9.99999999999999909326625337248462e-309
../../../boost/math/special_functions/beta.hpp:279 result = 9.99999999999999909326625337248462e-309
../../../boost/math/special_functions/beta.hpp:417 result = 9.99999999999999909326625337248462e-309
../../../boost/math/special_functions/beta.hpp:1263 fract = 1.6926248444201733823383717339722608e-308
tgamma_imp called with e N5boost4math7lanczos12lanczos17m64E
../../../boost/math/special_functions/gamma.hpp:153 result = 1
../../../boost/math/special_functions/gamma.hpp:758 -5.7721566490153280829063366506040647e-309
../../../boost/math/special_functions/beta.hpp:1274 fract = 1
../../../boost/math/tools/roots.hpp:554 f0 = 0.7999999999999999888977697537484346
../../../boost/math/tools/roots.hpp:555 f1 = 2.9743287383930791430219742500652233e+4623
../../../boost/math/tools/roots.hpp:556 f2 = 2.9743287383930791430219742500652233e+4623
../../../boost/math/tools/roots.hpp:347 denom = 1.5999999999999999777955395074968692
../../../boost/math/tools/roots.hpp:348 num = 5.9486574767861582860439485001304467e+4623
Second order root iteration, delta = 2.6896825144896750115355219142178362e-4624, residual = 0.7999999999999999888977697537484346
../../../boost/math/tools/roots.hpp:617 result = -2.6896825144896750115355219142178362e-4624
Second order root finder required 2 iterations.
FE_UNDERFLOW
Error at git_issue_1006.cpp:show_fpexcept_flags:39
  Condition '1 == 0' is not satisfied:
  Expected: 1 = 0x1
  Computed: 0 = 0x0
Second order root iteration, guess = 3.3621031431120935062626778173217526e-4932, min = 3.3621031431120935062626778173217526e-4932, max = 1, digits = 48, max_iter = 200
Second order root iteration, limit = 7.10542735760100185871124267578125e-15
../../../boost/math/special_functions/beta.hpp:1011 a = 1.0000000000000018855892087022346387e-309
../../../boost/math/special_functions/beta.hpp:1012 b = 5
../../../boost/math/special_functions/beta.hpp:1013 x = 3.3621031431120935062626778173217526e-4932
../../../boost/math/special_functions/beta.hpp:1014 inv = 0
../../../boost/math/special_functions/beta.hpp:1015 normalised = 1
../../../boost/math/special_functions/beta.hpp:745 k = 20
../../../boost/math/special_functions/beta.hpp:264 result = 1.0000000000000018855892087022346387e-309
../../../boost/math/special_functions/beta.hpp:279 result = 1.0000000000000018855892087022346387e-309
../../../boost/math/special_functions/beta.hpp:417 result = 1.0000000000000018855892087022346387e-309
../../../boost/math/special_functions/beta.hpp:1263 fract = 1.6926248444201767274739975377734781e-309
../../../boost/math/special_functions/gamma.hpp:153 result = 1
../../../boost/math/special_functions/gamma.hpp:758 -5.7721566490153394900057839596946173e-310
../../../boost/math/special_functions/beta.hpp:1274 fract = 1
../../../boost/math/tools/roots.hpp:554 f0 = 0.7999999999999999888977697537484346
../../../boost/math/tools/roots.hpp:555 f1 = 2.9743287383930850210765705634924873e+4622
../../../boost/math/tools/roots.hpp:556 f2 = 2.9743287383930850210765705634924873e+4622
../../../boost/math/tools/roots.hpp:347 denom = 1.5999999999999999777955395074968692
../../../boost/math/tools/roots.hpp:348 num = 5.9486574767861700421531411269849746e+4622
Second order root iteration, delta = 2.6896825144896696959789295395794399e-4623, residual = 0.7999999999999999888977697537484346
../../../boost/math/tools/roots.hpp:617 result = -2.6896825144896696959789295395794399e-4623
Second order root finder required 2 iterations.
FE_UNDERFLOW
Error at git_issue_1006.cpp:show_fpexcept_flags:39
  Condition '1 == 0' is not satisfied:
  Expected: 1 = 0x1
  Computed: 0 = 0x0
Second order root iteration, guess = 3.3621031431120935062626778173217526e-4932, min = 3.3621031431120935062626778173217526e-4932, max = 1, digits = 48, max_iter = 200
Second order root iteration, limit = 7.10542735760100185871124267578125e-15
../../../boost/math/special_functions/beta.hpp:1011 a = 9.8813129168249308835313758573644274e-324
../../../boost/math/special_functions/beta.hpp:1012 b = 5
../../../boost/math/special_functions/beta.hpp:1013 x = 3.3621031431120935062626778173217526e-4932
../../../boost/math/special_functions/beta.hpp:1014 inv = 0
../../../boost/math/special_functions/beta.hpp:1015 normalised = 1
../../../boost/math/special_functions/beta.hpp:745 k = 20
../../../boost/math/special_functions/beta.hpp:264 result = 9.8813129168249308824600417642213608e-324
../../../boost/math/special_functions/beta.hpp:279 result = 9.8813129168249308824600417642213608e-324
../../../boost/math/special_functions/beta.hpp:417 result = 9.8813129168249308824600417642213608e-324
../../../boost/math/special_functions/beta.hpp:1263 fract = 1.6725355738507849797162009039207305e-323
../../../boost/math/special_functions/gamma.hpp:153 result = 1
../../../boost/math/special_functions/gamma.hpp:758 -5.703648605385207552241717693489347e-324
../../../boost/math/special_functions/beta.hpp:1274 fract = 1
../../../boost/math/tools/roots.hpp:554 f0 = 0.7999999999999999888977697537484346
../../../boost/math/tools/roots.hpp:555 f1 = 2.9390272981567136316757344407503151e+4608
../../../boost/math/tools/roots.hpp:556 f2 = 2.9390272981567136316757344407503151e+4608
../../../boost/math/tools/roots.hpp:347 denom = 1.5999999999999999777955395074968692
../../../boost/math/tools/roots.hpp:348 num = 5.8780545963134272633514688815006302e+4608
Second order root iteration, delta = 2.721989008069916574949237277740126e-4609, residual = 0.7999999999999999888977697537484346
../../../boost/math/tools/roots.hpp:617 result = -2.721989008069916574949237277740126e-4609
Second order root finder required 2 iterations.
FE_UNDERFLOW
Error at git_issue_1006.cpp:show_fpexcept_flags:39
  Condition '1 == 0' is not satisfied:
  Expected: 1 = 0x1
  Computed: 0 = 0x0
Error count: 3

EXIT STATUS: 1
====== END OUTPUT ======
```
```