### PR TITLE
Run and cover compile-test instantiation

### DIFF
--- a/include/boost/math/concepts/distributions.hpp
+++ b/include/boost/math/concepts/distributions.hpp
@@ -343,7 +343,7 @@ struct DistributionConcept
    template <class R, class P>
    static void test_extra_members(const boost::math::hypergeometric_distribution<R, P>& d)
    {
-      unsigned u = d.defective();
+      unsigned u = static_cast<unsigned>(d.defective());
       u = d.sample_count();
       u = d.total();
       suppress_unused_variable_warning(u);

--- a/include/boost/math/distributions/cauchy.hpp
+++ b/include/boost/math/distributions/cauchy.hpp
@@ -17,8 +17,9 @@
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/distributions/complement.hpp>
 #include <boost/math/distributions/detail/common_error_handling.hpp>
-#include <utility>
+
 #include <cmath>
+#include <utility>
 
 namespace boost{ namespace math
 {

--- a/include/boost/math/distributions/cauchy.hpp
+++ b/include/boost/math/distributions/cauchy.hpp
@@ -276,29 +276,30 @@ inline RealType quantile(const complemented2_type<cauchy_distribution<RealType, 
 
 template <class RealType, class Policy>
 inline RealType mean(const cauchy_distribution<RealType, Policy>&)
-{  // There is no mean:
-   typedef typename Policy::assert_undefined_type assert_type;
-   static_assert(assert_type::value == 0, "assert type is undefined");
-
-   return policies::raise_domain_error<RealType>(
-      "boost::math::mean(cauchy<%1%>&)",
-      "The Cauchy distribution does not have a mean: "
-      "the only possible return value is %1%.",
-      std::numeric_limits<RealType>::quiet_NaN(), Policy());
+{
+   // There is no mean:
+   return
+      policies::raise_domain_error<RealType>
+      (
+         "boost::math::mean(cauchy<%1%>&)",
+         "The Cauchy distribution does not have a mean: "
+         "the only possible return value is %1%.",
+         std::numeric_limits<RealType>::quiet_NaN(), Policy()
+      );
 }
 
 template <class RealType, class Policy>
 inline RealType variance(const cauchy_distribution<RealType, Policy>& /*dist*/)
 {
    // There is no variance:
-   typedef typename Policy::assert_undefined_type assert_type;
-   static_assert(assert_type::value == 0, "assert type is undefined");
-
-   return policies::raise_domain_error<RealType>(
-      "boost::math::variance(cauchy<%1%>&)",
-      "The Cauchy distribution does not have a variance: "
-      "the only possible return value is %1%.",
-      std::numeric_limits<RealType>::quiet_NaN(), Policy());
+   return
+      policies::raise_domain_error<RealType>
+      (
+         "boost::math::variance(cauchy<%1%>&)",
+         "The Cauchy distribution does not have a variance: "
+         "the only possible return value is %1%.",
+         std::numeric_limits<RealType>::quiet_NaN(), Policy()
+      );
 }
 
 template <class RealType, class Policy>
@@ -316,42 +317,42 @@ template <class RealType, class Policy>
 inline RealType skewness(const cauchy_distribution<RealType, Policy>& /*dist*/)
 {
    // There is no skewness:
-   typedef typename Policy::assert_undefined_type assert_type;
-   static_assert(assert_type::value == 0, "assert type is undefined");
-
-   return policies::raise_domain_error<RealType>(
-      "boost::math::skewness(cauchy<%1%>&)",
-      "The Cauchy distribution does not have a skewness: "
-      "the only possible return value is %1%.",
-      std::numeric_limits<RealType>::quiet_NaN(), Policy()); // infinity?
+   return
+      policies::raise_domain_error<RealType>
+      (
+         "boost::math::skewness(cauchy<%1%>&)",
+         "The Cauchy distribution does not have a skewness: "
+         "the only possible return value is %1%.",
+         std::numeric_limits<RealType>::quiet_NaN(), Policy()
+      );
 }
 
 template <class RealType, class Policy>
 inline RealType kurtosis(const cauchy_distribution<RealType, Policy>& /*dist*/)
 {
    // There is no kurtosis:
-   typedef typename Policy::assert_undefined_type assert_type;
-   static_assert(assert_type::value == 0, "assert type is undefined");
-
-   return policies::raise_domain_error<RealType>(
-      "boost::math::kurtosis(cauchy<%1%>&)",
-      "The Cauchy distribution does not have a kurtosis: "
-      "the only possible return value is %1%.",
-      std::numeric_limits<RealType>::quiet_NaN(), Policy());
+   return
+      policies::raise_domain_error<RealType>
+      (
+         "boost::math::kurtosis(cauchy<%1%>&)",
+         "The Cauchy distribution does not have a kurtosis: "
+         "the only possible return value is %1%.",
+         std::numeric_limits<RealType>::quiet_NaN(), Policy()
+      );
 }
 
 template <class RealType, class Policy>
 inline RealType kurtosis_excess(const cauchy_distribution<RealType, Policy>& /*dist*/)
 {
    // There is no kurtosis excess:
-   typedef typename Policy::assert_undefined_type assert_type;
-   static_assert(assert_type::value == 0, "assert type is undefined");
-
-   return policies::raise_domain_error<RealType>(
-      "boost::math::kurtosis_excess(cauchy<%1%>&)",
-      "The Cauchy distribution does not have a kurtosis: "
-      "the only possible return value is %1%.",
-      std::numeric_limits<RealType>::quiet_NaN(), Policy());
+   return
+      policies::raise_domain_error<RealType>
+      (
+         "boost::math::kurtosis_excess(cauchy<%1%>&)",
+         "The Cauchy distribution does not have a kurtosis: "
+         "the only possible return value is %1%.",
+         std::numeric_limits<RealType>::quiet_NaN(), Policy()
+      );
 }
 
 template <class RealType, class Policy>

--- a/include/boost/math/distributions/detail/hypergeometric_pdf.hpp
+++ b/include/boost/math/distributions/detail/hypergeometric_pdf.hpp
@@ -321,7 +321,8 @@ T hypergeometric_pdf_prime_loop_imp(hypergeometric_pdf_prime_loop_data& data, hy
             // to sidestep the issue:
             //
             hypergeometric_pdf_prime_loop_result_entry<T> t = { p, &result };
-            data.current_prime = prime(++data.prime_index);
+            ++data.prime_index;
+            data.current_prime = prime(static_cast<unsigned>(data.prime_index));
             return hypergeometric_pdf_prime_loop_imp<T>(data, t);
          }
          if((p < 1) && (tools::min_value<T>() / p > result.value))
@@ -331,12 +332,14 @@ T hypergeometric_pdf_prime_loop_imp(hypergeometric_pdf_prime_loop_data& data, hy
             // to sidestep the issue:
             //
             hypergeometric_pdf_prime_loop_result_entry<T> t = { p, &result };
-            data.current_prime = prime(++data.prime_index);
+            ++data.prime_index;
+            data.current_prime = prime(static_cast<unsigned>(data.prime_index));
             return hypergeometric_pdf_prime_loop_imp<T>(data, t);
          }
          result.value *= p;
       }
-      data.current_prime = prime(++data.prime_index);
+      ++data.prime_index;
+      data.current_prime = prime(static_cast<unsigned>(data.prime_index));
    }
    //
    // When we get to here we have run out of prime factors,
@@ -397,16 +400,16 @@ T hypergeometric_pdf_factorial_imp(std::uint64_t x, std::uint64_t r, std::uint64
    BOOST_MATH_ASSERT(N <= boost::math::max_factorial<T>::value);
    T result = boost::math::unchecked_factorial<T>(n);
    T num[3] = {
-      boost::math::unchecked_factorial<T>(r),
-      boost::math::unchecked_factorial<T>(N - n),
-      boost::math::unchecked_factorial<T>(N - r)
+      boost::math::unchecked_factorial<T>(static_cast<unsigned>(r)),
+      boost::math::unchecked_factorial<T>(static_cast<unsigned>(N - n)),
+      boost::math::unchecked_factorial<T>(static_cast<unsigned>(N - r))
    };
    T denom[5] = {
-      boost::math::unchecked_factorial<T>(N),
-      boost::math::unchecked_factorial<T>(x),
-      boost::math::unchecked_factorial<T>(n - x),
-      boost::math::unchecked_factorial<T>(r - x),
-      boost::math::unchecked_factorial<T>(N - n - r + x)
+      boost::math::unchecked_factorial<T>(static_cast<unsigned>(N)),
+      boost::math::unchecked_factorial<T>(static_cast<unsigned>(x)),
+      boost::math::unchecked_factorial<T>(static_cast<unsigned>(n - x)),
+      boost::math::unchecked_factorial<T>(static_cast<unsigned>(r - x)),
+      boost::math::unchecked_factorial<T>(static_cast<unsigned>(N - n - r + x))
    };
    std::size_t i = 0;
    std::size_t j = 0;

--- a/include/boost/math/distributions/non_central_beta.hpp
+++ b/include/boost/math/distributions/non_central_beta.hpp
@@ -806,24 +806,34 @@ namespace boost
       // standard_deviation provided by derived accessors.
       template <class RealType, class Policy>
       inline RealType skewness(const non_central_beta_distribution<RealType, Policy>& /*dist*/)
-      { // skewness = sqrt(l).
+      {
+         // LCOV_EXCL_START
          const char* function = "boost::math::non_central_beta_distribution<%1%>::skewness()";
-         typedef typename Policy::assert_undefined_type assert_type;
-         static_assert(assert_type::value == 0, "Assert type is undefined.");
 
-         return policies::raise_evaluation_error<RealType>(function, "This function is not yet implemented, the only sensible result is %1%.", // LCOV_EXCL_LINE
-            std::numeric_limits<RealType>::quiet_NaN(), Policy()); // infinity?  LCOV_EXCL_LINE
+         return
+            policies::raise_evaluation_error<RealType>
+            (
+               function,
+               "This function is not yet implemented, the only sensible result is %1%.", // LCOV_EXCL_LINE
+               std::numeric_limits<RealType>::quiet_NaN(), Policy()
+            );
+         // LCOV_EXCL_STOP
       }
 
       template <class RealType, class Policy>
       inline RealType kurtosis_excess(const non_central_beta_distribution<RealType, Policy>& /*dist*/)
       {
+         // LCOV_EXCL_START
          const char* function = "boost::math::non_central_beta_distribution<%1%>::kurtosis_excess()";
-         typedef typename Policy::assert_undefined_type assert_type;
-         static_assert(assert_type::value == 0, "Assert type is undefined.");
 
-         return policies::raise_evaluation_error<RealType>(function, "This function is not yet implemented, the only sensible result is %1%.", // LCOV_EXCL_LINE
-            std::numeric_limits<RealType>::quiet_NaN(), Policy()); // infinity?  LCOV_EXCL_LINE
+         return
+            policies::raise_evaluation_error<RealType>
+            (
+               function,
+               "This function is not yet implemented, the only sensible result is %1%.",
+               std::numeric_limits<RealType>::quiet_NaN(), Policy()
+            );
+         // LCOV_EXCL_STOP
       } // kurtosis_excess
 
       template <class RealType, class Policy>

--- a/include/boost/math/special_functions/detail/bessel_y0.hpp
+++ b/include/boost/math/special_functions/detail/bessel_y0.hpp
@@ -145,6 +145,8 @@ T bessel_y0(T x, const Policy&)
 
     static const char* function = "boost::math::bessel_y0<%1%>(%1%,%1%)";
 
+    static_cast<void>(function[0U]);
+
     BOOST_MATH_ASSERT(x > 0);
 
     if (x <= 3)                       // x in (0, 3]

--- a/include/boost/math/special_functions/lambert_w.hpp
+++ b/include/boost/math/special_functions/lambert_w.hpp
@@ -1822,12 +1822,12 @@ T lambert_wm1_imp(const T z, const Policy&  pol)
       "Argument z = %1% is too small (z < -std::numeric_limits<T>::min so denormalized) for Lambert W-1 branch!",
       z, pol);
   }
-  if (z == -boost::math::constants::exp_minus_one<T>()) // == singularity/branch point z = -exp(-1) = -3.6787944.
+  if (z == -boost::math::constants::exp_minus_one<T>()) // == singularity/branch point z = -exp(-1) = -0.36787944.
   { // At singularity, so return exactly -1.
     return -static_cast<T>(1);
   }
   // z is too negative for the W-1 (or W0) branch.
-  if (z < -boost::math::constants::exp_minus_one<T>()) // > singularity/branch point z = -exp(-1) = -3.6787944.
+  if (z < -boost::math::constants::exp_minus_one<T>()) // > singularity/branch point z = -exp(-1) = -0.36787944.
   {
     return policies::raise_domain_error(function,
       "Argument z = %1% is out of range (z < -exp(-1) = -3.6787944... <= 0) for Lambert W-1 (or W0) branch!",

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -226,6 +226,7 @@ test-suite special_fun :
    [ run test_factorials.cpp pch ../../test/build//boost_unit_test_framework  ]
    [ run test_gamma.cpp test_instances//test_instances pch_light ../../test/build//boost_unit_test_framework  ]
    [ run test_gamma_edge.cpp ]
+   [ run test_compile_test_and_run.cpp ]
    [ run test_gamma_mp.cpp ../../test/build//boost_unit_test_framework : : : release <define>TEST=1 [ check-target-builds ../config//is_ci_sanitizer_run "Sanitizer CI run" : <build>no ] :  test_gamma_mp_1 ]
    [ run test_gamma_mp.cpp ../../test/build//boost_unit_test_framework : : : release <define>TEST=2 [ check-target-builds ../config//is_ci_sanitizer_run "Sanitizer CI run" : <build>no ] : test_gamma_mp_2 ]
    [ run test_gamma_mp.cpp ../../test/build//boost_unit_test_framework : : : release <define>TEST=3 [ check-target-builds ../config//is_ci_sanitizer_run "Sanitizer CI run" : <build>no ] : test_gamma_mp_3 ]

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -17,13 +17,15 @@ struct instantiate_runner_result
 template <class RealType>
 bool instantiate_runner_result<RealType>::value;
 
-#ifndef BOOST_MATH_ASSERT_UNDEFINED_POLICY
-#  define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
+#if defined(BOOST_MATH_ASSERT_UNDEFINED_POLICY)
+#undef BOOST_MATH_ASSERT_UNDEFINED_POLICY
 #endif
+
+#define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
 
 #include <boost/math/tools/config.hpp>
 
-#if (!defined(BOOST_MATH_STANDALONE) && !defined(__CYGWIN__))
+#if !defined(BOOST_MATH_STANDALONE)
 
 #include <boost/math/distributions.hpp>
 
@@ -88,7 +90,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<bernoulli_distribution<RealType> > >();
    function_requires<DistributionConcept<beta_distribution<RealType> > >();
    function_requires<DistributionConcept<binomial_distribution<RealType> > >();
-   //function_requires<DistributionConcept<cauchy_distribution<RealType> > >();
+   function_requires<DistributionConcept<cauchy_distribution<RealType> > >();
    function_requires<DistributionConcept<chi_squared_distribution<RealType> > >();
    function_requires<DistributionConcept<exponential_distribution<RealType> > >();
    function_requires<DistributionConcept<extreme_value_distribution<RealType> > >();
@@ -125,7 +127,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<bernoulli_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<beta_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<binomial_distribution<RealType, test_policy> > >();
-   //function_requires<DistributionConcept<cauchy_distribution<RealType, test_policy> > >();
+   function_requires<DistributionConcept<cauchy_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<chi_squared_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<exponential_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<extreme_value_distribution<RealType, test_policy> > >();

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -926,49 +926,28 @@ void instantiate(RealType)
    boost::math::airy_ai_zero<RealType>(i, i, oi, pol);
    boost::math::airy_bi_zero<RealType>(i, i, oi, pol);
 
-   try
+   boost::math::hypergeometric_1F0(i, v2, pol);
    {
-      boost::math::hypergeometric_1F0(i, v2, pol);
-   }
-   catch(std::domain_error& err)
-   {
-      static_cast<void>(err.what());
-   }
-   try
-   {
-      boost::math::hypergeometric_1F0(v1, i, pol);
-   }
-   catch(std::domain_error& err)
-   {
-      static_cast<void>(err.what());
+      using std::floor;
+      const auto v1_special = static_cast<RealType>(floor(v1) * 2);
+
+      boost::math::hypergeometric_1F0(v1_special, i, pol);
    }
    boost::math::hypergeometric_1F0(i, i, pol);
    boost::math::hypergeometric_0F1(i, v2, pol);
    boost::math::hypergeometric_0F1(v1, i, pol);
    boost::math::hypergeometric_0F1(i, i, pol);
-   try
    {
-      boost::math::hypergeometric_2F0(i, v2, v3, pol);
+      const auto i_negate = -i;
+
+      boost::math::hypergeometric_2F0(i_negate, v2, v3, pol);
+      boost::math::hypergeometric_2F0(v1, i_negate, v3, pol);
    }
-   catch(std::overflow_error& err)
    {
-      static_cast<void>(err.what());
-   }
-   try
-   {
-      boost::math::hypergeometric_2F0(v1, i, v3, pol);
-   }
-   catch(std::overflow_error& err)
-   {
-      static_cast<void>(err.what());
-   }
-   try
-   {
-      boost::math::hypergeometric_2F0(v1, v2, i, pol);
-   }
-   catch(std::overflow_error& err)
-   {
-      static_cast<void>(err.what());
+      using std::floor;
+      const auto v1_special = static_cast<RealType>(floor(v1) * 2);
+
+      boost::math::hypergeometric_2F0(v1_special, v2, i, pol);
    }
 #if !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_LAMBDAS) && !defined(BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX) && !defined(BOOST_NO_CXX11_HDR_TUPLE)
    boost::math::hypergeometric_1F1(i, v2, v3, pol);

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -8,6 +8,10 @@
 #ifndef BOOST_LIBS_MATH_TEST_INSTANTIATE_HPP
 #define BOOST_LIBS_MATH_TEST_INSTANTIATE_HPP
 
+#if !defined(BOOST_MATH_ASSERT_UNDEFINED_POLICY)
+#define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
+#endif
+
 template <class RealType>
 struct instantiate_runner_result
 {
@@ -16,12 +20,6 @@ struct instantiate_runner_result
 
 template <class RealType>
 bool instantiate_runner_result<RealType>::value;
-
-#if defined(BOOST_MATH_ASSERT_UNDEFINED_POLICY)
-#undef BOOST_MATH_ASSERT_UNDEFINED_POLICY
-#endif
-
-#define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
 
 #include <boost/math/tools/config.hpp>
 
@@ -90,7 +88,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<bernoulli_distribution<RealType> > >();
    function_requires<DistributionConcept<beta_distribution<RealType> > >();
    function_requires<DistributionConcept<binomial_distribution<RealType> > >();
-   //function_requires<DistributionConcept<cauchy_distribution<RealType> > >();
+   function_requires<DistributionConcept<cauchy_distribution<RealType> > >();
    function_requires<DistributionConcept<chi_squared_distribution<RealType> > >();
    function_requires<DistributionConcept<exponential_distribution<RealType> > >();
    function_requires<DistributionConcept<extreme_value_distribution<RealType> > >();
@@ -108,7 +106,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<lognormal_distribution<RealType> > >();
    function_requires<DistributionConcept<negative_binomial_distribution<RealType> > >();
    function_requires<DistributionConcept<non_central_chi_squared_distribution<RealType> > >();
-   //function_requires<DistributionConcept<non_central_beta_distribution<RealType> > >();
+   function_requires<DistributionConcept<non_central_beta_distribution<RealType> > >();
    function_requires<DistributionConcept<non_central_f_distribution<RealType> > >();
    function_requires<DistributionConcept<non_central_t_distribution<RealType> > >();
    function_requires<DistributionConcept<normal_distribution<RealType> > >();
@@ -127,7 +125,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<bernoulli_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<beta_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<binomial_distribution<RealType, test_policy> > >();
-   //function_requires<DistributionConcept<cauchy_distribution<RealType, test_policy> > >();
+   function_requires<DistributionConcept<cauchy_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<chi_squared_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<exponential_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<extreme_value_distribution<RealType, test_policy> > >();
@@ -144,7 +142,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<lognormal_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<negative_binomial_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<non_central_chi_squared_distribution<RealType, test_policy> > >();
-   //function_requires<DistributionConcept<non_central_beta_distribution<RealType, test_policy> > >();
+   function_requires<DistributionConcept<non_central_beta_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<non_central_f_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<non_central_t_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<normal_distribution<RealType, test_policy> > >();
@@ -162,7 +160,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<dist_test::bernoulli > >();
    function_requires<DistributionConcept<dist_test::beta > >();
    function_requires<DistributionConcept<dist_test::binomial > >();
-   //function_requires<DistributionConcept<dist_test::cauchy > >();
+   function_requires<DistributionConcept<dist_test::cauchy > >();
    function_requires<DistributionConcept<dist_test::chi_squared > >();
    function_requires<DistributionConcept<dist_test::exponential > >();
    function_requires<DistributionConcept<dist_test::extreme_value > >();
@@ -178,7 +176,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<dist_test::lognormal > >();
    function_requires<DistributionConcept<dist_test::negative_binomial > >();
    function_requires<DistributionConcept<dist_test::non_central_chi_squared > >();
-   //function_requires<DistributionConcept<dist_test::non_central_beta > >();
+   function_requires<DistributionConcept<dist_test::non_central_beta > >();
    function_requires<DistributionConcept<dist_test::non_central_f > >();
    function_requires<DistributionConcept<dist_test::non_central_t > >();
    function_requires<DistributionConcept<dist_test::normal > >();

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -88,7 +88,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<bernoulli_distribution<RealType> > >();
    function_requires<DistributionConcept<beta_distribution<RealType> > >();
    function_requires<DistributionConcept<binomial_distribution<RealType> > >();
-   function_requires<DistributionConcept<cauchy_distribution<RealType> > >();
+   //function_requires<DistributionConcept<cauchy_distribution<RealType> > >();
    function_requires<DistributionConcept<chi_squared_distribution<RealType> > >();
    function_requires<DistributionConcept<exponential_distribution<RealType> > >();
    function_requires<DistributionConcept<extreme_value_distribution<RealType> > >();
@@ -125,7 +125,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<bernoulli_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<beta_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<binomial_distribution<RealType, test_policy> > >();
-   function_requires<DistributionConcept<cauchy_distribution<RealType, test_policy> > >();
+   //function_requires<DistributionConcept<cauchy_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<chi_squared_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<exponential_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<extreme_value_distribution<RealType, test_policy> > >();

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -8,6 +8,15 @@
 #ifndef BOOST_LIBS_MATH_TEST_INSTANTIATE_HPP
 #define BOOST_LIBS_MATH_TEST_INSTANTIATE_HPP
 
+template <class RealType>
+struct instantiate_runner_result
+{
+   static bool value;
+};
+
+template <class RealType>
+bool instantiate_runner_result<RealType>::value;
+
 #ifndef BOOST_MATH_ASSERT_UNDEFINED_POLICY
 #  define BOOST_MATH_ASSERT_UNDEFINED_POLICY false
 #endif
@@ -21,16 +30,6 @@
 #include <boost/math/special_functions.hpp>
 #include <boost/math/concepts/distributions.hpp>
 #include <boost/concept_archetype.hpp>
-
-template <class RealType>
-struct instantiate_runner_result
-{
-   static auto get_value() -> bool { return value; }
-   static bool value;
-};
-
-template <class RealType>
-bool instantiate_runner_result<RealType>::value;
 
 #ifndef BOOST_MATH_INSTANTIATE_MINIMUM
 
@@ -1809,7 +1808,10 @@ void instantiate_mixed(RealType)
 #else // Standalone mode
 
 template <typename T>
-void instantiate(T) {}
+void instantiate(T)
+{
+   instantiate_runner_result<RealType>::value = true;
+}
 
 template <typename T>
 void instantiate_mixed(T) {}

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -1,5 +1,6 @@
 //  Copyright John Maddock 2006.
 //  Copyright Paul A. Bristow 2007, 2010.
+//  Copyright Christopher Kormanyos 2024.
 //  Use, modification and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -59,8 +60,19 @@ BOOST_MATH_DECLARE_DISTRIBUTIONS(double, test_policy)
 #endif
 
 template <class RealType>
+struct instantiate_runner_result
+{
+   static bool value;
+};
+
+template <class RealType>
+bool instantiate_runner_result<RealType>::value { };
+
+template <class RealType>
 void instantiate(RealType)
 {
+   instantiate_runner_result<RealType>::value = false;
+
    using namespace boost;
    using namespace boost::math;
    using namespace boost::math::concepts;
@@ -199,10 +211,14 @@ void instantiate(RealType)
    boost::math::tgamma_delta_ratio(v1, v2);
    boost::math::factorial<RealType>(i);
    boost::math::unchecked_factorial<RealType>(i);
-   i = boost::math::max_factorial<RealType>::value;
-   boost::math::double_factorial<RealType>(i);
-   boost::math::rising_factorial(v1, i);
-   boost::math::falling_factorial(v1, i);
+   {
+      const auto i_fact = boost::math::max_factorial<RealType>::value;
+
+      boost::math::double_factorial<RealType>(i_fact);
+      boost::math::rising_factorial(v1, i_fact);
+      boost::math::falling_factorial(v1, i_fact);
+   }
+   i = 4;
    boost::math::tgamma(v1, v2);
    boost::math::tgamma_lower(v1, v2);
    boost::math::gamma_p(v1, v2);
@@ -262,8 +278,11 @@ void instantiate(RealType)
    boost::math::chebyshev_t(1, v1);
    boost::math::chebyshev_u(1, v1);
    boost::math::chebyshev_t_prime(1, v1);
-   const RealType v1_other = v1;
-   boost::math::chebyshev_clenshaw_recurrence(&v1_other, 0, v2);
+   {
+      const RealType v1_other_const = v1;
+
+      boost::math::chebyshev_clenshaw_recurrence(&v1_other_const, 0, v2);
+   }
    boost::math::spherical_harmonic_r(2, 1, v1, v2);
    boost::math::spherical_harmonic_i(2, 1, v1, v2);
    boost::math::ellint_1(v1);
@@ -541,7 +560,11 @@ void instantiate(RealType)
    boost::math::chebyshev_t(1, 2 * v1);
    boost::math::chebyshev_u(1, 2 * v1);
    boost::math::chebyshev_t_prime(1, 2 * v1);
-   boost::math::chebyshev_clenshaw_recurrence(&v1_other, 0, 2 * v2);
+   {
+      const RealType v1_other_const = v1;
+
+      boost::math::chebyshev_clenshaw_recurrence(&v1_other_const, 0, 2 * v2);
+   }
    boost::math::spherical_harmonic_r(2, 1, v1 * 1, v2 + 0);
    boost::math::spherical_harmonic_i(2, 1, v1 * 1, v2 + 0);
    boost::math::ellint_1(v1 * 1);
@@ -560,7 +583,7 @@ void instantiate(RealType)
    boost::math::jacobi_zeta(v1 * 1, v2 + 0);
    boost::math::heuman_lambda(v1 * 1, v2 + 0);
    {
-      RealType v1_to_get { v1_other };
+      RealType v1_to_get { v1 };
 
       boost::math::jacobi_elliptic(v1 * 1, v2 + 0, &v1_to_get, &v2);
    }
@@ -790,7 +813,7 @@ void instantiate(RealType)
    boost::math::ellint_rg(v1, v2, v3, pol);
    boost::math::ellint_rj(v1, v2, v3, v1, pol);
    {
-      RealType v1_to_get { v1_other };
+      RealType v1_to_get { v1 };
 
       boost::math::jacobi_elliptic(v1, v2, &v1_to_get, &v2, pol);
    }
@@ -971,7 +994,7 @@ void instantiate(RealType)
    iround(v1, pol);
    lround(v1, pol);
    {
-      RealType v1_to_get { v1_other };
+      RealType v1_to_get { v1 };
 
       modf(v1, &v1_to_get, pol);
    }
@@ -1086,7 +1109,11 @@ void instantiate(RealType)
    test::chebyshev_t(1, v1);
    test::chebyshev_u(1, v1);
    test::chebyshev_t_prime(1, v1);
-   test::chebyshev_clenshaw_recurrence(&v1_other, 0, v2);
+   {
+      const RealType v1_other_const = v1;
+
+      test::chebyshev_clenshaw_recurrence(&v1_other_const, 0, v2);
+   }
    test::spherical_harmonic_r(2, 1, v1, v2);
    test::spherical_harmonic_i(2, 1, v1, v2);
    test::ellint_1(v1);
@@ -1105,7 +1132,7 @@ void instantiate(RealType)
    test::ellint_rg(v1, v2, v3);
    test::ellint_rj(v1, v2, v3, v1);
    {
-      RealType v1_to_get { v1_other };
+      RealType v1_to_get { v1 };
 
       test::jacobi_elliptic(v1, v2, &v1_to_get, &v2);
    }
@@ -1244,7 +1271,7 @@ void instantiate(RealType)
    test::iround(v1);
    test::lround(v1);
    {
-      RealType v1_to_get { v1_other };
+      RealType v1_to_get { v1 };
 
       test::modf(v1, &v1_to_get);
    }
@@ -1263,6 +1290,8 @@ void instantiate(RealType)
    test::ulp(v1);
 #endif
 #endif
+
+   instantiate_runner_result<RealType>::value = true;
 }
 
 template <class RealType>
@@ -1292,7 +1321,11 @@ void instantiate_mixed(RealType)
    boost::math::tgamma(i);
    boost::math::tgamma1pm1(i);
    boost::math::lgamma(i);
-   boost::math::lgamma(i, &i_other);
+   {
+      int i_other { i };
+
+      boost::math::lgamma(i, &i_other);
+   }
    boost::math::digamma(i);
    boost::math::trigamma(i);
    boost::math::polygamma(i, i);

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -25,6 +25,7 @@
 template <class RealType>
 struct instantiate_runner_result
 {
+   static auto get_value() -> bool { return value; }
    static bool value;
 };
 

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -23,7 +23,7 @@ bool instantiate_runner_result<RealType>::value;
 
 #include <boost/math/tools/config.hpp>
 
-#ifndef BOOST_MATH_NO_DISTRIBUTION_CONCEPT_TESTS
+#if (!defined(BOOST_MATH_STANDALONE) && !defined(__CYGWIN__))
 
 #include <boost/math/distributions.hpp>
 
@@ -1807,14 +1807,14 @@ void instantiate_mixed(RealType)
 
 #else // Standalone mode
 
-template <typename T>
-void instantiate(T)
+template <typename RealType>
+void instantiate(RealType)
 {
    instantiate_runner_result<RealType>::value = true;
 }
 
-template <typename T>
-void instantiate_mixed(T) {}
+template <typename RealType>
+void instantiate_mixed(RealType) {}
 
 #endif // Standalone mode
 

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -179,6 +179,7 @@ void instantiate(RealType)
 #endif
 #endif
    int i { 1 };
+   int i_other { };
    // Deal with unused variable warnings:
    static_cast<void>(i);
    auto v1(static_cast<RealType>(0.51));
@@ -190,7 +191,6 @@ void instantiate(RealType)
    boost::math::tgamma(v1);
    boost::math::tgamma1pm1(v1);
    boost::math::lgamma(v1);
-   int i_other { };
    boost::math::lgamma(v1, &i_other);
    boost::math::digamma(v1);
    boost::math::trigamma(v1);

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -90,7 +90,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<bernoulli_distribution<RealType> > >();
    function_requires<DistributionConcept<beta_distribution<RealType> > >();
    function_requires<DistributionConcept<binomial_distribution<RealType> > >();
-   function_requires<DistributionConcept<cauchy_distribution<RealType> > >();
+   //function_requires<DistributionConcept<cauchy_distribution<RealType> > >();
    function_requires<DistributionConcept<chi_squared_distribution<RealType> > >();
    function_requires<DistributionConcept<exponential_distribution<RealType> > >();
    function_requires<DistributionConcept<extreme_value_distribution<RealType> > >();
@@ -108,7 +108,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<lognormal_distribution<RealType> > >();
    function_requires<DistributionConcept<negative_binomial_distribution<RealType> > >();
    function_requires<DistributionConcept<non_central_chi_squared_distribution<RealType> > >();
-   function_requires<DistributionConcept<non_central_beta_distribution<RealType> > >();
+   //function_requires<DistributionConcept<non_central_beta_distribution<RealType> > >();
    function_requires<DistributionConcept<non_central_f_distribution<RealType> > >();
    function_requires<DistributionConcept<non_central_t_distribution<RealType> > >();
    function_requires<DistributionConcept<normal_distribution<RealType> > >();
@@ -127,7 +127,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<bernoulli_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<beta_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<binomial_distribution<RealType, test_policy> > >();
-   function_requires<DistributionConcept<cauchy_distribution<RealType, test_policy> > >();
+   //function_requires<DistributionConcept<cauchy_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<chi_squared_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<exponential_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<extreme_value_distribution<RealType, test_policy> > >();
@@ -144,7 +144,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<lognormal_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<negative_binomial_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<non_central_chi_squared_distribution<RealType, test_policy> > >();
-   function_requires<DistributionConcept<non_central_beta_distribution<RealType, test_policy> > >();
+   //function_requires<DistributionConcept<non_central_beta_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<non_central_f_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<non_central_t_distribution<RealType, test_policy> > >();
    function_requires<DistributionConcept<normal_distribution<RealType, test_policy> > >();
@@ -162,7 +162,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<dist_test::bernoulli > >();
    function_requires<DistributionConcept<dist_test::beta > >();
    function_requires<DistributionConcept<dist_test::binomial > >();
-   function_requires<DistributionConcept<dist_test::cauchy > >();
+   //function_requires<DistributionConcept<dist_test::cauchy > >();
    function_requires<DistributionConcept<dist_test::chi_squared > >();
    function_requires<DistributionConcept<dist_test::exponential > >();
    function_requires<DistributionConcept<dist_test::extreme_value > >();
@@ -178,7 +178,7 @@ void instantiate(RealType)
    function_requires<DistributionConcept<dist_test::lognormal > >();
    function_requires<DistributionConcept<dist_test::negative_binomial > >();
    function_requires<DistributionConcept<dist_test::non_central_chi_squared > >();
-   function_requires<DistributionConcept<dist_test::non_central_beta > >();
+   //function_requires<DistributionConcept<dist_test::non_central_beta > >();
    function_requires<DistributionConcept<dist_test::non_central_f > >();
    function_requires<DistributionConcept<dist_test::non_central_t > >();
    function_requires<DistributionConcept<dist_test::normal > >();

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -1489,11 +1489,14 @@ void instantiate_mixed(RealType)
 
    boost::math::policies::policy<> pol;
 
-
    boost::math::tgamma(i, pol);
    boost::math::tgamma1pm1(i, pol);
    boost::math::lgamma(i, pol);
-   boost::math::lgamma(i, &i_other, pol);
+   {
+      int i_other { i };
+
+      boost::math::lgamma(i, &i_other, pol);
+   }
    boost::math::digamma(i, pol);
    boost::math::trigamma(i, pol);
    boost::math::polygamma(i, i, pol);
@@ -1657,7 +1660,11 @@ void instantiate_mixed(RealType)
    test::tgamma(i);
    test::tgamma1pm1(i);
    test::lgamma(i);
-   test::lgamma(i, &i_other);
+   {
+      int i_other { i };
+
+      test::lgamma(i, &i_other);
+   }
    test::digamma(i);
    test::trigamma(i);
    test::polygamma(i, i);

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -29,7 +29,7 @@ struct instantiate_runner_result
 };
 
 template <class RealType>
-bool instantiate_runner_result<RealType>::value { };
+bool instantiate_runner_result<RealType>::value;
 
 #ifndef BOOST_MATH_INSTANTIATE_MINIMUM
 
@@ -446,8 +446,11 @@ void instantiate(RealType)
       boost::math::modf(v1, &v1_to_get);
    }
    boost::math::modf(v1, &i_other);
-   long l_other { };
-   boost::math::modf(v1, &l_other);
+   {
+      long l_other { };
+
+      boost::math::modf(v1, &l_other);
+   }
 #ifdef BOOST_HAS_LONG_LONG
    boost::math::lltrunc(v1);
    boost::math::llround(v1);
@@ -709,8 +712,11 @@ void instantiate(RealType)
    boost::math::lround(v1 * 1);
    //boost::math::modf(v1 * 1, &v1_other);
    //boost::math::modf(v1 * 1, &i_other);
-   //long l;
-   //boost::math::modf(v1 * 1, &l_other);
+   //{
+   //   long l_other { };
+   //
+   //   boost::math::modf(v1 * 1, &l_other);
+   //}
 #ifdef BOOST_HAS_LONG_LONG
    boost::math::lltrunc(v1 * 1);
    boost::math::llround(v1 * 1);
@@ -978,7 +984,11 @@ void instantiate(RealType)
       modf(v1, &v1_to_get, pol);
    }
    modf(v1, &i_other, pol);
-   modf(v1, &l_other, pol);
+   {
+      long l_other { };
+
+      modf(v1, &l_other, pol);
+   }
 #ifdef BOOST_HAS_LONG_LONG
    using boost::math::lltrunc;
    using boost::math::llround;
@@ -1255,7 +1265,11 @@ void instantiate(RealType)
       test::modf(v1, &v1_to_get);
    }
    test::modf(v1, &i_other);
-   test::modf(v1, &l_other);
+   {
+      long l_other { };
+
+     test::modf(v1, &l_other);
+   }
 #ifdef BOOST_HAS_LONG_LONG
    test::lltrunc(v1);
    test::llround(v1);

--- a/test/compile_test/instantiate.hpp
+++ b/test/compile_test/instantiate.hpp
@@ -22,6 +22,15 @@
 #include <boost/math/concepts/distributions.hpp>
 #include <boost/concept_archetype.hpp>
 
+template <class RealType>
+struct instantiate_runner_result
+{
+   static bool value;
+};
+
+template <class RealType>
+bool instantiate_runner_result<RealType>::value { };
+
 #ifndef BOOST_MATH_INSTANTIATE_MINIMUM
 
 typedef boost::math::policies::policy<boost::math::policies::promote_float<false>, boost::math::policies::promote_double<false> > test_policy;
@@ -58,15 +67,6 @@ BOOST_MATH_DECLARE_DISTRIBUTIONS(double, test_policy)
 #  define TEST_GROUP_14
 #  define TEST_GROUP_15
 #endif
-
-template <class RealType>
-struct instantiate_runner_result
-{
-   static bool value;
-};
-
-template <class RealType>
-bool instantiate_runner_result<RealType>::value { };
 
 template <class RealType>
 void instantiate(RealType)

--- a/test/test_compile_test_and_run.cpp
+++ b/test/test_compile_test_and_run.cpp
@@ -7,7 +7,7 @@
 #include <boost/core/lightweight_test.hpp>
 #include <boost/cstdfloat.hpp>
 
-#if !defined(__CYGWIN__)
+#if (!defined(__CYGWIN__) && !defined(BOOST_MATH_NO_DISTRIBUTION_CONCEPT_TESTS))
 #include "compile_test/instantiate.hpp"
 #endif
 
@@ -15,7 +15,7 @@ namespace local
 {
   auto instantiate_runner() -> void
   {
-    #if (defined(BOOST_FLOAT64_C) && !defined(__CYGWIN__))
+    #if (defined(BOOST_FLOAT64_C) && !defined(__CYGWIN__) && !defined(BOOST_MATH_NO_DISTRIBUTION_CONCEPT_TESTS))
 
     instantiate(static_cast<boost::float64_t>(BOOST_FLOAT64_C(1.23)));
 

--- a/test/test_compile_test_and_run.cpp
+++ b/test/test_compile_test_and_run.cpp
@@ -7,15 +7,13 @@
 #include <boost/core/lightweight_test.hpp>
 #include <boost/cstdfloat.hpp>
 
-#if (!defined(__CYGWIN__) && !defined(BOOST_MATH_NO_DISTRIBUTION_CONCEPT_TESTS))
 #include "compile_test/instantiate.hpp"
-#endif
 
 namespace local
 {
   auto instantiate_runner() -> void
   {
-    #if (defined(BOOST_FLOAT64_C) && !defined(__CYGWIN__) && !defined(BOOST_MATH_NO_DISTRIBUTION_CONCEPT_TESTS))
+    #if defined(BOOST_FLOAT64_C)
 
     instantiate(static_cast<boost::float64_t>(BOOST_FLOAT64_C(1.23)));
 

--- a/test/test_compile_test_and_run.cpp
+++ b/test/test_compile_test_and_run.cpp
@@ -15,8 +15,8 @@ namespace local
   {
     #if defined(BOOST_FLOAT64_C)
 
-    instantiate(BOOST_FLOAT64_C(1.23));
-    BOOST_TEST(instantiate_runner_result<boost::float64_t>::value);
+    instantiate<boost::float64_t>(BOOST_FLOAT64_C(1.23));
+    BOOST_TEST(::instantiate_runner_result<boost::float64_t>::value);
 
     #else
 

--- a/test/test_compile_test_and_run.cpp
+++ b/test/test_compile_test_and_run.cpp
@@ -15,7 +15,7 @@ namespace local
   {
     #if defined(BOOST_FLOAT64_C)
 
-    instantiate<boost::float64_t>(BOOST_FLOAT64_C(1.23));
+    instantiate(static_cast<boost::float64_t>(BOOST_FLOAT64_C(1.23)));
     BOOST_TEST(::instantiate_runner_result<boost::float64_t>::value);
 
     #else

--- a/test/test_compile_test_and_run.cpp
+++ b/test/test_compile_test_and_run.cpp
@@ -16,7 +16,10 @@ namespace local
     #if defined(BOOST_FLOAT64_C)
 
     instantiate(static_cast<boost::float64_t>(BOOST_FLOAT64_C(1.23)));
-    BOOST_TEST(::instantiate_runner_result<boost::float64_t>::value);
+
+    volatile bool result_instantiate_and_run_is_ok = (::instantiate_runner_result<boost::float64_t>::get_value)();
+
+    BOOST_TEST(result_instantiate_and_run_is_ok);
 
     #else
 

--- a/test/test_compile_test_and_run.cpp
+++ b/test/test_compile_test_and_run.cpp
@@ -1,0 +1,35 @@
+//  Copyright John Maddock 2014.
+//  Copyright Christopher Kormanyos 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/core/lightweight_test.hpp>
+#include <boost/cstdfloat.hpp>
+
+#include "compile_test/instantiate.hpp"
+
+namespace local
+{
+  auto instantiate_runner() -> void
+  {
+    volatile bool result_instantiate_and_run_is_ok { false };
+    #if defined(BOOST_FLOAT64_C)
+    instantiate(BOOST_FLOAT64_C(1.23));
+    result_instantiate_and_run_is_ok = true;
+    #else
+    result_instantiate_and_run_is_ok = true;
+    #endif
+
+    BOOST_TEST(result_instantiate_and_run_is_ok);
+  }
+}
+
+auto main() -> int
+{
+  local::instantiate_runner();
+
+  const auto result_is_ok = (boost::report_errors() == 0);
+
+  return (result_is_ok ? 0 : -1);
+}

--- a/test/test_compile_test_and_run.cpp
+++ b/test/test_compile_test_and_run.cpp
@@ -13,15 +13,16 @@ namespace local
 {
   auto instantiate_runner() -> void
   {
-    volatile bool result_instantiate_and_run_is_ok { false };
     #if defined(BOOST_FLOAT64_C)
-    instantiate(BOOST_FLOAT64_C(1.23));
-    result_instantiate_and_run_is_ok = true;
-    #else
-    result_instantiate_and_run_is_ok = true;
-    #endif
 
-    BOOST_TEST(result_instantiate_and_run_is_ok);
+    instantiate(BOOST_FLOAT64_C(1.23));
+    BOOST_TEST(instantiate_runner_result<boost::float64_t>::value);
+
+    #else
+
+    BOOST_TEST(true);
+
+    #endif
   }
 }
 

--- a/test/test_compile_test_and_run.cpp
+++ b/test/test_compile_test_and_run.cpp
@@ -7,20 +7,19 @@
 #include <boost/core/lightweight_test.hpp>
 #include <boost/cstdfloat.hpp>
 
+#if !defined(__CYGWIN__)
 #include "compile_test/instantiate.hpp"
+#endif
 
 namespace local
 {
   auto instantiate_runner() -> void
   {
-    #if defined(BOOST_FLOAT64_C)
+    #if (defined(BOOST_FLOAT64_C) && !defined(__CYGWIN__))
+
     instantiate(static_cast<boost::float64_t>(BOOST_FLOAT64_C(1.23)));
 
-    #if defined(__CYGWIN__)
-    const bool result_instantiate_and_run_is_ok = true;
-    #else
     const bool result_instantiate_and_run_is_ok = instantiate_runner_result<boost::float64_t>::value;
-    #endif
 
     BOOST_TEST(result_instantiate_and_run_is_ok);
 

--- a/test/test_compile_test_and_run.cpp
+++ b/test/test_compile_test_and_run.cpp
@@ -14,10 +14,13 @@ namespace local
   auto instantiate_runner() -> void
   {
     #if defined(BOOST_FLOAT64_C)
-
     instantiate(static_cast<boost::float64_t>(BOOST_FLOAT64_C(1.23)));
 
-    volatile bool result_instantiate_and_run_is_ok = (::instantiate_runner_result<boost::float64_t>::get_value)();
+    #if defined(__CYGWIN__)
+    const bool result_instantiate_and_run_is_ok = true;
+    #else
+    const bool result_instantiate_and_run_is_ok = instantiate_runner_result<boost::float64_t>::value;
+    #endif
 
     BOOST_TEST(result_instantiate_and_run_is_ok);
 


### PR DESCRIPTION
The purpose of this PR is to cover the file [instantiate.hpp](https://github.com/boostorg/math/blob/develop/test/compile_test/instantiate.hpp).

The file [instantiate.hpp](https://github.com/boostorg/math/blob/develop/test/compile_test/instantiate.hpp) has been extremely useful for compilation-syntactical correctness.

It is/was not all that far away from actually running with `boost::float64_t`, which is exercised (with a few tens of modifications in the header) in this PR.
