### PR TITLE
More efficient bisection for 1D Newton root finder

### DIFF
--- a/include/boost/math/tools/ieee754_linear.hpp
+++ b/include/boost/math/tools/ieee754_linear.hpp
@@ -1,0 +1,366 @@
+#ifndef BOOST_MATH_TOOLS_IEEE754_BITSPACE_HPP
+#define BOOST_MATH_TOOLS_IEEE754_BITSPACE_HPP
+
+#ifdef _MSC_VER
+#pragma once
+#endif
+
+#include <type_traits>
+
+
+#ifdef BOOST_HAS_FLOAT128
+#include <boost/multiprecision/float128.hpp>
+#endif
+
+
+namespace boost {
+namespace math {
+namespace tools {
+namespace detail {
+namespace ieee754_linear {
+
+   // The `IsFloat32` class contains a static constexpr method `value()` that
+   // returns true if the type T is a 32 bit floating point type. This duck type
+   // test for 32 bit float types returns true for the following types:
+   //   - `float`
+   //   - `_Float32` (NOTE: not a type alias for `float`)
+   //   - `std_real_concept` when emulating a 32 bit float with EMULATE32
+   //   - other types that seem to be 32 bit floats
+   class IsFloat32 {
+   public:
+      template <typename T>
+      static constexpr bool value() {
+         return std::numeric_limits<T>::is_iec559 &&
+                std::numeric_limits<T>::radix == 2 &&
+                std::numeric_limits<T>::digits == 24 &&  // Mantissa has 23 bits + 1 implicit bit
+                sizeof(T) == 4;
+      }
+   };
+
+   // The `IsFloat64` class contains a static constexpr method `value()` that
+   // returns true if the type T is a 64 bit floating point type. This duck type
+   // test for 64 bit float types returns true for the following types:
+   //   - `double`
+   //   - `_Float64` (NOTE: not a type alias for `double`)
+   //   - `std_real_concept` when emulating a 64 bit float with EMULATE64
+   //   - other types that seem to be 64 bit floats
+   class IsFloat64 {
+   public:
+      template <typename T>
+      static constexpr bool value() {
+         return std::numeric_limits<T>::is_iec559 &&
+                std::numeric_limits<T>::radix == 2 &&
+                std::numeric_limits<T>::digits == 53 &&  // Mantissa has 52 bits + 1 implicit bit
+                sizeof(T) == 8;
+      }
+   };
+
+   // The `IsFloat128` class contains a static constexpr method `value()` that
+   // returns true if the type T is a 128 bit floating point type. This duck type
+   // test for 128 bit float types returns true for the following types:
+   //   - `__float128`
+   //   - `_Float128` (NOTE: not a type alias for `__float128`)
+   //   - `std_real_concept` when emulating a 128 bit float with EMULATE128
+   //   - other types that seem to be 128 bit floats
+   class IsFloat128 {
+   public:
+      template <typename T>
+      static constexpr bool value() {
+         return std::numeric_limits<T>::is_iec559 &&
+                std::numeric_limits<T>::radix == 2 &&
+                std::numeric_limits<T>::digits == 113 &&  // Mantissa has 112 bits + 1 implicit bit
+                sizeof(T) == 16;
+      }
+   };
+
+   // The `Layout_IEEE754Linear` class represents IEEE 754 floating point types
+   // for which increasing float values (with the same sign) have increasing 
+   // values in bit space. And for which there is a corresponding unsigned integer
+   // type U that has the same number of bits as T. Types that satisfy these
+   //  conditions include 32, 64, and 128 bit floats. The table below shows select
+   // numbers for `float` (single precision).
+   //
+   //   0            |  0 00000000 00000000000000000000000  |  positive zero
+   //   1.4013e-45   |  0 00000000 00000000000000000000001  |  std::numeric_limits<float>::denorm_min()
+   //   1.17549e-38  |  0 00000001 00000000000000000000000  |  std::numeric_limits<float>::min()
+   //   1.19209e-07  |  0 01101000 00000000000000000000000  |  std::numeric_limits<float>::epsilon()
+   //   1            |  0 01111111 00000000000000000000000  |  positive one
+   //   3.40282e+38  |  0 11111110 11111111111111111111111  |  std::numeric_limits<float>::max()
+   //   inf          |  0 11111111 00000000000000000000000  |  std::numeric_limits<float>::infinity()
+   //   nan          |  0 11111111 10000000000000000000000  |  std::numeric_limits<float>::quiet_NaN() 
+   //
+   // NOTE: the 80 bit `long double` is not "linear" due to the "integer part". See:
+   //       https://en.wikipedia.org/wiki/Extended_precision#x86_extended_precision_format
+   //
+   template <typename T, typename U>
+   class Layout_IEEE754Linear {
+      static_assert(std::numeric_limits<T>::is_iec559, "Type must be IEEE 754 floating point.");
+      static_assert(std::is_unsigned<U>::value, "U must be an unsigned integer type.");
+      static_assert(sizeof(T) == sizeof(U), "Type and uint size must be the same.");
+
+   public:
+      using type_float = T;  // The linear floating point type
+   };
+
+   // The `Layout_Unspecified` class represents floating point types for which
+   // are not supported by the `Layout_IEEE754Linear` class.
+   template <typename T>
+   class Layout_Unspecified {
+   public:
+      using type_float = T;  // The linear floating point type
+   };
+
+   // The `LayoutIdentifier` class identifies the layout type for a floating
+   // point type T. The layout type is one of the following:
+   //   - `Layout_IEEE754Linear<T, U>` for 32, 64, and 128 bit floats
+   //   - `Layout_Unspecified<T>` for other types
+   class LayoutIdentifier {
+   public:
+      // Layout: 32 bit linear
+      template <typename T>
+      static typename std::enable_if<IsFloat32::value<T>(), Layout_IEEE754Linear<T, std::uint32_t>>::type
+      get_layout() { return Layout_IEEE754Linear<T, std::uint32_t>(); }
+
+      // Layout: 64 bit linear
+      template <typename T>
+      static typename std::enable_if<IsFloat64::value<T>(), Layout_IEEE754Linear<T, std::uint64_t>>::type
+      get_layout() { return Layout_IEEE754Linear<T, std::uint64_t>(); }
+
+      // Layout: 128 bit linear
+#if defined(BOOST_HAS_INT128) && defined(BOOST_HAS_FLOAT128)
+      // NOTE: returns Layout_IEEE754Linear<__float128, ...> instead of Layout_IEEE754Linear<T, ...>
+      //       in order to work with boost::multiprecision::float128, which is a wrapper
+      //       around __float128.
+      template <typename T>
+      static typename std::enable_if<IsFloat128::value<T>(), Layout_IEEE754Linear<__float128, boost::uint128_type>>::type
+      get_layout() { return Layout_IEEE754Linear<__float128, boost::uint128_type>(); }
+
+      template <typename T>
+      static constexpr bool is_layout_nonlinear() {
+         return !IsFloat32::value<T>() &&
+                !IsFloat64::value<T>() &&
+                !IsFloat128::value<T>();
+      }
+#else
+      template <typename T>
+      static constexpr bool is_layout_nonlinear() {
+         return !IsFloat32::value<T>() &&
+                !IsFloat64::value<T>();
+      }
+#endif
+
+      // Layout: unspecified
+      template <typename T>
+      static typename std::enable_if<is_layout_nonlinear<T>(), Layout_Unspecified<T>>::type
+      get_layout() { return Layout_Unspecified<T>(); }
+   };
+
+   // Base class for the `BitsInflated` and `BitsDeflated` classes.
+   //
+   // This class stores the bit values of a floating point type `T` as a
+   // sign bit as a unsigned integer magnitude. For example, a floating
+   // point type with 50 discrete values (zero is counted twice) between
+   // -Inf and +Inf is shown below.
+   //
+   //    -24 -20 -16 -12 -8  -4   0   4   8   12  16  20  24
+   //     .   .   .   .   .   .   .   .   .   .   .   .   .
+   //     |-----------------------|-----------------------|
+   //   -Inf                      0                     +Inf
+   //
+   template <typename T, typename U>
+   class BitsFromZero: public Layout_IEEE754Linear<T, U> {
+   public:
+      bool sign_bit() const { return sign_bit_; }
+      const U& mag() const { return mag_; }
+      U& mag() { return mag_; }
+
+   protected:
+      BitsFromZero(const bool sign, const U mag) : sign_bit_(sign), mag_(mag) {}
+
+      BitsFromZero(const T x) { 
+         // The sign bit is 1, all other bits are 0
+         constexpr U bits_sign_mask = U(1) << (sizeof(U) * 8 - 1);
+
+         U bits_;
+         std::memcpy(&bits_, &x, sizeof(U));
+         sign_bit_ = bits_ & bits_sign_mask;
+         mag_ = bits_ & ~bits_sign_mask;
+      }
+
+      void flip_sign_bit() { sign_bit_ = !sign_bit_; }
+
+   private:
+      bool sign_bit_;
+      U mag_;
+   };
+
+   // The inflated bitspace representation of a floating point type `T`.
+   //
+   // This representation always includes denormal numbers, even if denorm
+   // support is turned off. For example, a floating point type with 50
+   // discrete values (zero is counted twice) between -Inf and +Inf is shown
+   // below with *** marking denormal numbers.
+   //
+   //    -24 -20 -16 -12 -8  -4   0   4   8   12  16  20  24
+   //     .   .   .   .   .   .   .   .   .   .   .   .   .
+   //     |-------------------|***|***|-------------------|
+   //   -Inf                      0                     +Inf
+   //
+   template <typename T, typename U>
+   class BitsInflated : public BitsFromZero<T, U> {
+   public:
+      BitsInflated(const T x) : BitsFromZero<T, U>(x) {}
+      BitsInflated(const bool sign, const U mag) : BitsFromZero<T, U>(sign, mag) {}
+      
+      T reinterpret_as_float() const {
+         T f_out;
+         std::memcpy(&f_out, &this->mag(), sizeof(T));
+         return this->sign_bit() ? -f_out : f_out;
+      }
+
+      void divide_by_2() { this->mag() >>= 1; }
+   };
+
+   // The deflated bitspace representation of a floating point type `T`. 
+   //
+   // Denorm Support ON:
+   //   This representation is identical to the inflated representation.
+   //
+   // Denorm Support OFF:
+   //    This representation shifts the bitspace representation toward `0`
+   //    to remove gaps in the bitspace caused by denormal numbers. For 
+   //    example, consider a floating point type with 50 discrete values
+   //    (zero is counted twice) between -Inf and +Inf is shown below with
+   //    *** marking denormal numbers shown below.
+   // 
+   //                  Inflated representation:
+   //    -24 -20 -16 -12 -8  -4   0   4   8   12  16  20  24
+   //     .   .   .   .   .   .   .   .   .   .   .   .   .
+   //     |-------------------|***|***|-------------------|
+   //   -Inf                      0                     +Inf
+   // _________________________________________________________________
+   //
+   //                  Deflated representation:
+   //    -24 -20 -16 -12 -8  -4   0   4   8   12  16  20  24
+   //     .   .   .   .   .   .   .   .   .   .   .   .   .
+   //        |-------------------|||-------------------|
+   //      -Inf                   0                  +Inf
+   //
+   template <typename T, typename U>
+   class BitsDeflated : public BitsFromZero<T, U> {
+   public:
+      BitsDeflated(const bool sign, const U mag) : BitsFromZero<T, U>(sign, mag) {}
+
+      T static_cast_int_value_to_float() const {
+         T mag_float = static_cast<T>(this->mag());
+         return this->sign_bit() ? -mag_float : mag_float;
+      }
+
+      // Move over `n` in bitspace
+      BitsDeflated<T,U> operator+(int n) const {
+         return BitsDeflated<T,U>(this->sign_bit(), this->mag() + n);
+      }
+
+      BitsDeflated<T,U> operator-(const BitsDeflated<T,U>& y) const {
+         auto y_copy = y;
+         y_copy.flip_sign_bit();
+         return *this + y_copy;
+      }
+
+      BitsDeflated<T,U> operator+(const BitsDeflated<T,U>& y) const {
+         // Gaurantee that y has the larger magnitude
+         if (y.mag() < this->mag()) { return y + *this; }
+
+         // Call *this x
+         const BitsDeflated<T, U>& x = *this;
+
+         const U mag_x = x.mag();
+         const U mag_y = y.mag();
+
+         // Calculate the deflated sum in bits (always positive)
+         U bits_sum = (x.sign_bit() == y.sign_bit()) ? (mag_y + mag_x) 
+                                                     : (mag_y - mag_x);
+
+         // Sum always has the sign of the bigger magnitude (y)
+         return BitsDeflated<T,U>(y.sign_bit(), bits_sum);
+      }
+
+      BitsDeflated<T,U>& operator>>(const int n) {
+         this->mag() >>= n;
+         return *this;
+      }
+   };
+
+   // The `Denormflator` converts between inflated and deflated bitspace representations
+   // to compensate for gaps in the bitspace caused by denormal numbers. The `deflate`
+   // operation shifts the bitspace representation toward `0`. The `inflate` operation
+   // shifts the bitspace representation away from `0`. These operations only have 
+   // an effect if denorm support is turned off. If denorm support is turned on, then
+   // the shift is zero. The effect of these operations is illustrated in various
+   // cartoons below.
+   //
+   template <typename T, typename U>
+   class Denormflator : public Layout_IEEE754Linear<T, U> {
+   public:
+      Denormflator() : has_denorm_(calc_has_denorm()) {}
+
+      BitsDeflated<T, U> deflate(const BitsInflated<T, U>& bit_view) const {
+         const U penalty = bits_denorm_shift();
+         const U mag_un = bit_view.mag();
+         const U mag_sh = (has_denorm_ | (mag_un < penalty)) ? mag_un : mag_un - penalty;
+         return BitsDeflated<T, U>(bit_view.sign_bit(), mag_sh);
+      }
+
+      BitsInflated<T,U> inflate(const BitsDeflated<T,U>& b) const {
+         const U mag = b.mag();
+         const U mag_inflated = (has_denorm_ | (mag == 0)) ? mag : mag + bits_denorm_shift();
+         return BitsInflated<T, U>(b.sign_bit(), mag_inflated);
+      }
+
+   private:
+      // Denorm penalty
+      static constexpr U bits_denorm_shift() { return (U(1) << (std::numeric_limits<T>::digits - 1)) - 1; }
+      
+      static bool calc_has_denorm() {
+         return boost::math::detail::get_smallest_value<T>() != (std::numeric_limits<T>::min)();
+      }
+
+      bool has_denorm_;
+   };
+
+   // Check if T has a member function named "value".
+   template <typename T>
+   class has_value_member
+   {
+      template <typename U>
+      static auto test(int) -> decltype(std::declval<U>().value(), std::true_type());
+
+      template <typename U>
+      static std::false_type test(...);
+
+   public:
+      static constexpr bool value = decltype(test<T>(0))::value;
+   };
+
+   // Allows one to static_cast from ‘boost::math::concepts::std_real_concept’ to
+   // type ‘__float128’
+   class StaticCast {
+   public:
+      template <typename T, typename V>
+      static typename std::enable_if<has_value_member<V>::value, T>::type value(V x) {
+         return static_cast<T>(x.value());
+      }
+
+      template <typename T, typename V>
+      static typename std::enable_if<!has_value_member<V>::value, T>::type value(V x) {
+         return static_cast<T>(x);
+      }
+   };
+
+}  // namespace ieee754_linear
+}  // namespace detail
+}  // namespace tools
+}  // namespace math
+}  // namespace boost   
+
+#endif  // BOOST_MATH_TOOLS_IEEE754_BITSPACE_HPP

