### PR TITLE
Fix for msvc defining _Complex_I in complex.h

### DIFF
--- a/doc/internals/polynomial.qbk
+++ b/doc/internals/polynomial.qbk
@@ -21,7 +21,7 @@
       polynomial(){}
       template <class U>
       polynomial(const U* data, unsigned order);
-      template <class I>
+      template <class Iterator>
       polynomial(I first, I last);
       template <class U>
       explicit polynomial(const U& point, 

--- a/doc/internals/polynomial.qbk
+++ b/doc/internals/polynomial.qbk
@@ -22,7 +22,7 @@
       template <class U>
       polynomial(const U* data, unsigned order);
       template <class Iterator>
-      polynomial(I first, I last);
+      polynomial(Iterator first, Iterator last);
       template <class U>
       explicit polynomial(const U& point, 
             typename std::enable_if<std::is_convertible<U, T> >::type* = nullptr);

--- a/include/boost/math/bindings/mpfr.hpp
+++ b/include/boost/math/bindings/mpfr.hpp
@@ -304,8 +304,8 @@ inline int digits<mpfr_class>(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE_SPEC(mpfr_class)
 
 namespace detail{
 
-template<class I>
-void convert_to_long_result(mpfr_class const& r, I& result)
+template<class Integer>
+void convert_to_long_result(mpfr_class const& r, Integer& result)
 {
    result = 0;
    I last_result(0);

--- a/include/boost/math/bindings/mpreal.hpp
+++ b/include/boost/math/bindings/mpreal.hpp
@@ -264,8 +264,8 @@ inline int digits<mpfr::mpreal>(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE_SPEC(mpfr::mpr
 
 namespace detail{
 
-template<class I>
-void convert_to_long_result(mpfr::mpreal const& r, I& result)
+template<class Integer
+void convert_to_long_result(mpfr::mpreal const& r, Integer& result)
 {
    result = 0;
    I last_result(0);

--- a/include/boost/math/bindings/rr.hpp
+++ b/include/boost/math/bindings/rr.hpp
@@ -514,8 +514,8 @@ inline double real_cast<double, boost::math::ntl::RR>(boost::math::ntl::RR t)
 
 namespace detail{
 
-template<class I>
-void convert_to_long_result(NTL::RR const& r, I& result)
+template<class Integer>
+void convert_to_long_result(NTL::RR const& r, Integer& result)
 {
    result = 0;
    I last_result(0);

--- a/include/boost/math/special_functions.hpp
+++ b/include/boost/math/special_functions.hpp
@@ -12,6 +12,14 @@
 #ifndef BOOST_MATH_SPECIAL_FUNCTIONS_HPP
 #define BOOST_MATH_SPECIAL_FUNCTIONS_HPP
 
+#ifdef _MSC_VER
+#  ifdef I
+#    pragma push_macro("I")
+#    define BOOST_MATH_PUSHED_I
+#    undef I 
+#  endif
+#endif
+
 #include <boost/math/special_functions/airy.hpp>
 #include <boost/math/special_functions/acosh.hpp>
 #include <boost/math/special_functions/asinh.hpp>
@@ -82,4 +90,9 @@
 #ifndef BOOST_NO_EXCEPTIONS
 #include <boost/math/special_functions/legendre_stieltjes.hpp>
 #endif
+
+#ifdef BOOST_MATH_PUSHED_I
+#  pragma push_macro("I")
+#endif
+
 #endif // BOOST_MATH_SPECIAL_FUNCTIONS_HPP

--- a/include/boost/math/special_functions.hpp
+++ b/include/boost/math/special_functions.hpp
@@ -12,14 +12,6 @@
 #ifndef BOOST_MATH_SPECIAL_FUNCTIONS_HPP
 #define BOOST_MATH_SPECIAL_FUNCTIONS_HPP
 
-#ifdef _MSC_VER
-#  ifdef I
-#    pragma push_macro("I")
-#    define BOOST_MATH_PUSHED_I
-#    undef I 
-#  endif
-#endif
-
 #include <boost/math/special_functions/airy.hpp>
 #include <boost/math/special_functions/acosh.hpp>
 #include <boost/math/special_functions/asinh.hpp>
@@ -89,10 +81,6 @@
 #include <boost/math/special_functions/jacobi.hpp>
 #ifndef BOOST_NO_EXCEPTIONS
 #include <boost/math/special_functions/legendre_stieltjes.hpp>
-#endif
-
-#ifdef BOOST_MATH_PUSHED_I
-#  pragma push_macro("I")
 #endif
 
 #endif // BOOST_MATH_SPECIAL_FUNCTIONS_HPP

--- a/include/boost/math/special_functions/bessel.hpp
+++ b/include/boost/math/special_functions/bessel.hpp
@@ -112,9 +112,9 @@ T cyl_bessel_j_imp(T v, T x, const bessel_no_int_tag& t, const Policy& pol)
             "Got x = %1%, but we need x >= 0", x, pol);
    }
 
-   T j, y;
-   bessel_jy(v, x, &j, &y, need_j, pol);
-   return j;
+   T result_J, y;
+   bessel_jy(v, x, &result_J, &y, need_j, pol);
+   return result_J;
 }
 
 template <class T, class Policy>
@@ -221,9 +221,9 @@ T cyl_bessel_i_imp(T v, T x, const Policy& pol)
    }
    if((v > 0) && (x / v < 0.25))
       return bessel_i_small_z_series(v, x, pol);
-   T I, K;
-   bessel_ik(v, x, &I, &K, need_i, pol);
-   return I;
+   T result_I, result_K;
+   bessel_ik(v, x, &result_I, &result_K, need_i, pol);
+   return result_I;
 }
 
 template <class T, class Policy>
@@ -244,9 +244,9 @@ inline T cyl_bessel_k_imp(T v, T x, const bessel_no_int_tag& /* t */, const Poli
          function,
          "Got x = %1%, but we need x > 0", x, pol);
    }
-   T I, K;
-   bessel_ik(v, x, &I, &K, need_k, pol);
-   return K;
+   T result_I, result_K;
+   bessel_ik(v, x, &result_I, &result_K, need_k, pol);
+   return result_K;
 }
 
 template <class T, class Policy>
@@ -282,8 +282,8 @@ inline T cyl_neumann_imp(T v, T x, const bessel_no_int_tag&, const Policy& pol)
                function,
                "Got x = %1%, but result is complex for x <= 0", x, pol);
    }
-   T j, y;
-   bessel_jy(v, x, &j, &y, need_y, pol);
+   T result_J, y;
+   bessel_jy(v, x, &result_J, &y, need_y, pol);
    //
    // Post evaluation check for internal overflow during evaluation,
    // can occur when x is small and v is large, in which case the result

--- a/include/boost/math/special_functions/detail/bessel_ik.hpp
+++ b/include/boost/math/special_functions/detail/bessel_ik.hpp
@@ -77,7 +77,7 @@ inline T bessel_i_small_z_series(T v, T x, const Policy& pol)
    return prefix * result;
 }
 
