### PR TITLE
Fix for skew_normal quantile non-convergence

### DIFF
--- a/include/boost/math/distributions/skew_normal.hpp
+++ b/include/boost/math/distributions/skew_normal.hpp
@@ -685,11 +685,21 @@ namespace boost{ namespace math{
     const RealType search_max = support(dist).second;
 
     const int get_digits = policies::digits<RealType, Policy>();// get digits from policy,
+    
     std::uintmax_t max_iter = policies::get_max_root_iterations<Policy>(); // and max iterations.
+    std::uintmax_t comparison_max_iter = max_iter;
+
+    // Shape 200 takes ~150 steps and 250 takes >200 which is the default policy
+    if (shape > 200)
+    {
+      // Shape equal to std::numeric_limits<double>:max() takes 1044 steps to converge
+      max_iter = 1100U;
+      comparison_max_iter = max_iter;
+    }
 
     result = tools::newton_raphson_iterate(detail::skew_normal_quantile_functor<RealType, Policy>(dist, p), result,
       search_min, search_max, get_digits, max_iter);
-    if (max_iter >= policies::get_max_root_iterations<Policy>())
+    if (max_iter >= comparison_max_iter)
     {
        return policies::raise_evaluation_error<RealType>(function, "Unable to locate solution in a reasonable time: either there is no answer to quantile" // LCOV_EXCL_LINE
           " or the answer is infinite.  Current best guess is %1%", result, Policy());  // LCOV_EXCL_LINE

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -873,6 +873,7 @@ test-suite distribution_tests :
    [ run scipy_issue_18302.cpp ../../test/build//boost_unit_test_framework  ]
    [ run scipy_issue_18511.cpp ../../test/build//boost_unit_test_framework ]
    [ compile scipy_issue_19762.cpp ]
+   [ run git_issue_1120.cpp ../../test/build//boost_unit_test_framework ]
 ;
 
 test-suite new_floats : 

--- a/test/git_issue_1120.cpp
+++ b/test/git_issue_1120.cpp
@@ -1,0 +1,23 @@
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+//  See: https://github.com/scipy/scipy/issues/20124
+//  See: https://github.com/boostorg/math/issues/1120
+
+#include <boost/math/distributions/skew_normal.hpp>
+#include "math_unit_test.hpp"
+#include <limits>
+
+int main()
+{
+    using scipy_policy = boost::math::policies::policy<boost::math::policies::promote_double<false>>;
+    constexpr auto q = 0.012533469508013;
+
+    boost::math::skew_normal_distribution<double, scipy_policy> dist(0, 1, 500);
+    CHECK_ULP_CLOSE(0.01, boost::math::cdf(dist, q), 100);
+    CHECK_ULP_CLOSE(q, boost::math::quantile(dist, 0.01), 100);
+
+    return boost::math::test::report_errors();
+}


### PR DESCRIPTION
@jzmaddock This may not be _the_ fix but it certainly gets things working. I just tested different shapes of the issue distribution to find decent places to make the change in allowable steps and how many we might need. Im not quite search how to narrow down the search range from (-inf, inf) to speed up convergence organically.