### PR TITLE
Try LCOV Exclude on BIG_CONSTANT

### DIFF
--- a/include/boost/math/tools/big_constant.hpp
+++ b/include/boost/math/tools/big_constant.hpp
@@ -1,5 +1,6 @@
 
 //  Copyright (c) 2011 John Maddock
+//  Copyright (c) 2024 Christopher Kormanyos
 //  Use, modification and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -62,7 +63,7 @@ inline T make_big_value(largest_float, const char* s, std::false_type const&, st
 template <typename T>
 inline T make_big_value(largest_float, const char*, std::false_type const&, std::false_type const&)
 {
-   static_assert(sizeof(T) == 0, "Type is unsupported in standalone mode. Please disable and try again.");
+   static_assert(sizeof(T) == 0, "Type is unsupported in standalone mode. Please disable and try again."); // LCOV_EXCL_LINE
 }
 #endif
 template <class T>
@@ -83,16 +84,15 @@ inline constexpr T make_big_value(largest_float, const char* s, std::false_type 
           || std::is_floating_point<T>::value \
           || (boost::math::tools::numeric_traits<T>::is_specialized && \
           (boost::math::tools::numeric_traits<T>::digits10 <= boost::math::tools::numeric_traits<boost::math::tools::largest_float>::digits10))) >(), \
-      std::is_constructible<T, const char*>())
+      std::is_constructible<T, const char*>()) // LCOV_EXCL_LINE
 //
 // For constants too huge for any conceivable long double (and which generate compiler errors if we try and declare them as such):
 //
 #define BOOST_MATH_HUGE_CONSTANT(T, D, x)\
    boost::math::tools::make_big_value<T>(0.0L, BOOST_STRINGIZE(x), \
    std::integral_constant<bool, std::is_floating_point<T>::value || (boost::math::tools::numeric_traits<T>::is_specialized && boost::math::tools::numeric_traits<T>::max_exponent <= boost::math::tools::numeric_traits<boost::math::tools::largest_float>::max_exponent && boost::math::tools::numeric_traits<T>::digits <= boost::math::tools::numeric_traits<boost::math::tools::largest_float>::digits)>(), \
-   std::is_constructible<T, const char*>())
+   std::is_constructible<T, const char*>()) // LCOV_EXCL_LINE
 
 }}} // namespaces
 
 #endif
-

--- a/include/boost/math/tools/big_constant.hpp
+++ b/include/boost/math/tools/big_constant.hpp
@@ -37,10 +37,10 @@ struct numeric_traits<__float128>
 };
 #elif LDBL_DIG > DBL_DIG
 typedef long double largest_float;
-#define BOOST_MATH_LARGEST_FLOAT_C(x) x##L
+#define BOOST_MATH_LARGEST_FLOAT_C(x) x##L // LCOV_EXCL_LINE
 #else
 typedef double largest_float;
-#define BOOST_MATH_LARGEST_FLOAT_C(x) x
+#define BOOST_MATH_LARGEST_FLOAT_C(x) x // LCOV_EXCL_LINE
 #endif
 
 template <class T>
@@ -75,16 +75,16 @@ inline constexpr T make_big_value(largest_float, const char* s, std::false_type 
 //
 // For constants which might fit in a long double (if it's big enough):
 //
-#define BOOST_MATH_BIG_CONSTANT(T, D, x)\
-   boost::math::tools::make_big_value<T>(\
-      BOOST_MATH_LARGEST_FLOAT_C(x), \
-      BOOST_STRINGIZE(x), \
-      std::integral_constant<bool, (std::is_convertible<boost::math::tools::largest_float, T>::value) && \
-      ((D <= boost::math::tools::numeric_traits<boost::math::tools::largest_float>::digits) \
-          || std::is_floating_point<T>::value \
-          || (boost::math::tools::numeric_traits<T>::is_specialized && \
-          (boost::math::tools::numeric_traits<T>::digits10 <= boost::math::tools::numeric_traits<boost::math::tools::largest_float>::digits10))) >(), \
-      std::is_constructible<T, const char*>()) // LCOV_EXCL_LINE
+#define BOOST_MATH_BIG_CONSTANT(T, D, x)    /* LCOV_EXCL_LINE */ \
+   boost::math::tools::make_big_value<T>(   /* LCOV_EXCL_LINE */ \
+      BOOST_MATH_LARGEST_FLOAT_C(x),        /* LCOV_EXCL_LINE */ \
+      BOOST_STRINGIZE(x),                   /* LCOV_EXCL_LINE */ \
+      std::integral_constant<bool, (std::is_convertible<boost::math::tools::largest_float, T>::value) &&  /* LCOV_EXCL_LINE */ \
+      ((D <= boost::math::tools::numeric_traits<boost::math::tools::largest_float>::digits)               /* LCOV_EXCL_LINE */ \
+          || std::is_floating_point<T>::value                                                             /* LCOV_EXCL_LINE */ \
+          || (boost::math::tools::numeric_traits<T>::is_specialized &&                                    /* LCOV_EXCL_LINE */ \
+          (boost::math::tools::numeric_traits<T>::digits10 <= boost::math::tools::numeric_traits<boost::math::tools::largest_float>::digits10))) >(), /* LCOV_EXCL_LINE */ \
+      std::is_constructible<T, const char*>()) /* LCOV_EXCL_LINE */
 //
 // For constants too huge for any conceivable long double (and which generate compiler errors if we try and declare them as such):
 //


### PR DESCRIPTION
The purpose of this PR is to see if `LCOV_EXCL_LINE` can/should simply be applied to big-constants and if this simple change _catches_ all of these lines. Also we ponder if this is philosophically the right fix for big-constants?