-// Calculate result_K(v, x) and result_K(v+1, x) by method analogous to
+// Calculate K(v, x) and K(v+1, x) by method analogous to
 // Temme, Journal of Computational Physics, vol 21, 343 (1976)
 template <typename T, typename Policy>
 int temme_ik(T v, T x, T* result_K, T* K1, const Policy& pol)
@@ -200,7 +200,7 @@ int CF1_ik(T v, T x, T* fv, const Policy& pol)
     return 0;
 }
 
-// Calculate result_K(v, x) and result_K(v+1, x) by evaluating continued fraction
+// Calculate K(v, x) and K(v+1, x) by evaluating continued fraction
 // z1 / z0 = U(v+1.5, 2v+1, 2x) / U(v+0.5, 2v+1, 2x), see
 // Thompson and Barnett, Computer Physics Communications, vol 47, 245 (1987)
 template <typename T, typename Policy>
@@ -374,7 +374,7 @@ int bessel_ik(T v, T x, T* result_I, T* result_K, int kind, const Policy& pol)
     current = Ku1;
     T scale = 1;
     T scale_sign = 1;
-    for (k = 1; k <= n; k++)                   // forward recurrence for result_K
+    for (k = 1; k <= n; k++)                   // forward recurrence for K
     {
         T fact = 2 * (u + k) / x;
         // Check for overflow: if (max - |prev|) / fact > max, then overflow

--- a/include/boost/math/special_functions/detail/bessel_ik.hpp
+++ b/include/boost/math/special_functions/detail/bessel_ik.hpp
@@ -77,10 +77,10 @@ inline T bessel_i_small_z_series(T v, T x, const Policy& pol)
    return prefix * result;
 }
 
-// Calculate K(v, x) and K(v+1, x) by method analogous to
+// Calculate result_K(v, x) and result_K(v+1, x) by method analogous to
 // Temme, Journal of Computational Physics, vol 21, 343 (1976)
 template <typename T, typename Policy>
