### PR TITLE
Add C++14 build requirements

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -13,13 +13,13 @@ project
       <toolset>intel-win:<linkflags>-nologo 
       #<toolset>intel-linux:<pch>off
       <toolset>intel-darwin:<pch>off
-      <toolset>msvc-7.1:<pch>off
       <toolset>gcc,<target-os>windows:<pch>off
       #<toolset>gcc:<cxxflags>-fvisibility=hidden
       <toolset>intel-linux:<cxxflags>-fvisibility=hidden
       #<toolset>sun:<cxxflags>-xldscope=hidden
       [ check-target-builds ../config//has_gcc_visibility "gcc visibility" : <toolset>gcc:<cxxflags>-fvisibility=hidden : ]
       [ requires cxx11_noexcept cxx11_rvalue_references sfinae_expr cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_tuple cxx11_hdr_initializer_list cxx11_hdr_chrono cxx11_thread_local cxx11_constexpr cxx11_nullptr cxx11_numeric_limits cxx11_decltype cxx11_hdr_array cxx11_hdr_atomic cxx11_hdr_type_traits cxx11_allocator cxx11_explicit_conversion_operators ]
+      [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction ]
     ;
 
 cpp-pch pch : ../src/tr1/pch.hpp : <include>../src/tr1 <link>shared:<define>BOOST_MATH_TR1_DYN_LINK=1 ; 


### PR DESCRIPTION
Noticed the C++14 warnings while building the 1.85 Beta RC this morning. Also remove handling for MSVC-7.1 as there's no way it builds the library anymore.