### PR TITLE
Update geometric.hpp

### DIFF
--- a/include/boost/math/distributions/geometric.hpp
+++ b/include/boost/math/distributions/geometric.hpp
@@ -401,7 +401,7 @@ namespace boost
       }
       if(k == 0)
       {
-        return log(p); // success_fraction
+        return std::log(p); // success_fraction
       }
       //RealType q = 1 - p;  // Bad for small p
       //RealType probability = 1 - std::pow(q, k+1);

--- a/include/boost/math/distributions/geometric.hpp
+++ b/include/boost/math/distributions/geometric.hpp
@@ -384,6 +384,7 @@ namespace boost
     inline RealType logcdf(const geometric_distribution<RealType, Policy>& dist, const RealType& k)
     { // Cumulative Distribution Function of geometric.
       using std::pow;
+      using std::log;
       static const char* function = "boost::math::logcdf(const geometric_distribution<%1%>&, %1%)";
 
       // k argument may be integral, signed, or unsigned, or floating point.
@@ -401,7 +402,7 @@ namespace boost
       }
       if(k == 0)
       {
-        return std::log(p); // success_fraction
+        return log(p); // success_fraction
       }
       //RealType q = 1 - p;  // Bad for small p
       //RealType probability = 1 - std::pow(q, k+1);

--- a/include/boost/math/distributions/geometric.hpp
+++ b/include/boost/math/distributions/geometric.hpp
@@ -385,6 +385,7 @@ namespace boost
     { // Cumulative Distribution Function of geometric.
       using std::pow;
       using std::log;
+      using std::exp;
       static const char* function = "boost::math::logcdf(const geometric_distribution<%1%>&, %1%)";
 
       // k argument may be integral, signed, or unsigned, or floating point.


### PR DESCRIPTION
The proposal is derived from this issue

https://github.com/boostorg/math/issues/1126



This line should be corrected
At /math/distributions/geometric.hpp at line 404
```
  return std::log(p); // success_fraction
      
```
Now the code is
```
  return log(p); // success_fraction
      
```


When building that library. Throws this error

```
In file included from /opt/homebrew/include/boost/math/distributions.hpp:26:
/opt/homebrew/include/boost/math/distributions/geometric.hpp:404:16: error: unexpected namespace name 'log': expected expression
        return log(p); // success_fraction
               ^
1 error generated.
make[2]: *** [CMakeFiles/PonisIqCoreNLV.dir/Unity/unity_0_cxx.cxx.o] Error 1
make[1]: *** [CMakeFiles/PonisIqCoreNLV.dir/all] Error 2
make: *** [all] Error 2
```