### PR TITLE
Fix clang-14 run in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [ g++-12, clang++-14 ]
-        standard: [ c++14, c++17, c++20 ]
+        standard: [ c++14, c++17 ]
         suite: [ github_ci_block_1, github_ci_block_2 ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The updated GHA runners broke Clang-14 in C++20 mode. G++12 in C++20 mode is covered in our drone runs which are fine..