### PR TITLE
fix unused abterm1 compile warnings

### DIFF
--- a/include/boost/math/quadrature/detail/exp_sinh_detail.hpp
+++ b/include/boost/math/quadrature/detail/exp_sinh_detail.hpp
@@ -226,7 +226,6 @@ auto exp_sinh_detail<Real, Policy>::integrate(const F& f, Real* error, Real* L1,
         auto weight_row = get_weight_row(i);
 
         first_j = first_j == 0 ? 0 : 2 * first_j - 1;  // appoximate location to start looking for lowest meaningful abscissa value
-        BOOST_MATH_MAYBE_UNUSED Real abterm1 = 1;
         std::size_t j = first_j;
         while (abscissas_row[j] < min_abscissa)
            ++j;
@@ -237,7 +236,6 @@ auto exp_sinh_detail<Real, Policy>::integrate(const F& f, Real* error, Real* L1,
             sum += y*weight_row[j];
             Real abterm0 = abs(y)*weight_row[j];
             absum += abterm0;
-            abterm1 = abterm0;
         }
 
         I1 += sum*h;

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -146,23 +146,6 @@
 #  define BOOST_MATH_EXEC_COMPATIBLE
 #endif
 
-// Attributes from C++14 and newer
-#ifdef __has_cpp_attribute
-
-// C++17
-#if (__cplusplus >= 201703L || _MSVC_LANG >= 201703L)
-#  if __has_cpp_attribute(maybe_unused)
-#    define BOOST_MATH_MAYBE_UNUSED [[maybe_unused]]
-#  endif
-#endif
-
-#endif // Standalone config
-
-// If attributes are not defined make sure we don't have compiler errors
-#ifndef BOOST_MATH_MAYBE_UNUSED
-#  define BOOST_MATH_MAYBE_UNUSED 
-#endif
-
 // C++23
 #if __cplusplus > 202002L || _MSVC_LANG > 202002L
 #  if __GNUC__ >= 13


### PR DESCRIPTION
The file `exp_sinh_detail.hpp` contains an unconditionally unused variable `abterm1` that causes compile warnings. This issue was fixed for C++17 and above in #884 with the addition of the `BOOST_MATH_MAYBE_UNUSED` macro. 

**This PR** implements a direct fix that removes the warning for all C++ versions. It also removes the `BOOST_MATH_MAYBE_UNUSED` macro as this is the only place it's used in the Boost (all libraries).