### PR TITLE
Make boost::math::ccmath::fminf and boost::math::ccmath::fminl constexpr

### DIFF
--- a/include/boost/math/ccmath/fmin.hpp
+++ b/include/boost/math/ccmath/fmin.hpp
@@ -72,13 +72,13 @@ constexpr auto fmin(T1 x, T2 y) noexcept
     }
 }
 
-float fminf(float x, float y) noexcept
+constexpr float fminf(float x, float y) noexcept
 {
     return boost::math::ccmath::fmin(x, y);
 }
 
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-long double fminl(long double x, long double y) noexcept
+constexpr long double fminl(long double x, long double y) noexcept
 {
     return boost::math::ccmath::fmin(x, y);
 }


### PR DESCRIPTION
The publicly visible declarations of `boost::math::ccmath::fminf` and `boost::math::ccmath::fminfl` are neither marked `inline` nor `constexpr`, which causes "multiple definition" linker errors when the `boost/math/ccmath/fmin.hpp` header gets included in multiple translation units of a binary.

Therefore this PR marks said functions `constexpr`.

Fixes #1145 