--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -495,12 +495,12 @@ T newton_raphson_iterate(F f, T guess, T min, T max, int digits, std::uintmax_t&
       last_f0 = f0;
       delta2 = delta1;
       delta1 = delta;
-      detail::unpack_tuple(f(result), f0, f1);
       if (count == 0) {
          return policies::raise_evaluation_error(function, "Ran out of iterations in boost::math::tools::newton_raphson_iterate, perhaps we have a local minima near current best guess of %1%", guess, boost::math::policies::policy<>());
       } else {
          --count;
       }
+      detail::unpack_tuple(f(result), f0, f1);
 
       if (0 == f0)
          break;

--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -496,7 +496,7 @@ T newton_raphson_iterate(F f, T guess, T min, T max, int digits, std::uintmax_t&
       delta2 = delta1;
       delta1 = delta;
       if (count == 0) {
-         return policies::raise_evaluation_error(function, "Ran out of iterations in boost::math::tools::newton_raphson_iterate, perhaps we have a local minima near current best guess of %1%", guess, boost::math::policies::policy<>());
+         return policies::raise_evaluation_error(function, "Ran out of iterations in boost::math::tools::newton_raphson_iterate, guess: %1%", guess, boost::math::policies::policy<>());
       } else {
          --count;
       }

--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -18,6 +18,7 @@
 
 #include <boost/math/tools/config.hpp>
 #include <boost/math/tools/cxx03_warn.hpp>
+#include <boost/math/tools/throw_exception.hpp>
 
 #include <boost/math/special_functions/sign.hpp>
 #include <boost/math/special_functions/next.hpp>

--- a/include/boost/math/tools/roots.hpp
+++ b/include/boost/math/tools/roots.hpp
@@ -309,12 +309,15 @@ namespace Bisection {
             std::swap(x, y);
          }
 
+         // Recast as unsigned integers
          const U bits_x = float_to_uint(x);
          const U bits_y = float_to_uint(y);
 
+         // Get just the sign bit
          const U sign_x = bits_x & sign_mask();
          const U sign_y = bits_y & sign_mask();
 
+         // Get everything but the sign bit
          const U mag_x = bits_x & ~sign_mask();
          const U mag_y = bits_y & ~sign_mask();
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1048,6 +1048,7 @@ test-suite misc :
    [ run test_real_concept.cpp ../../test/build//boost_unit_test_framework  ]
    [ run test_remez.cpp pch ../../test/build//boost_unit_test_framework  ]
    [ run test_roots.cpp pch ../../test/build//boost_unit_test_framework  ]
+   [ run ieee754_linear_test.cpp pch ../../test/build//boost_unit_test_framework  ]
    [ run test_root_iterations.cpp pch ../../test/build//boost_unit_test_framework : : : [ requires cxx11_hdr_tuple ]  ]
    [ run test_root_finding_concepts.cpp ../../test/build//boost_unit_test_framework  ]
    [ run test_toms748_solve.cpp pch ../../test/build//boost_unit_test_framework  ]

--- a/test/ieee754_linear_test.cpp
+++ b/test/ieee754_linear_test.cpp
@@ -1,0 +1,81 @@
+//  (C) Copyright Ryan Elandt 2023.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
+#include <boost/test/results_collector.hpp>
+
+#include <boost/multiprecision/cpp_bin_float.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+#include <boost/multiprecision/cpp_complex.hpp>
+#include <boost/math/concepts/real_concept.hpp>
+
+#ifdef BOOST_HAS_FLOAT128
+#include <boost/multiprecision/float128.hpp>
+#endif
+
+#if __has_include(<stdfloat>)
+#  include <stdfloat>
+#endif
+
+using boost::math::tools::detail::ieee754_linear::Layout_IEEE754Linear;
+using boost::math::tools::detail::ieee754_linear::Layout_Unspecified;
+
+
+template <typename L>
+bool is_layout_equal(L, L) { return true; }
+
+template <typename L1, typename L2>
+bool is_layout_equal(L1, L2) { return false; }
+
+template <typename T>
+bool is_unspeci(Layout_Unspecified<T>) { return true; }
+
+void test_layout() {
+   using boost::math::tools::detail::ieee754_linear::LayoutIdentifier;
+
+   const auto layout_f32_u32 = Layout_IEEE754Linear<float, uint32_t>();
+   const auto layout_f64_u64 = Layout_IEEE754Linear<double, uint64_t>();
+#if defined(BOOST_HAS_FLOAT128) && defined(BOOST_HAS_INT128)
+   const auto layout_f128_u128 = Layout_IEEE754Linear<__float128, boost::uint128_type>();
+#endif
+
+   // Check layout for float types
+   BOOST_CHECK(is_layout_equal(layout_f32_u32, LayoutIdentifier::get_layout<float>()));
+   BOOST_CHECK(is_layout_equal(layout_f64_u64, LayoutIdentifier::get_layout<double>()));
+   BOOST_CHECK(is_unspeci(LayoutIdentifier::get_layout<boost::math::concepts::real_concept>()));
+   BOOST_CHECK(is_unspeci(LayoutIdentifier::get_layout<boost::multiprecision::cpp_bin_float_50>()));
+   BOOST_CHECK(is_unspeci(LayoutIdentifier::get_layout<boost::multiprecision::cpp_bin_float_100>()));
+   BOOST_CHECK(is_unspeci(LayoutIdentifier::get_layout<boost::multiprecision::cpp_dec_float_50>()));
+   BOOST_CHECK(is_unspeci(LayoutIdentifier::get_layout<boost::multiprecision::cpp_dec_float_100>()));
+
+// Float128
+#if defined(BOOST_HAS_FLOAT128) && defined(BOOST_HAS_INT128)
+   BOOST_CHECK(is_layout_equal(layout_f128_u128, LayoutIdentifier::get_layout<boost::multiprecision::float128>()));
+   BOOST_CHECK(is_layout_equal(layout_f128_u128, LayoutIdentifier::get_layout<__float128>()));
+#endif
+
+// stdfloat
+#if __has_include(<stdfloat>)
+#ifdef __STDCPP_FLOAT32_T__
+   BOOST_CHECK(is_layout_equal(layout_f32_u32, LayoutIdentifier::get_layout<std::float32_t>()));
+#endif
+#ifdef __STDCPP_FLOAT64_T__
+   BOOST_CHECK(is_layout_equal(layout_f64_u64, LayoutIdentifier::get_layout<std::float64_t>()));
+#endif 
+#endif
+
+// 80 bit long double
+#if LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384
+   BOOST_CHECK(is_unspeci(LayoutIdentifier::get_layout<long double>()));
+#endif
+}
+
+BOOST_AUTO_TEST_CASE( test_main )
+{
+   test_layout();
+   
+}

--- a/test/test_roots.cpp
+++ b/test/test_roots.cpp
@@ -710,7 +710,7 @@ std::vector<T> create_test_ladder() {
 };
 
 template <typename T, typename S>
-void test_bisect_non(S solver) {
+void test_bisect(S solver) {
    // Test for all combinations from the ladder
    auto v = create_test_ladder<T>();
 
@@ -729,21 +729,18 @@ void test_bisect_non(S solver) {
 
 template <typename T>
 void test_bisect_non() {
-   const auto solver = boost::math::tools::detail::Bisection::CalcMidpoint::get_solver(T(1));  // Input value unused
-   test_bisect_non<T,decltype(solver)>(solver);
-}
-
-template <typename S>
-void test_bisect_754(S solver) {
-   BOOST_MATH_ASSERT(solver.is_one_plus_max_bits_inf());  // Catch infinity misbehavior for 80 bit `long double`
-                                                          // before it causes downstream failures
-   test_bisect_non<typename S::type_float,S>(solver);
+   const auto solver = boost::math::tools::detail::Bisection::CalcMidpoint::get_solver<T>();
+   test_bisect<T,decltype(solver)>(solver);
 }
 
 template <typename T>
 void test_bisect_754() {
-   const auto solver = boost::math::tools::detail::Bisection::CalcMidpoint::get_solver(T(1));  // Input value unused
-   test_bisect_754(solver);
+   const auto solver = boost::math::tools::detail::Bisection::CalcMidpoint::get_solver<T>();
+   BOOST_MATH_ASSERT(solver.is_one_plus_max_bits_inf());  // Catch infinity misbehavior for 80 bit `long double`
+                                                          // before it causes downstream failures
+   // We need to use the float type associated with the solver to avoid needing to link with libquadmath
+   using S = decltype(solver);
+   test_bisect<typename S::type_float,S>(solver);
 }
 
 void test_bisect_all_cases() {

--- a/test/test_roots.cpp
+++ b/test/test_roots.cpp
@@ -23,7 +23,9 @@
 #include <iomanip>
 
 #include <boost/multiprecision/cpp_bin_float.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
 #include <boost/multiprecision/cpp_complex.hpp>
+#include <boost/math/concepts/real_concept.hpp>
 
 #define BOOST_CHECK_CLOSE_EX(a, b, prec, i) \
    {\
@@ -649,11 +651,93 @@ void test_failures()
 #endif
 }
 
+template <typename T>
+void test_bisect() {
+   // Creates a vector of test values that include: zero, denorm_min, min, epsilon, max,
+   // and infinity. Also includes powers of 2 ranging from 2^-15 to 2^+15 by powers of 3.
+   const auto fn_create_test_ladder = [](){
+      std::vector<T> v;
+
+      const auto fn_push_back_x_scaled = [&v](const T& x) {
+         const auto fn_add_if_non_zero_and_finite = [&v](const T& x) {
+            if (x != 0 && boost::math::isfinite(x)) {  // Avoids most duplications
+               v.push_back(x);
+            }
+         };
+
+         const T two_thirds = T(2) / T(3);
+         const T four_thirds = T(4) / T(3);
+
+         v.push_back(x);
+         fn_add_if_non_zero_and_finite(x * T(0.5));
+         fn_add_if_non_zero_and_finite(x * two_thirds);
+         fn_add_if_non_zero_and_finite(x * four_thirds);
+         fn_add_if_non_zero_and_finite(x * T(2.0));
+      };
+
+      const auto fn_push_back_pm = [&](std::vector<T>& v, const T& x) {
+         fn_push_back_x_scaled( x);
+         fn_push_back_x_scaled(-x);
+      };
+
+      fn_push_back_pm(v, T(0.0));
+      fn_push_back_pm(v, std::numeric_limits<T>::denorm_min());
+      fn_push_back_pm(v, (std::numeric_limits<T>::min)());
+      fn_push_back_pm(v, std::numeric_limits<T>::epsilon());
+      const int test_exp_range = 5;
+      for (int i = -test_exp_range; i < (test_exp_range + 1); ++i) {
+         const int exponent = i * 3;
+         const T x = std::ldexp(1.0, exponent);
+         fn_push_back_pm(v, x);
+      }
+      fn_push_back_pm(v, (std::numeric_limits<T>::max)());
+
+      // Real_concept doesn't have infinity
+      if (std::numeric_limits<T>::has_infinity) {
+         fn_push_back_pm(v, std::numeric_limits<T>::infinity());
+      }
+
+      std::sort(v.begin(), v.end());
+
+      const int num_zeros = std::count(v.begin(), v.end(), T(0.0));
+      BOOST_CHECK_LE(2, num_zeros);  // Positive and negative zero 
+
+      return v;
+   };
+
+   // Test for all combinations from the ladder
+   auto v = fn_create_test_ladder();
+   for (const T& x_i: v) {
+      for (const T& x_j: v) {
+         const T x_mid_ij = boost::math::tools::detail::Bisection::calc_midpoint(x_i, x_j);
+
+         const T x_lo = (std::min)(x_i, x_j);
+         const T x_hi = (std::max)(x_i, x_j);
+
+         BOOST_CHECK_LE(x_lo, x_mid_ij);
+         BOOST_CHECK_LE(x_mid_ij, x_hi);
+      }
+   }
+}
+
+void test_bisect_all_cases() {
+   test_bisect<float>();
+   test_bisect<double>();
+   test_bisect<long double>();
+   test_bisect<boost::math::concepts::real_concept>();
+   test_bisect<boost::multiprecision::cpp_bin_float_50>();
+   test_bisect<boost::multiprecision::cpp_bin_float_100>();
+   test_bisect<boost::multiprecision::cpp_dec_float_50>();
+   test_bisect<boost::multiprecision::cpp_dec_float_100>();
+}
+
 BOOST_AUTO_TEST_CASE( test_main )
 {
 
    test_beta(0.1, "double");
 
+   test_bisect_all_cases();
+#if 0
    // bug reports:
    boost::math::skew_normal_distribution<> dist(2.0, 1.0, -2.5);
    BOOST_CHECK(boost::math::isfinite(quantile(dist, 0.075)));
@@ -675,4 +759,5 @@ BOOST_AUTO_TEST_CASE( test_main )
     test_solve_complex_quadratic<std::complex<double>>();
 #endif
     test_failures();
+#endif
 }

--- a/test/test_roots.cpp
+++ b/test/test_roots.cpp
@@ -746,19 +746,6 @@ void test_bisect_754() {
    test_bisect_754(solver);
 }
 
-template <bool>
-struct CompileTimeLongDoubleChecker {
-   static void check() {}
-};
-
-template <>
-struct CompileTimeLongDoubleChecker<true> {
-   static void check() {
-      const auto solver = boost::math::tools::detail::Bisection::Midpoint754<long double,boost::uint128_type>();
-      BOOST_CHECK(!solver.is_one_plus_max_bits_inf());
-   }
-};
-
 void test_bisect_all_cases() {
    test_bisect_754<float>();
    test_bisect_754<double>();
@@ -787,9 +774,7 @@ void test_bisect_all_cases() {
    // CI says this fails to compile sometimes because the static_assert
    // in `Midpoint754` that `std::is_unsigned<boost::uint128_type>::value is
    // true is not met. This occurs despite the preprocessor assertion that
-   // `BOOST_HAS_INT128` is defined and being compile time dispatched based
-   // on `std::is_unsigned<boost::uint128_type>::value` being true. I'm not
-   // sure why this occurs.
+   // `BOOST_HAS_INT128` is defined. I'm not sure why this occurs.
    //
    // That being said, this test is mostly pedogogical. It shows that
    // `long double` does not possess the property that increasing values in
@@ -797,7 +782,8 @@ void test_bisect_all_cases() {
    // correctness, only for completeness. If you can compile this locally
    // this test should pass.
 #if 0
-   CompileTimeLongDoubleChecker<std::is_unsigned<boost::uint128_type>::value>::check();
+   const auto solver = boost::math::tools::detail::Bisection::Midpoint754<long double,boost::uint128_type>();
+   BOOST_CHECK(!solver.is_one_plus_max_bits_inf());
 #endif   
 #endif
 }

--- a/test/test_roots.cpp
+++ b/test/test_roots.cpp
@@ -27,6 +27,10 @@
 #include <boost/multiprecision/cpp_complex.hpp>
 #include <boost/math/concepts/real_concept.hpp>
 
+#if __has_include(<stdfloat>)
+#  include <stdfloat>
+#endif
+
 #define BOOST_CHECK_CLOSE_EX(a, b, prec, i) \
    {\
       unsigned int failures = boost::unit_test::results_collector.results( boost::unit_test::framework::current_test_case().p_id ).p_assertions_failed;\
@@ -729,6 +733,15 @@ void test_bisect_all_cases() {
    test_bisect<boost::multiprecision::cpp_bin_float_100>();
    test_bisect<boost::multiprecision::cpp_dec_float_50>();
    test_bisect<boost::multiprecision::cpp_dec_float_100>();
+
+#if __has_include(<stdfloat>)
+#ifdef __STDCPP_FLOAT32_T__
+   test_bisect<std::float32_t>();
+#endif
+#ifdef __STDCPP_FLOAT64_T__
+   test_bisect<std::float64_t>();
+#endif 
+#endif
 }
 
 void test_count() {
@@ -765,7 +778,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 
    test_count();
    test_bisect_all_cases();
-#if 0
+
    // bug reports:
    boost::math::skew_normal_distribution<> dist(2.0, 1.0, -2.5);
    BOOST_CHECK(boost::math::isfinite(quantile(dist, 0.075)));
@@ -787,5 +800,4 @@ BOOST_AUTO_TEST_CASE( test_main )
     test_solve_complex_quadratic<std::complex<double>>();
 #endif
     test_failures();
-#endif
 }

--- a/test/test_roots.cpp
+++ b/test/test_roots.cpp
@@ -745,11 +745,6 @@ void test_bisect_754() {
    test_bisect_754(solver);
 }
 
-void test_long_double_fail() {
-   const auto solver = boost::math::tools::detail::Bisection::Midpoint754<long double,boost::uint128_type>();
-   BOOST_CHECK(!solver.is_one_plus_max_bits_inf());
-}
-
 void test_bisect_all_cases() {
    test_bisect_754<float>();
    test_bisect_754<double>();
@@ -775,7 +770,8 @@ void test_bisect_all_cases() {
 #endif
 
 #if LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384 && defined(BOOST_HAS_INT128)
-   test_long_double_fail();
+   const auto solver = boost::math::tools::detail::Bisection::Midpoint754<long double,boost::uint128_type>();
+   BOOST_CHECK(!solver.is_one_plus_max_bits_inf());
 #endif
 }
 

--- a/test/test_roots.cpp
+++ b/test/test_roots.cpp
@@ -784,9 +784,21 @@ void test_bisect_all_cases() {
 #endif
 
 #if LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384 && defined(BOOST_HAS_INT128)
-   // NOTE: this is necessary because BOOST_HAS_INT128 deing befined does not
-   //       guarantee that std::is_unsigned<boost::uint128_type>::value is true
+   // CI says this fails to compile sometimes because the static_assert
+   // in `Midpoint754` that `std::is_unsigned<boost::uint128_type>::value is
+   // true is not met. This occurs despite the preprocessor assertion that
+   // `BOOST_HAS_INT128` is defined and being compile time dispatched based
+   // on `std::is_unsigned<boost::uint128_type>::value` being true. I'm not
+   // sure why this occurs.
+   //
+   // That being said, this test is mostly pedogogical. It shows that
+   // `long double` does not possess the property that increasing values in
+   // bitspace result in increasing float values. It is not required for
+   // correctness, only for completeness. If you can compile this locally
+   // this test should pass.
+#if 0
    CompileTimeLongDoubleChecker<std::is_unsigned<boost::uint128_type>::value>::check();
+#endif   
 #endif
 }
 

--- a/test/test_roots.cpp
+++ b/test/test_roots.cpp
@@ -770,8 +770,10 @@ void test_bisect_all_cases() {
 #endif
 
 #if LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384 && defined(BOOST_HAS_INT128)
-   const auto solver = boost::math::tools::detail::Bisection::Midpoint754<long double,boost::uint128_type>();
-   BOOST_CHECK(!solver.is_one_plus_max_bits_inf());
+   if (std::is_unsigned<boost::uint128_type>::value) {
+      const auto solver = boost::math::tools::detail::Bisection::Midpoint754<long double,boost::uint128_type>();
+      BOOST_CHECK(!solver.is_one_plus_max_bits_inf());
+   }
 #endif
 }
 

--- a/test/test_roots.cpp
+++ b/test/test_roots.cpp
@@ -731,11 +731,39 @@ void test_bisect_all_cases() {
    test_bisect<boost::multiprecision::cpp_dec_float_100>();
 }
 
+void test_count() {
+   const auto fn_newton = [](std::uintmax_t& i_max) {
+      return boost::math::tools::newton_raphson_iterate(
+         [](double x) { return std::make_pair(x * x - 3, 2 * x); },
+         10.0  /* x_initial */,
+         0.0   /* bound lower*/,
+         100.0 /* bound upper */, 52, i_max);
+   };
+
+   // Find the minimum number of iterations to find the solution
+   std::uintmax_t iter_find_solution = 100;
+   fn_newton(iter_find_solution);
+   BOOST_CHECK_EQUAL(iter_find_solution, std::uintmax_t(8));  // Confirm is 8
+
+   for (std::uintmax_t count = 0; count < (iter_find_solution * 2); count++) {
+      std::uintmax_t iters = count;
+      if (iter_find_solution <= count) {  // Finds correct answer
+         using std::sqrt;
+         BOOST_CHECK_EQUAL(fn_newton(iters), sqrt(3.0));
+         BOOST_CHECK_EQUAL(iters, iter_find_solution);
+      }
+      else {  // Throws error for running out of iterations
+         BOOST_CHECK_THROW(fn_newton(iters), boost::math::evaluation_error);
+      }
+   }
+}
+
 BOOST_AUTO_TEST_CASE( test_main )
 {
 
    test_beta(0.1, "double");
 
+   test_count();
    test_bisect_all_cases();
 #if 0
    // bug reports:

--- a/test/test_roots.cpp
+++ b/test/test_roots.cpp
@@ -19,7 +19,6 @@
 #include <boost/array.hpp>
 #include <boost/type_index.hpp>
 #include "table_type.hpp"
-#include <iostream>
 #include <iomanip>
 #include <type_traits>
 


### PR DESCRIPTION
This is chunk #4 for #1000. Also closes #1008.

This PR adds tools that enable efficient bisection for the 1D Newton root finder.

### The Situation

The 1D Newton root finder has a bisection fallback mechanism. If one of the bounds is large (i.e., `std::numeric_limits::max()`), naively bisecting the bounds is slow. For example, for type `double`, bisecting from `1.79769e+308` to `1` takes `1024` iterations. The situation is even worse for types with more precision. When the Newton solver runs out of (e.g., 200) iterations during bisection, the solver declares success even if far from a root. Again, see issue #1008.

### Functionality

What's the maximum number of bisections needed to root find a `double`? A `double` is 64 bits. So the maximum number of iterations needed is 64. Efficient bisection is bisection in bit space. An interesting consequence of bisection in bitspace, is that infinity is a bisectable bound.

For types that do not conform to the standard (i.e., IEEE 754), an approximate version of the bisection algorithm above is used. The approximate version supports bisection with infinity if the type is specialized (i.e., if `std::numeric_limits<T>::is_specialized = true`).

### Fun Facts

The mean of `0` and `infinity` is:
- `infinity` (arithmetic mean)
- `NaN` (geometric mean)
- 1.5 (bitspace mean for `double` and `float`)
- 1.0 (bitspace mean for `long double` using the approximate algorithm)