### PR TITLE
Avoid unused variable warning in ibeta_inverse

### DIFF
--- a/include/boost/math/special_functions/detail/ibeta_inverse.hpp
+++ b/include/boost/math/special_functions/detail/ibeta_inverse.hpp
@@ -15,6 +15,8 @@
 #include <boost/math/special_functions/erf.hpp>
 #include <boost/math/tools/roots.hpp>
 #include <boost/math/special_functions/detail/t_distribution_inv.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/math/tools/precision.hpp>
 
 namespace boost{ namespace math{ namespace detail{
 
@@ -26,8 +28,8 @@ template <class T>
 struct temme_root_finder
 {
    temme_root_finder(const T t_, const T a_) : t(t_), a(a_) {
-      const T x_extrema = 1 / (1 + a);
-      BOOST_MATH_ASSERT(0 < x_extrema && x_extrema < 1);
+      BOOST_MATH_ASSERT(
+         math::tools::epsilon<T>() <= a && !(boost::math::isinf)(a));
    }
 
    boost::math::tuple<T, T> operator()(T x)


### PR DESCRIPTION
Using the `ibeta_inverse` function currently gives an unused variable warning at compile time since there is a variable that is only used in an assert:

```cpp
      const T x_extrema = 1 / (1 + a);
      BOOST_MATH_ASSERT(0 < x_extrema && x_extrema < 1);
```

This can be avoided (and a few operations saved) by checking whether `a` is bounded by the values which would result in `x_extrema` failing the assert:

```cpp
      BOOST_MATH_ASSERT(
         std::numeric_limits<T>::epsilon() < a
         && a < std::numeric_limits<T>::infinity());
```