### PR TITLE
ten should be a constexpr as a float

### DIFF
--- a/include/boost/math/cstdfloat/cstdfloat_iostream.hpp
+++ b/include/boost/math/cstdfloat/cstdfloat_iostream.hpp
@@ -442,7 +442,7 @@
       if(isneg) { x = -x; }
 
       float_type t;
-      float_type ten = 10;
+      constexpr float_type ten = 10;
 
       eval_log10(t, x);
       eval_floor(t, t);
@@ -571,7 +571,7 @@
 
     if((p == static_cast<const char*>(0U)) || (*p == static_cast<char>(0)))
     {
-      return;
+      return false;
     }
 
     bool is_neg       = false;


### PR DESCRIPTION
Its int counterpart is a constexpr, and the ten variable never changes, so for consistency, we should make float_type ten constexpr as welll.