-int temme_ik(T v, T x, T* K, T* K1, const Policy& pol)
+int temme_ik(T v, T x, T* result_K, T* K1, const Policy& pol)
 {
     T f, h, p, q, coef, sum, sum1, tolerance;
     T a, b, c, d, sigma, gamma1, gamma2;
@@ -148,7 +148,7 @@ int temme_ik(T v, T x, T* K, T* K1, const Policy& pol)
     }
     policies::check_series_iterations<T>("boost::math::bessel_ik<%1%>(%1%,%1%) in temme_ik", k, pol);
 
-    *K = sum;
+    *result_K = sum;
     *K1 = 2 * sum1 / x;
 
     return 0;
@@ -200,7 +200,7 @@ int CF1_ik(T v, T x, T* fv, const Policy& pol)
     return 0;
 }
 
-// Calculate K(v, x) and K(v+1, x) by evaluating continued fraction
+// Calculate result_K(v, x) and result_K(v+1, x) by evaluating continued fraction
 // z1 / z0 = U(v+1.5, 2v+1, 2x) / U(v+0.5, 2v+1, 2x), see
 // Thompson and Barnett, Computer Physics Communications, vol 47, 245 (1987)
 template <typename T, typename Policy>
@@ -297,7 +297,7 @@ enum{
 // Compute I(v, x) and K(v, x) simultaneously by Temme's method, see
 // Temme, Journal of Computational Physics, vol 19, 324 (1975)
 template <typename T, typename Policy>
-int bessel_ik(T v, T x, T* I, T* K, int kind, const Policy& pol)
+int bessel_ik(T v, T x, T* result_I, T* result_K, int kind, const Policy& pol)
 {
     // Kv1 = K_(v+1), fv = I_(v+1) / I_v
     // Ku1 = K_(u+1), fu = I_(u+1) / I_u
@@ -329,7 +329,7 @@ int bessel_ik(T v, T x, T* I, T* K, int kind, const Policy& pol)
 
     if (x < 0)
     {
-       *I = *K = policies::raise_domain_error<T>(function,
+       *result_I = *result_K = policies::raise_domain_error<T>(function,
             "Got x = %1% but real argument x must be non-negative, complex number result not supported.", x, pol);
         return 1;
     }
@@ -353,8 +353,8 @@ int bessel_ik(T v, T x, T* I, T* K, int kind, const Policy& pol)
                policies::raise_overflow_error<T>(function, nullptr, pol);   // reflection formula
        }
 
-       *I = Iv;
-       *K = Kv;
+       *result_I = Iv;
+       *result_K = Kv;
        return 0;
     }
 
@@ -374,7 +374,7 @@ int bessel_ik(T v, T x, T* I, T* K, int kind, const Policy& pol)
     current = Ku1;
     T scale = 1;
     T scale_sign = 1;
-    for (k = 1; k <= n; k++)                   // forward recurrence for K
+    for (k = 1; k <= n; k++)                   // forward recurrence for result_K
     {
         T fact = 2 * (u + k) / x;
         // Check for overflow: if (max - |prev|) / fact > max, then overflow
@@ -433,22 +433,22 @@ int bessel_ik(T v, T x, T* I, T* K, int kind, const Policy& pol)
         T z = (u + n % 2);
         T fact = (2 / pi<T>()) * (boost::math::sin_pi(z, pol) * Kv);
         if(fact == 0)
-           *I = Iv;
+           *result_I = Iv;
         else if(tools::max_value<T>() * scale < fact)
-           *I = (org_kind & need_i) ? T(sign(fact) * scale_sign * policies::raise_overflow_error<T>(function, nullptr, pol)) : T(0);
+           *result_I = (org_kind & need_i) ? T(sign(fact) * scale_sign * policies::raise_overflow_error<T>(function, nullptr, pol)) : T(0);
         else
-         *I = Iv + fact / scale;   // reflection formula
+         *result_I = Iv + fact / scale;   // reflection formula
     }
     else
     {
-        *I = Iv;
+        *result_I = Iv;
     }
     if(tools::max_value<T>() * scale < Kv)
-       *K = (org_kind & need_k) ? T(sign(Kv) * scale_sign * policies::raise_overflow_error<T>(function, nullptr, pol)) : T(0);
+       *result_K = (org_kind & need_k) ? T(sign(Kv) * scale_sign * policies::raise_overflow_error<T>(function, nullptr, pol)) : T(0);
     else
-      *K = Kv / scale;
-    BOOST_MATH_INSTRUMENT_VARIABLE(*I);
-    BOOST_MATH_INSTRUMENT_VARIABLE(*K);
+      *result_K = Kv / scale;
+    BOOST_MATH_INSTRUMENT_VARIABLE(*result_I);
+    BOOST_MATH_INSTRUMENT_VARIABLE(*result_K);
     return 0;
 }
 

--- a/include/boost/math/tools/convert_from_string.hpp
+++ b/include/boost/math/tools/convert_from_string.hpp
@@ -14,7 +14,18 @@
 #include <boost/math/tools/config.hpp>
 #include <type_traits>
 #ifndef BOOST_MATH_STANDALONE
+
+#if defined(_MSC_VER) || defined(__GNUC__)
+# pragma push_macro( "I" )
+# undef I
+#endif
+
 #include <boost/lexical_cast.hpp>
+
+#if defined(_MSC_VER) || defined(__GNUC__)
+# pragma pop_macro( "I" )
+#endif
+
 #endif
 
 namespace boost{ namespace math{ namespace tools{

--- a/include/boost/math/tools/mp.hpp
+++ b/include/boost/math/tools/mp.hpp
@@ -15,14 +15,6 @@
 #include <cstddef>
 #include <utility>
 
-#ifdef _MSC_VER
-#  ifdef I
-#    pragma push_macro("I")
-#    define BOOST_MATH_PUSHED_I
-#    undef I 
-#  endif
-#endif
-
 namespace boost { namespace math { namespace tools { namespace meta_programming {
 
 // Types:
@@ -176,11 +168,11 @@ struct mp_at_c<L<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T...>, 1
 };
 }
 
-template<typename L, std::size_t I>
-using mp_at_c = typename detail::mp_at_c<L, I>::type;
+template<typename L, std::size_t Index>
+using mp_at_c = typename detail::mp_at_c<L, Index>::type;
 
-template<typename L, typename I>
-using mp_at = typename detail::mp_at_c<L, I::value>::type;
+template<typename L, typename Index>
+using mp_at = typename detail::mp_at_c<L, Index::value>::type;
 
 // Back
 template<typename L> 
@@ -347,8 +339,8 @@ using mp_remove_if_q = mp_remove_if<L, Q::template fn>;
 // Index sequence
 // Use C++14 index sequence if available
 #if defined(__cpp_lib_integer_sequence) && (__cpp_lib_integer_sequence >= 201304)
-template<std::size_t... I>
-using index_sequence = std::index_sequence<I...>;
+template<std::size_t... Index>
+using index_sequence = std::index_sequence<Index...>;
 
 template<std::size_t N>
 using make_index_sequence = std::make_index_sequence<N>;
@@ -358,11 +350,11 @@ using index_sequence_for = std::index_sequence_for<T...>;
 
 #else
 
-template<typename T, T... I>
+template<typename T, T... Index>
 struct integer_sequence {};
 
-template<std::size_t... I>
-using index_sequence = integer_sequence<std::size_t, I...>;
+template<std::size_t... Index>
+using index_sequence = integer_sequence<std::size_t, Index...>;
 
 namespace detail {
 
@@ -393,10 +385,10 @@ struct iseq_identity
 template<typename T1, typename T2>
 struct append_integer_sequence {};
 
-template<typename T, T... I, T... J>
-struct append_integer_sequence<integer_sequence<T, I...>, integer_sequence<T, J...>>
+template<typename T, T... Index, T... J>
+struct append_integer_sequence<integer_sequence<T, Index...>, integer_sequence<T, J...>>
 {
-    using type = integer_sequence<T, I..., (J + sizeof...(I))...>;
+    using type = integer_sequence<T, Index..., (J + sizeof...(I))...>;
 };
 
 template<typename T, T N>
@@ -443,9 +435,5 @@ using index_sequence_for = make_integer_sequence<std::size_t, sizeof...(T)>;
 #endif 
 
 }}}} // namespaces
-
-#ifdef BOOST_MATH_PUSHED_I
-#  pragma push_macro("I")
-#endif
 
 #endif // BOOST_MATH_TOOLS_MP

--- a/include/boost/math/tools/mp.hpp
+++ b/include/boost/math/tools/mp.hpp
@@ -16,8 +16,11 @@
 #include <utility>
 
 #ifdef _MSC_VER
-#  pragma push_macro("I")
-#  undef I
+#  ifdef I
+#    pragma push_macro("I")
+#    define BOOST_MATH_PUSHED_I
+#    undef I 
+#  endif
 #endif
 
 namespace boost { namespace math { namespace tools { namespace meta_programming {
@@ -441,8 +444,8 @@ using index_sequence_for = make_integer_sequence<std::size_t, sizeof...(T)>;
 
 }}}} // namespaces
 
-#ifdef _MSC_VER
-#  pragma pop_macro("I")
+#ifdef BOOST_MATH_PUSHED_I
+#  pragma push_macro("I")
 #endif
 
 #endif // BOOST_MATH_TOOLS_MP

--- a/include/boost/math/tools/mp.hpp
+++ b/include/boost/math/tools/mp.hpp
@@ -17,6 +17,7 @@
 
 #ifdef _MSC_VER
 #  pragma push_macro("I")
+#  undef I
 #endif
 
 namespace boost { namespace math { namespace tools { namespace meta_programming {

--- a/include/boost/math/tools/mp.hpp
+++ b/include/boost/math/tools/mp.hpp
@@ -15,6 +15,10 @@
 #include <cstddef>
 #include <utility>
 
+#ifdef _MSC_VER
+#  pragma push_macro("I")
+#endif
+
 namespace boost { namespace math { namespace tools { namespace meta_programming {
 
 // Types:
@@ -435,5 +439,9 @@ using index_sequence_for = make_integer_sequence<std::size_t, sizeof...(T)>;
 #endif 
 
 }}}} // namespaces
+
+#ifdef _MSC_VER
+#  pragma pop_macro("I")
+#endif
 
 #endif // BOOST_MATH_TOOLS_MP

--- a/include/boost/math/tools/mp.hpp
+++ b/include/boost/math/tools/mp.hpp
@@ -388,7 +388,7 @@ struct append_integer_sequence {};
 template<typename T, T... Index, T... J>
 struct append_integer_sequence<integer_sequence<T, Index...>, integer_sequence<T, J...>>
 {
-    using type = integer_sequence<T, Index..., (J + sizeof...(I))...>;
+    using type = integer_sequence<T, Index..., (J + sizeof...(Index))...>;
 };
 
 template<typename T, T N>

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -292,15 +292,15 @@ public:
        normalize();
    }
 
-   template <class I>
-   polynomial(I first, I last)
+   template <class Iterator>
+   polynomial(Iterator first, Iterator last)
       : m_data(first, last)
    {
        normalize();
    }
 
-   template <class I>
-   polynomial(I first, unsigned length)
+   template <class Iterator>
+   polynomial(Iterator first, unsigned length)
       : m_data(first, std::next(first, length + 1))
    {
        normalize();

--- a/include/boost/math/tools/throw_exception.hpp
+++ b/include/boost/math/tools/throw_exception.hpp
@@ -10,8 +10,17 @@
 
 #ifndef BOOST_MATH_STANDALONE
 
+#if defined(_MSC_VER) || defined(__GNUC__)
+# pragma push_macro( "I" )
+# undef I
+#endif
+
 #include <boost/throw_exception.hpp>
 #define BOOST_MATH_THROW_EXCEPTION(expr) boost::throw_exception(expr);
+
+#if defined(_MSC_VER) || defined(__GNUC__)
+# pragma pop_macro( "I" )
+#endif
 
 #else // Standalone mode - use standard library facilities
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -904,6 +904,7 @@ test-suite distribution_tests :
    [ run scipy_issue_17916_nct.cpp ../../test/build//boost_unit_test_framework  ]
    [ run scipy_issue_18302.cpp ../../test/build//boost_unit_test_framework  ]
    [ run scipy_issue_18511.cpp ../../test/build//boost_unit_test_framework ]
+   [ compile scipy_issue_19762.cpp ]
 ;
 
 test-suite new_floats : 

--- a/test/scipy_issue_19762.cpp
+++ b/test/scipy_issue_19762.cpp
@@ -7,6 +7,7 @@
 
 #include <complex.h>
 #include <boost/math/special_functions.hpp>
+#include <boost/math/distributions.hpp>
 
 int main()
 {

--- a/test/scipy_issue_19762.cpp
+++ b/test/scipy_issue_19762.cpp
@@ -1,0 +1,14 @@
+// Copyright John Maddock, 2023
+// Use, modification and distribution are subject to the
+// Boost Software License, Version 1.0. (See accompanying file
+// LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// https://github.com/scipy/scipy/issues/19726#issuecomment-1866143568
+
+#include <complex.h>
+#include <boost/math/special_functions.hpp>
+
+int main()
+{
+   return 0;
+}


### PR DESCRIPTION
@jzmaddock. I think pushing and popping the value of "I" seems to be the safest workaround unless you have a better idea.