### PR TITLE
NVRTC batch 3

### DIFF
--- a/include/boost/math/distributions/bernoulli.hpp
+++ b/include/boost/math/distributions/bernoulli.hpp
@@ -31,6 +31,7 @@
 #include <boost/math/distributions/fwd.hpp>
 #include <boost/math/tools/config.hpp>
 #include <boost/math/tools/tuple.hpp>
+#include <boost/math/tools/type_traits.hpp>
 #include <boost/math/distributions/complement.hpp> // complements
 #include <boost/math/distributions/detail/common_error_handling.hpp> // error checks
 #include <boost/math/special_functions/fpclassify.hpp> // isnan.
@@ -57,12 +58,12 @@ namespace boost
         return true;
       }
       template <class RealType, class Policy>
-      BOOST_MATH_GPU_ENABLED inline bool check_dist(const char* function, const RealType& p, RealType* result, const Policy& /* pol */, const std::true_type&)
+      BOOST_MATH_GPU_ENABLED inline bool check_dist(const char* function, const RealType& p, RealType* result, const Policy& /* pol */, const boost::math::true_type&)
       {
         return check_success_fraction(function, p, result, Policy());
       }
       template <class RealType, class Policy>
-      BOOST_MATH_GPU_ENABLED inline bool check_dist(const char* , const RealType& , RealType* , const Policy& /* pol */, const std::false_type&)
+      BOOST_MATH_GPU_ENABLED inline bool check_dist(const char* , const RealType& , RealType* , const Policy& /* pol */, const boost::math::false_type&)
       {
          return true;
       }

--- a/include/boost/math/policies/policy.hpp
+++ b/include/boost/math/policies/policy.hpp
@@ -9,11 +9,8 @@
 
 #include <boost/math/tools/config.hpp>
 #include <boost/math/tools/mp.hpp>
-#include <limits>
-#include <type_traits>
-#include <cmath>
-#include <cstdint>
-#include <cstddef>
+#include <boost/math/tools/numeric_limits.hpp>
+#include <boost/math/tools/type_traits.hpp>
 
 namespace boost{ namespace math{
 
@@ -24,7 +21,7 @@ namespace tools{
 template <class T>
 BOOST_MATH_GPU_ENABLED constexpr int digits(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE(T)) noexcept;
 template <class T>
-BOOST_MATH_GPU_ENABLED constexpr T epsilon(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE(T)) noexcept(std::is_floating_point<T>::value);
+BOOST_MATH_GPU_ENABLED constexpr T epsilon(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE(T)) noexcept(boost::math::is_floating_point<T>::value);
 
 }
 
@@ -134,7 +131,7 @@ namespace policies{
 
 #define BOOST_MATH_META_INT(Type, name, Default)                                                \
    template <Type N = Default>                                                                  \
-   class name : public std::integral_constant<int, N>{};                                        \
+   class name : public boost::math::integral_constant<int, N>{};                                \
                                                                                                 \
    namespace detail{                                                                            \
    template <Type N>                                                                            \
@@ -158,12 +155,12 @@ namespace policies{
    {                                                                                            \
    public:                                                                                      \
       static constexpr bool value = boost::math::policies::detail::is_##name##_imp<T>::value;   \
-      using type = std::integral_constant<bool, value>;                                         \
+      using type = boost::math::integral_constant<bool, value>;                                 \
    };
 
 #define BOOST_MATH_META_BOOL(name, Default)                                                     \
    template <bool N = Default>                                                                  \
-   class name : public std::integral_constant<bool, N>{};                                       \
+   class name : public boost::math::integral_constant<bool, N>{};                               \
                                                                                                 \
    namespace detail{                                                                            \
    template <bool N>                                                                            \
@@ -178,7 +175,7 @@ namespace policies{
       static char test(const name<N>* = nullptr);                                               \
       static double test(...);                                                                  \
    public:                                                                                      \
-      static constexpr bool value = sizeof(test(static_cast<T*>(nullptr))) == sizeof(char);           \
+      static constexpr bool value = sizeof(test(static_cast<T*>(nullptr))) == sizeof(char);     \
    };                                                                                           \
    }                                                                                            \
                                                                                                 \
@@ -187,7 +184,7 @@ namespace policies{
    {                                                                                            \
    public:                                                                                      \
       static constexpr bool value = boost::math::policies::detail::is_##name##_imp<T>::value;   \
-      using type = std::integral_constant<bool, value>;                                         \
+      using type = boost::math::integral_constant<bool, value>;                                 \
    };
 
 //
@@ -259,18 +256,18 @@ struct precision
    //
    // Now work out the precision:
    //
-   using digits2_type = typename std::conditional<
+   using digits2_type = typename boost::math::conditional<
       (Digits10::value == 0),
       digits2<0>,
       digits2<((Digits10::value + 1) * 1000L) / 301L>
    >::type;
 public:
 #ifdef BOOST_BORLANDC
-   using type = typename std::conditional<
+   using type = typename boost::math::conditional<
       (Digits2::value > ::boost::math::policies::detail::precision<Digits10,Digits2>::digits2_type::value),
       Digits2, digits2_type>::type;
 #else
-   using type = typename std::conditional<
+   using type = typename boost::math::conditional<
       (Digits2::value > digits2_type::value),
       Digits2, digits2_type>::type;
 #endif
@@ -307,7 +304,7 @@ class is_default_policy
 {
 public:
    static constexpr bool value = boost::math::policies::detail::is_default_policy_imp<T>::value;
-   using type = std::integral_constant<bool, value>;
+   using type = boost::math::integral_constant<bool, value>;
 
    template <typename U>
    struct apply
@@ -316,7 +313,7 @@ public:
    };
 };
 
-template <class Seq, class T, std::size_t N>
+template <class Seq, class T, BOOST_MATH_SIZE_T N>
 struct append_N
 {
    using type = typename append_N<mp::mp_push_back<Seq, T>, T, N-1>::type;
@@ -405,7 +402,7 @@ private:
    // Typelist of the arguments:
    //
    using arg_list = mp::mp_list<A1,A2,A3,A4,A5,A6,A7,A8,A9,A10,A11,A12,A13>;
-   static constexpr std::size_t arg_list_size = mp::mp_size<arg_list>::value;
+   static constexpr BOOST_MATH_SIZE_T arg_list_size = mp::mp_size<arg_list>::value;
 
    template<typename A, typename B, bool b>
    struct pick_arg
@@ -536,7 +533,7 @@ class normalise
 {
 private:
    using arg_list = mp::mp_list<A1,A2,A3,A4,A5,A6,A7,A8,A9,A10,A11,A12,A13>;
-   static constexpr std::size_t arg_list_size = mp::mp_size<arg_list>::value;
+   static constexpr BOOST_MATH_SIZE_T arg_list_size = mp::mp_size<arg_list>::value;
 
    template<typename A, typename B, bool b>
    struct pick_arg
@@ -759,47 +756,47 @@ struct evaluation
 template <class Policy>
 struct evaluation<float, Policy>
 {
-   using type = typename std::conditional<Policy::promote_float_type::value, double, float>::type;
+   using type = typename boost::math::conditional<Policy::promote_float_type::value, double, float>::type;
 };
 
 template <class Policy>
 struct evaluation<double, Policy>
 {
-   using type = typename std::conditional<Policy::promote_double_type::value, long double, double>::type;
+   using type = typename boost::math::conditional<Policy::promote_double_type::value, long double, double>::type;
 };
 
 template <class Real, class Policy>
 struct precision
 {
-   static_assert((std::numeric_limits<Real>::radix == 2) || ((std::numeric_limits<Real>::is_specialized == 0) || (std::numeric_limits<Real>::digits == 0)),
-   "(std::numeric_limits<Real>::radix == 2) || ((std::numeric_limits<Real>::is_specialized == 0) || (std::numeric_limits<Real>::digits == 0))");
+   static_assert((boost::math::numeric_limits<Real>::radix == 2) || ((boost::math::numeric_limits<Real>::is_specialized == 0) || (boost::math::numeric_limits<Real>::digits == 0)),
+   "(boost::math::numeric_limits<Real>::radix == 2) || ((boost::math::numeric_limits<Real>::is_specialized == 0) || (boost::math::numeric_limits<Real>::digits == 0))");
 #ifndef BOOST_BORLANDC
    using precision_type = typename Policy::precision_type;
-   using type = typename std::conditional<
-      ((std::numeric_limits<Real>::is_specialized == 0) || (std::numeric_limits<Real>::digits == 0)),
+   using type = typename boost::math::conditional<
+      ((boost::math::numeric_limits<Real>::is_specialized == 0) || (boost::math::numeric_limits<Real>::digits == 0)),
       // Possibly unknown precision:
       precision_type,
-      typename std::conditional<
-         ((std::numeric_limits<Real>::digits <= precision_type::value)
+      typename boost::math::conditional<
+         ((boost::math::numeric_limits<Real>::digits <= precision_type::value)
          || (Policy::precision_type::value <= 0)),
          // Default case, full precision for RealType:
-         digits2< std::numeric_limits<Real>::digits>,
+         digits2< boost::math::numeric_limits<Real>::digits>,
          // User customised precision:
          precision_type
       >::type
    >::type;
 #else
    using precision_type = typename Policy::precision_type;
-   using digits_t = std::integral_constant<int, std::numeric_limits<Real>::digits>;
-   using spec_t = std::integral_constant<bool, std::numeric_limits<Real>::is_specialized>;
-   using type = typename std::conditional<
-      (spec_t::value == true std::true_type || digits_t::value == 0),
+   using digits_t = boost::math::integral_constant<int, boost::math::numeric_limits<Real>::digits>;
+   using spec_t = boost::math::integral_constant<bool, boost::math::numeric_limits<Real>::is_specialized>;
+   using type = typename boost::math::conditional<
+      (spec_t::value == true boost::math::true_type || digits_t::value == 0),
       // Possibly unknown precision:
       precision_type,
-      typename std::conditional<
+      typename boost::math::conditional<
          (digits_t::value <= precision_type::value || precision_type::value <= 0),
          // Default case, full precision for RealType:
-         digits2< std::numeric_limits<Real>::digits>,
+         digits2< boost::math::numeric_limits<Real>::digits>,
          // User customised precision:
          precision_type
       >::type
@@ -812,7 +809,7 @@ struct precision
 template <class Policy>
 struct precision<BOOST_MATH_FLOAT128_TYPE, Policy>
 {
-   typedef std::integral_constant<int, 113> type;
+   typedef boost::math::integral_constant<int, 113> type;
 };
 
 #endif
@@ -820,15 +817,15 @@ struct precision<BOOST_MATH_FLOAT128_TYPE, Policy>
 namespace detail{
 
 template <class T, class Policy>
-BOOST_MATH_GPU_ENABLED constexpr int digits_imp(std::true_type const&) noexcept
+BOOST_MATH_GPU_ENABLED constexpr int digits_imp(boost::math::true_type const&) noexcept
 {
-   static_assert( std::numeric_limits<T>::is_specialized, "std::numeric_limits<T>::is_specialized");
+   static_assert( boost::math::numeric_limits<T>::is_specialized, "boost::math::numeric_limits<T>::is_specialized");
    typedef typename boost::math::policies::precision<T, Policy>::type p_t;
    return p_t::value;
 }
 
 template <class T, class Policy>
-BOOST_MATH_GPU_ENABLED constexpr int digits_imp(std::false_type const&) noexcept
+BOOST_MATH_GPU_ENABLED constexpr int digits_imp(boost::math::false_type const&) noexcept
 {
    return tools::digits<T>();
 }
@@ -838,7 +835,7 @@ BOOST_MATH_GPU_ENABLED constexpr int digits_imp(std::false_type const&) noexcept
 template <class T, class Policy>
 BOOST_MATH_GPU_ENABLED constexpr int digits(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE(T)) noexcept
 {
-   typedef std::integral_constant<bool, std::numeric_limits<T>::is_specialized > tag_type;
+   typedef boost::math::integral_constant<bool, boost::math::numeric_limits<T>::is_specialized > tag_type;
    return detail::digits_imp<T, Policy>(tag_type());
 }
 template <class T, class Policy>
@@ -866,51 +863,51 @@ namespace detail{
 template <class T, class Digits, class Small, class Default>
 struct series_factor_calc
 {
-   BOOST_MATH_GPU_ENABLED static T get() noexcept(std::is_floating_point<T>::value)
+   BOOST_MATH_GPU_ENABLED static T get() noexcept(boost::math::is_floating_point<T>::value)
    {
       return ldexp(T(1.0), 1 - Digits::value);
    }
 };
 
 template <class T, class Digits>
-struct series_factor_calc<T, Digits, std::true_type, std::true_type>
+struct series_factor_calc<T, Digits, boost::math::true_type, boost::math::true_type>
 {
-   BOOST_MATH_GPU_ENABLED static constexpr T get() noexcept(std::is_floating_point<T>::value)
+   BOOST_MATH_GPU_ENABLED static constexpr T get() noexcept(boost::math::is_floating_point<T>::value)
    {
       return boost::math::tools::epsilon<T>();
    }
 };
 template <class T, class Digits>
-struct series_factor_calc<T, Digits, std::true_type, std::false_type>
+struct series_factor_calc<T, Digits, boost::math::true_type, boost::math::false_type>
 {
-   BOOST_MATH_GPU_ENABLED static constexpr T get() noexcept(std::is_floating_point<T>::value)
+   BOOST_MATH_GPU_ENABLED static constexpr T get() noexcept(boost::math::is_floating_point<T>::value)
    {
-      return 1 / static_cast<T>(static_cast<std::uintmax_t>(1u) << (Digits::value - 1));
+      return 1 / static_cast<T>(static_cast<BOOST_MATH_UINTMAX_T>(1u) << (Digits::value - 1));
    }
 };
 template <class T, class Digits>
-struct series_factor_calc<T, Digits, std::false_type, std::true_type>
+struct series_factor_calc<T, Digits, boost::math::false_type, boost::math::true_type>
 {
-   BOOST_MATH_GPU_ENABLED static constexpr T get() noexcept(std::is_floating_point<T>::value)
+   BOOST_MATH_GPU_ENABLED static constexpr T get() noexcept(boost::math::is_floating_point<T>::value)
    {
       return boost::math::tools::epsilon<T>();
    }
 };
 
 template <class T, class Policy>
-BOOST_MATH_GPU_ENABLED constexpr T get_epsilon_imp(std::true_type const&) noexcept(std::is_floating_point<T>::value)
+BOOST_MATH_GPU_ENABLED constexpr T get_epsilon_imp(boost::math::true_type const&) noexcept(boost::math::is_floating_point<T>::value)
 {
-   static_assert(std::numeric_limits<T>::is_specialized, "std::numeric_limits<T>::is_specialized");
-   static_assert(std::numeric_limits<T>::radix == 2, "std::numeric_limits<T>::radix == 2");
+   static_assert(boost::math::numeric_limits<T>::is_specialized, "boost::math::numeric_limits<T>::is_specialized");
+   static_assert(boost::math::numeric_limits<T>::radix == 2, "boost::math::numeric_limits<T>::radix == 2");
 
    typedef typename boost::math::policies::precision<T, Policy>::type p_t;
-   typedef std::integral_constant<bool, p_t::value <= std::numeric_limits<std::uintmax_t>::digits> is_small_int;
-   typedef std::integral_constant<bool, p_t::value >= std::numeric_limits<T>::digits> is_default_value;
+   typedef boost::math::integral_constant<bool, p_t::value <= boost::math::numeric_limits<BOOST_MATH_UINTMAX_T>::digits> is_small_int;
+   typedef boost::math::integral_constant<bool, p_t::value >= boost::math::numeric_limits<T>::digits> is_default_value;
    return series_factor_calc<T, p_t, is_small_int, is_default_value>::get();
 }
 
 template <class T, class Policy>
-BOOST_MATH_GPU_ENABLED constexpr T get_epsilon_imp(std::false_type const&) noexcept(std::is_floating_point<T>::value)
+BOOST_MATH_GPU_ENABLED constexpr T get_epsilon_imp(boost::math::false_type const&) noexcept(boost::math::is_floating_point<T>::value)
 {
    return tools::epsilon<T>();
 }
@@ -918,9 +915,9 @@ BOOST_MATH_GPU_ENABLED constexpr T get_epsilon_imp(std::false_type const&) noexc
 } // namespace detail
 
 template <class T, class Policy>
-BOOST_MATH_GPU_ENABLED constexpr T get_epsilon(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE(T)) noexcept(std::is_floating_point<T>::value)
+BOOST_MATH_GPU_ENABLED constexpr T get_epsilon(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE(T)) noexcept(boost::math::is_floating_point<T>::value)
 {
-   typedef std::integral_constant<bool, (std::numeric_limits<T>::is_specialized && (std::numeric_limits<T>::radix == 2)) > tag_type;
+   typedef boost::math::integral_constant<bool, (boost::math::numeric_limits<T>::is_specialized && (boost::math::numeric_limits<T>::radix == 2)) > tag_type;
    return detail::get_epsilon_imp<T, Policy>(tag_type());
 }
 
@@ -954,7 +951,7 @@ class is_policy
 {
 public:
    static constexpr bool value = boost::math::policies::detail::is_policy_imp<P>::value;
-   using type = std::integral_constant<bool, value>;
+   using type = boost::math::integral_constant<bool, value>;
 };
 
 //
@@ -964,20 +961,20 @@ template <class Policy>
 struct constructor_error_check
 {
    using domain_error_type = typename Policy::domain_error_type;
-   using type = typename std::conditional<
+   using type = typename boost::math::conditional<
       (domain_error_type::value == throw_on_error) || (domain_error_type::value == user_error) || (domain_error_type::value == errno_on_error),
-      std::true_type,
-      std::false_type>::type;
+      boost::math::true_type,
+      boost::math::false_type>::type;
 };
 
 template <class Policy>
 struct method_error_check
 {
    using domain_error_type = typename Policy::domain_error_type;
-   using type = typename std::conditional<
+   using type = typename boost::math::conditional<
       (domain_error_type::value == throw_on_error),
-      std::false_type,
-      std::true_type>::type;
+      boost::math::false_type,
+      boost::math::true_type>::type;
 };
 //
 // Does the Policy ever throw on error?

--- a/include/boost/math/special_functions/beta.hpp
+++ b/include/boost/math/special_functions/beta.hpp
@@ -13,6 +13,7 @@
 
 #include <boost/math/special_functions/math_fwd.hpp>
 #include <boost/math/tools/config.hpp>
+#include <boost/math/tools/type_traits.hpp>
 #include <boost/math/special_functions/gamma.hpp>
 #include <boost/math/special_functions/binomial.hpp>
 #include <boost/math/special_functions/factorials.hpp>
@@ -1569,7 +1570,7 @@ BOOST_MATH_GPU_ENABLED T ibeta_derivative_imp(T a, T b, T x, const Policy& pol)
 //
 template <class RT1, class RT2, class Policy>
 BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<RT1, RT2>::type
-   beta(RT1 a, RT2 b, const Policy&, const std::true_type*)
+   beta(RT1 a, RT2 b, const Policy&, const boost::math::true_type*)
 {
    BOOST_FPU_EXCEPTION_GUARD
    typedef typename tools::promote_args<RT1, RT2>::type result_type;
@@ -1586,7 +1587,7 @@ BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<RT1, RT2>::type
 }
 template <class RT1, class RT2, class RT3>
 BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<RT1, RT2, RT3>::type
-   beta(RT1 a, RT2 b, RT3 x, const std::false_type*)
+   beta(RT1 a, RT2 b, RT3 x, const boost::math::false_type*)
 {
    return boost::math::beta(a, b, x, policies::policy<>());
 }

--- a/include/boost/math/special_functions/expm1.hpp
+++ b/include/boost/math/special_functions/expm1.hpp
@@ -334,6 +334,18 @@ BOOST_MATH_GPU_ENABLED auto expm1(float x)
    return ::expm1f(x);
 }
 
+template <typename T, typename Policy>
+BOOST_MATH_GPU_ENABLED auto expm1(T x, const Policy&)
+{
+   return ::expm1(x);
+}
+
+template <typename Policy>
+BOOST_MATH_GPU_ENABLED auto expm1(float x, const Policy&)
+{
+   return ::expm1f(x);
+}
+
 } // Namespace math
 } // Namespace boost
 

--- a/include/boost/math/special_functions/expm1.hpp
+++ b/include/boost/math/special_functions/expm1.hpp
@@ -11,10 +11,13 @@
 #pragma once
 #endif
 
+#include <boost/math/tools/config.hpp>
+
+#ifndef BOOST_MATH_HAS_NVRTC
+
 #include <cmath>
 #include <cstdint>
 #include <limits>
-#include <boost/math/tools/config.hpp>
 #include <boost/math/tools/series.hpp>
 #include <boost/math/tools/precision.hpp>
 #include <boost/math/tools/big_constant.hpp>
@@ -313,6 +316,28 @@ BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<T>::type expm1(T x)
 
 } // namespace math
 } // namespace boost
+
+#else // Special handling for NVRTC 
+
+namespace boost {
+namespace math {
+
+template <typename T>
+BOOST_MATH_GPU_ENABLED auto expm1(T x)
+{
+   return ::expm1(x);
+}
+
+template <>
+BOOST_MATH_GPU_ENABLED auto expm1(float x)
+{
+   return ::expm1f(x);
+}
+
+} // Namespace math
+} // Namespace boost
+
+#endif // BOOST_MATH_HAS_NVRTC
 
 #endif // BOOST_MATH_HYPOT_INCLUDED
 

--- a/include/boost/math/special_functions/fpclassify.hpp
+++ b/include/boost/math/special_functions/fpclassify.hpp
@@ -14,7 +14,7 @@
 
 #include <boost/math/tools/config.hpp>
 
-#ifndef BOOST_MATH_NVRTC_ENABLED
+#ifndef BOOST_MATH_HAS_NVRTC
 
 #include <boost/math/tools/real_cast.hpp>
 #include <boost/math/special_functions/math_fwd.hpp>
@@ -791,7 +791,7 @@ inline BOOST_MATH_GPU_ENABLED int fpclassify(T x)
 } // Namespace math
 } // Namespace boost
 
-#endif // BOOST_MATH_NVRTC_ENABLED
+#endif // BOOST_MATH_HAS_NVRTC
 
 #endif // BOOST_MATH_FPCLASSIFY_HPP
 

--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -21,6 +21,7 @@
 #include <boost/math/tools/fraction.hpp>
 #include <boost/math/tools/precision.hpp>
 #include <boost/math/tools/promotion.hpp>
+#include <boost/math/tools/type_traits.hpp>
 #include <boost/math/tools/assert.hpp>
 #include <boost/math/policies/error_handling.hpp>
 #include <boost/math/constants/constants.hpp>
@@ -1875,7 +1876,7 @@ BOOST_MATH_GPU_ENABLED T gamma_p_derivative_imp(T a, T x, const Policy& pol)
 
 template <class T, class Policy>
 BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<T>::type
-   tgamma(T z, const Policy& /* pol */, const std::true_type)
+   tgamma(T z, const Policy& /* pol */, const boost::math::true_type)
 {
    BOOST_FPU_EXCEPTION_GUARD
    typedef typename tools::promote_args<T>::type result_type;
@@ -1983,7 +1984,7 @@ const typename lgamma_initializer<T, Policy>::init lgamma_initializer<T, Policy>
 
 template <class T1, class T2, class Policy>
 BOOST_MATH_GPU_ENABLED inline tools::promote_args_t<T1, T2>
-   tgamma(T1 a, T2 z, const Policy&, const std::false_type)
+   tgamma(T1 a, T2 z, const Policy&, const boost::math::false_type)
 {
    BOOST_FPU_EXCEPTION_GUARD
    typedef tools::promote_args_t<T1, T2> result_type;
@@ -2006,7 +2007,7 @@ BOOST_MATH_GPU_ENABLED inline tools::promote_args_t<T1, T2>
 
 template <class T1, class T2>
 BOOST_MATH_GPU_ENABLED inline tools::promote_args_t<T1, T2>
-   tgamma(T1 a, T2 z, const std::false_type& tag)
+   tgamma(T1 a, T2 z, const boost::math::false_type& tag)
 {
    return tgamma(a, z, policies::policy<>(), tag);
 }
@@ -2107,7 +2108,7 @@ BOOST_MATH_GPU_ENABLED inline tools::promote_args_t<T1, T2>
    tgamma(T1 a, T2 z, const Policy& pol)
 {
    using result_type = tools::promote_args_t<T1, T2>;
-   return static_cast<result_type>(detail::tgamma(a, z, pol, std::false_type()));
+   return static_cast<result_type>(detail::tgamma(a, z, pol, boost::math::false_type()));
 }
 //
 // Full lower incomplete gamma:

--- a/include/boost/math/special_functions/log1p.hpp
+++ b/include/boost/math/special_functions/log1p.hpp
@@ -12,10 +12,13 @@
 #pragma warning(disable:4702) // Unreachable code (release mode only warning)
 #endif
 
+#include <boost/math/tools/config.hpp>
+
+#ifndef BOOST_MATH_HAS_NVRTC
+
 #include <cmath>
 #include <cstdint>
 #include <limits>
-#include <boost/math/tools/config.hpp>
 #include <boost/math/tools/series.hpp>
 #include <boost/math/tools/rational.hpp>
 #include <boost/math/tools/big_constant.hpp>
@@ -472,6 +475,40 @@ BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<T>::type log1pmx(T x)
 
 } // namespace math
 } // namespace boost
+
+#else // Special handling for NVRTC platform
+
+namespace boost {
+namespace math {
+
+template <typename T>
+BOOST_MATH_GPU_ENABLED auto log1p(T x)
+{
+   return ::log1p(x);
+}
+
+template <>
+BOOST_MATH_GPU_ENABLED auto log1p(float x)
+{
+   return ::log1pf(x);
+}
+
+template <typename T, typename Policy>
+BOOST_MATH_GPU_ENABLED auto log1p(T x, const Policy&)
+{
+   return ::log1p(x);
+}
+
+template <typename Policy>
+BOOST_MATH_GPU_ENABLED auto log1p(float x, const Policy&)
+{
+   return ::log1pf(x);
+}
+
+} // namespace math
+} // namespace boost
+
+#endif // BOOST_MATH_HAS_NVRTC
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/include/boost/math/special_functions/round.hpp
+++ b/include/boost/math/special_functions/round.hpp
@@ -12,6 +12,9 @@
 #endif
 
 #include <boost/math/tools/config.hpp>
+
+#ifndef BOOST_MATH_HAS_NVRTC
+
 #include <boost/math/ccmath/detail/config.hpp>
 #include <boost/math/policies/error_handling.hpp>
 #include <boost/math/special_functions/math_fwd.hpp>
@@ -240,5 +243,87 @@ BOOST_MATH_GPU_ENABLED inline long long llround(const T& v)
 }
 
 }} // namespaces
+
+#else // Specialized NVRTC overloads
+
+namespace boost {
+namespace math {
+
+template <typename T>
+BOOST_MATH_GPU_ENABLED T round(T x)
+{
+   return ::round(x);
+}
+
+template <>
+BOOST_MATH_GPU_ENABLED float round(float x)
+{
+   return ::roundf(x);
+}
+
+template <typename T, typename Policy>
+BOOST_MATH_GPU_ENABLED T round(T x, const Policy&)
+{
+   return ::round(x);
+}
+
+template <typename Policy>
+BOOST_MATH_GPU_ENABLED float round(float x, const Policy&)
+{
+   return ::roundf(x);
+}
+
+template <typename T>
+BOOST_MATH_GPU_ENABLED long lround(T x)
+{
+   return ::lround(x);
+}
+
+template <>
+BOOST_MATH_GPU_ENABLED long lround(float x)
+{
+   return ::lroundf(x);
+}
+
+template <typename T, typename Policy>
+BOOST_MATH_GPU_ENABLED long lround(T x, const Policy&)
+{
+   return ::lround(x);
+}
+
+template <typename Policy>
+BOOST_MATH_GPU_ENABLED long lround(float x, const Policy&)
+{
+   return ::lroundf(x);
+}
+
+template <typename T>
+BOOST_MATH_GPU_ENABLED long long llround(T x)
+{
+   return ::llround(x);
+}
+
+template <>
+BOOST_MATH_GPU_ENABLED long long llround(float x)
+{
+   return ::llroundf(x);
+}
+
+template <typename T, typename Policy>
+BOOST_MATH_GPU_ENABLED long long llround(T x, const Policy&)
+{
+   return ::llround(x);
+}
+
+template <typename Policy>
+BOOST_MATH_GPU_ENABLED long long llround(float x, const Policy&)
+{
+   return ::llroundf(x);
+}
+
+} // Namespace math
+} // Namespace boost
+
+#endif // BOOST_MATH_HAS_NVRTC
 
 #endif // BOOST_MATH_ROUND_HPP

--- a/include/boost/math/special_functions/trunc.hpp
+++ b/include/boost/math/special_functions/trunc.hpp
@@ -352,13 +352,28 @@ BOOST_MATH_GPU_ENABLED inline boost::math::enable_if_t<!boost::math::is_construc
 
 template <class T, class Policy>
 BOOST_MATH_GPU_ENABLED inline boost::math::enable_if_t<boost::math::is_constructible_v<long long, T>, long long>
-   llconvertert(const T& v, const Policy&)
+   llconvert(const T& v, const Policy&)
 {
    return static_cast<long long>(v);
 }
 
 template <class T, class Policy>
 BOOST_MATH_GPU_ENABLED inline typename boost::math::enable_if_t<!boost::math::is_constructible_v<long long, T>, long long>
+   llconvert(const T& v, const Policy& pol)
+{
+   using boost::math::lltrunc;
+   return lltrunc(v, pol);
+}
+
+template <class T, class Policy>
+BOOST_MATH_GPU_ENABLED [[deprecated("Use llconvert")]] inline boost::math::enable_if_t<boost::math::is_constructible_v<long long, T>, long long>
+   llconvertert(const T& v, const Policy&)
+{
+   return static_cast<long long>(v);
+}
+
+template <class T, class Policy>
+BOOST_MATH_GPU_ENABLED [[deprecated("Use llconvert")]] inline typename boost::math::enable_if_t<!boost::math::is_constructible_v<long long, T>, long long>
    llconvertert(const T& v, const Policy& pol)
 {
    using boost::math::lltrunc;

--- a/include/boost/math/special_functions/trunc.hpp
+++ b/include/boost/math/special_functions/trunc.hpp
@@ -268,7 +268,7 @@ namespace detail {
 template <typename TargetType, typename T>
 BOOST_MATH_GPU_ENABLED TargetType integer_trunc_impl(T v)
 {
-   double r = boost::math::trunc(v, pol);
+   double r = boost::math::trunc(v);
 
    const double max_val = ldexp(1.0, boost::math::numeric_limits<TargetType>::digits);
 

--- a/include/boost/math/special_functions/trunc.hpp
+++ b/include/boost/math/special_functions/trunc.hpp
@@ -11,9 +11,14 @@
 #pragma once
 #endif
 
+#include <boost/math/tools/config.hpp>
+#include <boost/math/tools/type_traits.hpp>
+#include <boost/math/tools/numeric_limits.hpp>
+
+#ifndef BOOST_MATH_HAS_NVRTC
+
 #include <type_traits>
 #include <boost/math/special_functions/math_fwd.hpp>
-#include <boost/math/tools/config.hpp>
 #include <boost/math/ccmath/detail/config.hpp>
 #include <boost/math/policies/error_handling.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
@@ -57,6 +62,48 @@ BOOST_MATH_GPU_ENABLED inline tools::promote_args_t<T> trunc(const T& v)
 {
    return trunc(v, policies::policy<>());
 }
+
+#else // Special handling for nvrtc
+
+namespace boost {
+namespace math {
+
+namespace detail {
+
+template <typename T>
+BOOST_MATH_GPU_ENABLED double trunc_impl(T x)
+{
+   return static_cast<double>(x);
+}
+
+BOOST_MATH_GPU_ENABLED inline float trunc_impl(float x)
+{
+   return ::truncf(x);
+}
+
+BOOST_MATH_GPU_ENABLED inline double trunc_impl(double x)
+{
+   return ::trunc(x);
+}
+
+} // Namespace detail
+
+template <typename T, typename Policy>
+BOOST_MATH_GPU_ENABLED auto trunc(T x, const Policy&)
+{
+   return detail::trunc_impl(x);
+}
+
+template <typename T>
+BOOST_MATH_GPU_ENABLED auto trunc(T x)
+{
+   return detail::trunc_impl(x);
+}
+
+#endif
+
+#ifndef BOOST_MATH_HAS_NVRTC
+
 //
 // The following functions will not compile unless T has an
 // implicit conversion to the integer types.  For user-defined
@@ -214,15 +261,74 @@ BOOST_MATH_GPU_ENABLED inline long long lltrunc(const T& v)
    return lltrunc(v, policies::policy<>());
 }
 
+#else // Reduced impl specifically for NVRTC platform
+
+namespace detail {
+
+template <typename TargetType, typename T>
+BOOST_MATH_GPU_ENABLED TargetType integer_trunc_impl(T v)
+{
+   double r = boost::math::trunc(v, pol);
+
+   const double max_val = ldexp(1.0, boost::math::numeric_limits<TargetType>::digits);
+
+   if (r >= max_val || r < -max_val)
+   {
+      r = 0;
+   }
+
+   return static_cast<TargetType>(r);
+}
+
+} // Namespace detail
+
+template <typename T>
+BOOST_MATH_GPU_ENABLED int itrunc(T v)
+{
+   return detail::integer_trunc_impl<int>(v);
+}
+
+template <typename T, typename Policy>
+BOOST_MATH_GPU_ENABLED int itrunc(T v, const Policy&)
+{
+   return detail::integer_trunc_impl<int>(v);
+}
+
+template <typename T>
+BOOST_MATH_GPU_ENABLED long ltrunc(T v)
+{
+   return detail::integer_trunc_impl<long>(v);
+}
+
+template <typename T, typename Policy>
+BOOST_MATH_GPU_ENABLED long ltrunc(T v, const Policy&)
+{
+   return detail::integer_trunc_impl<long>(v);
+}
+
+template <typename T>
+BOOST_MATH_GPU_ENABLED long long lltrunc(T v)
+{
+   return detail::integer_trunc_impl<long long>(v);
+}
+
+template <typename T, typename Policy>
+BOOST_MATH_GPU_ENABLED long long lltrunc(T v, const Policy&)
+{
+   return detail::integer_trunc_impl<long long>(v);
+}
+
+#endif // BOOST_MATH_HAS_NVRTC
+
 template <class T, class Policy>
-BOOST_MATH_GPU_ENABLED inline typename std::enable_if<std::is_constructible<int, T>::value, int>::type
+BOOST_MATH_GPU_ENABLED inline boost::math::enable_if_t<boost::math::is_constructible_v<int, T>, int>
    iconvert(const T& v, const Policy&)
 {
    return static_cast<int>(v);
 }
 
 template <class T, class Policy>
-BOOST_MATH_GPU_ENABLED inline typename std::enable_if<!std::is_constructible<int, T>::value, int>::type
+BOOST_MATH_GPU_ENABLED inline boost::math::enable_if_t<!boost::math::is_constructible_v<int, T>, int>
    iconvert(const T& v, const Policy& pol)
 {
    using boost::math::itrunc;
@@ -230,14 +336,14 @@ BOOST_MATH_GPU_ENABLED inline typename std::enable_if<!std::is_constructible<int
 }
 
 template <class T, class Policy>
-BOOST_MATH_GPU_ENABLED inline typename std::enable_if<std::is_constructible<long, T>::value, long>::type
+BOOST_MATH_GPU_ENABLED inline boost::math::enable_if_t<boost::math::is_constructible_v<long, T>, long>
    lconvert(const T& v, const Policy&)
 {
    return static_cast<long>(v);
 }
 
 template <class T, class Policy>
-BOOST_MATH_GPU_ENABLED inline typename std::enable_if<!std::is_constructible<long, T>::value, long>::type
+BOOST_MATH_GPU_ENABLED inline boost::math::enable_if_t<!boost::math::is_constructible_v<long, T>, long>
    lconvert(const T& v, const Policy& pol)
 {
    using boost::math::ltrunc;
@@ -245,14 +351,14 @@ BOOST_MATH_GPU_ENABLED inline typename std::enable_if<!std::is_constructible<lon
 }
 
 template <class T, class Policy>
-BOOST_MATH_GPU_ENABLED inline typename std::enable_if<std::is_constructible<long long, T>::value, long long>::type
+BOOST_MATH_GPU_ENABLED inline boost::math::enable_if_t<boost::math::is_constructible_v<long long, T>, long long>
    llconvertert(const T& v, const Policy&)
 {
    return static_cast<long long>(v);
 }
 
 template <class T, class Policy>
-BOOST_MATH_GPU_ENABLED inline typename std::enable_if<!std::is_constructible<long long, T>::value, long long>::type
+BOOST_MATH_GPU_ENABLED inline typename boost::math::enable_if_t<!boost::math::is_constructible_v<long long, T>, long long>
    llconvertert(const T& v, const Policy& pol)
 {
    using boost::math::lltrunc;

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -775,7 +775,9 @@ BOOST_MATH_GPU_ENABLED constexpr T cuda_safe_max(const T& a, const T& b) { retur
 #define BOOST_MATH_FP_NORMAL FP_NORMAL
 
 // Missing type from NVRTC
+#include <cstdint>
 #define BOOST_MATH_SIZE_T std::size_t
+#define BOOST_MATH_UINTMAX_T std::uintmax_t
 
 #else // Special section for CUDA NVRTC to ensure we consume no STL headers
 
@@ -803,7 +805,9 @@ BOOST_MATH_GPU_ENABLED constexpr void gpu_safe_swap(T& a, T& b) { T t(a); a = b;
 #define BOOST_MATH_FP_ZERO 2
 #define BOOST_MATH_FP_SUBNORMAL 3
 #define BOOST_MATH_FP_NORMAL 4
+
 #define BOOST_MATH_SIZE_T unsigned long
+#define BOOST_MATH_UINTMAX_T unsigned long
 
 #if defined(__cpp_inline_variables) && __cpp_inline_variables >= 201606L
 #  define BOOST_MATH_INLINE_CONSTEXPR inline constexpr

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -774,7 +774,7 @@ BOOST_MATH_GPU_ENABLED constexpr T cuda_safe_max(const T& a, const T& b) { retur
 #  define BOOST_MATH_STANDALONE
 #endif
 
-#define BOOST_MATH_NVRTC_ENABLED
+#define BOOST_MATH_HAS_NVRTC
 #define BOOST_MATH_ENABLE_CUDA
 #define BOOST_MATH_HAS_GPU_SUPPORT
 

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -776,12 +776,6 @@ BOOST_MATH_GPU_ENABLED constexpr T cuda_safe_max(const T& a, const T& b) { retur
 
 #else // Special section for CUDA NVRTC to ensure we consume no STL headers
 
-// Dependency on the order of includes
-#include <nvrtc.h>
-#include <cuda.h>
-#include <cuda_runtime.h>
-#include <cuda/std/type_traits>
-
 #ifndef BOOST_MATH_STANDALONE
 #  define BOOST_MATH_STANDALONE
 #endif
@@ -791,6 +785,8 @@ BOOST_MATH_GPU_ENABLED constexpr T cuda_safe_max(const T& a, const T& b) { retur
 #define BOOST_MATH_HAS_GPU_SUPPORT
 
 #define BOOST_MATH_GPU_ENABLED __host__ __device__
+
+#define BOOST_MATH_STATIC static
 
 template <class T>
 BOOST_MATH_GPU_ENABLED constexpr void gpu_safe_swap(T& a, T& b) { T t(a); a = b; b = t; }

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -774,6 +774,9 @@ BOOST_MATH_GPU_ENABLED constexpr T cuda_safe_max(const T& a, const T& b) { retur
 #define BOOST_MATH_FP_SUBNORMAL FP_SUBNORMAL
 #define BOOST_MATH_FP_NORMAL FP_NORMAL
 
+// Missing type from NVRTC
+#define BOOST_MATH_SIZE_T std::size_t
+
 #else // Special section for CUDA NVRTC to ensure we consume no STL headers
 
 #ifndef BOOST_MATH_STANDALONE
@@ -800,6 +803,7 @@ BOOST_MATH_GPU_ENABLED constexpr void gpu_safe_swap(T& a, T& b) { T t(a); a = b;
 #define BOOST_MATH_FP_ZERO 2
 #define BOOST_MATH_FP_SUBNORMAL 3
 #define BOOST_MATH_FP_NORMAL 4
+#define BOOST_MATH_SIZE_T unsigned long
 
 #if defined(__cpp_inline_variables) && __cpp_inline_variables >= 201606L
 #  define BOOST_MATH_INLINE_CONSTEXPR inline constexpr

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -669,6 +669,12 @@ namespace boost{ namespace math{
 //
 
 #ifdef __CUDACC__
+
+// We have to get our include order correct otherwise you get compilation failures
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda/std/type_traits>
+
 #  define BOOST_MATH_CUDA_ENABLED __host__ __device__
 #  define BOOST_MATH_HAS_GPU_SUPPORT
 
@@ -768,7 +774,13 @@ BOOST_MATH_GPU_ENABLED constexpr T cuda_safe_max(const T& a, const T& b) { retur
 #define BOOST_MATH_FP_SUBNORMAL FP_SUBNORMAL
 #define BOOST_MATH_FP_NORMAL FP_NORMAL
 
-#else // Special section for CUDA NVRTC to ensure we consume no headers
+#else // Special section for CUDA NVRTC to ensure we consume no STL headers
+
+// Dependency on the order of includes
+#include <nvrtc.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda/std/type_traits>
 
 #ifndef BOOST_MATH_STANDALONE
 #  define BOOST_MATH_STANDALONE

--- a/include/boost/math/tools/mp.hpp
+++ b/include/boost/math/tools/mp.hpp
@@ -11,9 +11,8 @@
 #ifndef BOOST_MATH_TOOLS_MP
 #define BOOST_MATH_TOOLS_MP
 
-#include <type_traits>
-#include <cstddef>
-#include <utility>
+#include <boost/math/tools/config.hpp>
+#include <boost/math/tools/type_traits.hpp>
 
 namespace boost { namespace math { namespace tools { namespace meta_programming {
 
@@ -23,12 +22,12 @@ template<typename... T>
 struct mp_list {};
 
 // Size_t
-template<std::size_t N> 
-using mp_size_t = std::integral_constant<std::size_t, N>;
+template<BOOST_MATH_SIZE_T N> 
+using mp_size_t = boost::math::integral_constant<BOOST_MATH_SIZE_T, N>;
 
 // Boolean
 template<bool B>
-using mp_bool = std::integral_constant<bool, B>;
+using mp_bool = boost::math::integral_constant<bool, B>;
 
 // Identity
 template<typename T>
@@ -53,7 +52,7 @@ struct mp_size_impl {};
 template<template<typename...> class L, typename... T> // Template template parameter must use class
 struct mp_size_impl<L<T...>>
 {
-    using type = std::integral_constant<std::size_t, sizeof...(T)>;
+    using type = boost::math::integral_constant<BOOST_MATH_SIZE_T, sizeof...(T)>;
 };
 }
 
@@ -79,7 +78,7 @@ namespace detail {
 // At
 // TODO - Use tree based lookup for larger typelists
 // http://odinthenerd.blogspot.com/2017/04/tree-based-lookup-why-kvasirmpl-is.html
-template<typename L, std::size_t>
+template<typename L, BOOST_MATH_SIZE_T>
 struct mp_at_c {};
 
 template<template<typename...> class L, typename T0, typename... T>
@@ -168,7 +167,7 @@ struct mp_at_c<L<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T...>, 1
 };
 }
 
-template<typename L, std::size_t Index>
+template<typename L, BOOST_MATH_SIZE_T Index>
 using mp_at_c = typename detail::mp_at_c<L, Index>::type;
 
 template<typename L, typename Index>
@@ -336,25 +335,11 @@ using mp_remove_if = typename detail::mp_remove_if_impl<L, P>::type;
 template<typename L, typename Q> 
 using mp_remove_if_q = mp_remove_if<L, Q::template fn>;
 
-// Index sequence
-// Use C++14 index sequence if available
-#if defined(__cpp_lib_integer_sequence) && (__cpp_lib_integer_sequence >= 201304)
-template<std::size_t... Index>
-using index_sequence = std::index_sequence<Index...>;
-
-template<std::size_t N>
-using make_index_sequence = std::make_index_sequence<N>;
-
-template<typename... T>
-using index_sequence_for = std::index_sequence_for<T...>;
-
-#else
-
 template<typename T, T... Index>
 struct integer_sequence {};
 
-template<std::size_t... Index>
-using index_sequence = integer_sequence<std::size_t, Index...>;
+template<BOOST_MATH_SIZE_T... Index>
+using index_sequence = integer_sequence<BOOST_MATH_SIZE_T, Index...>;
 
 namespace detail {
 
@@ -426,13 +411,11 @@ struct make_integer_sequence_impl
 template<typename T, T N>
 using make_integer_sequence = typename detail::make_integer_sequence_impl<T, N>::type;
 
-template<std::size_t N>
-using make_index_sequence = make_integer_sequence<std::size_t, N>;
+template<BOOST_MATH_SIZE_T N>
+using make_index_sequence = make_integer_sequence<BOOST_MATH_SIZE_T, N>;
 
 template<typename... T>
-using index_sequence_for = make_integer_sequence<std::size_t, sizeof...(T)>;
-
-#endif 
+using index_sequence_for = make_integer_sequence<BOOST_MATH_SIZE_T, sizeof...(T)>;
 
 }}}} // namespaces
 

--- a/include/boost/math/tools/numeric_limits.hpp
+++ b/include/boost/math/tools/numeric_limits.hpp
@@ -33,6 +33,8 @@ template <typename T>
 struct numeric_limits 
 #ifndef BOOST_MATH_HAS_NVRTC
 : public std::numeric_limits<T> {};
+#else
+{};
 #endif
 
 #if defined(BOOST_MATH_HAS_GPU_SUPPORT) && !defined(BOOST_MATH_HAS_NVRTC)
@@ -608,15 +610,15 @@ struct numeric_limits<unsigned short>
     BOOST_MATH_STATIC constexpr bool tinyness_before = false;
 
     // Member Functions
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 65535; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned short (min)         () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned short (max)         () { return 65535U; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned short lowest        () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned short epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned short round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned short infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned short quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned short signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned short denorm_min    () { return 0; }
 };
 
 template <>
@@ -645,15 +647,15 @@ struct numeric_limits<int>
     BOOST_MATH_STATIC constexpr bool tinyness_before = false;
 
     // Member Functions
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return -2147483648; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 2147483647; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return -2147483648; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr int (min)         () { return -2147483648; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr int (max)         () { return 2147483647; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr int lowest        () { return -2147483648; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr int epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr int round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr int infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr int quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr int signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr int denorm_min    () { return 0; }
 };
 
 template <>
@@ -682,15 +684,15 @@ struct numeric_limits<unsigned int>
     BOOST_MATH_STATIC constexpr bool tinyness_before = false;
 
     // Member Functions
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 4294967295U; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned int (min)         () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned int (max)         () { return 4294967295U; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned int lowest        () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned int epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned int round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned int infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned int quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned int signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned int denorm_min    () { return 0; }
 };
 
 template <>
@@ -719,15 +721,15 @@ struct numeric_limits<long>
     BOOST_MATH_STATIC constexpr bool tinyness_before = false;
 
     // Member Functions
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return -9223372036854775808L; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 9223372036854775807L; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return -9223372036854775808L; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long (min)         () { return -9223372036854775808L; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long (max)         () { return 9223372036854775807L; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long lowest        () { return -9223372036854775808L; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long denorm_min    () { return 0; }
 };
 
 template <>
@@ -756,15 +758,15 @@ struct numeric_limits<unsigned long>
     BOOST_MATH_STATIC constexpr bool tinyness_before = false;
 
     // Member Functions
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 18446744073709551615UL; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long (min)         () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long (max)         () { return 18446744073709551615UL; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long lowest        () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long denorm_min    () { return 0; }
 };
 
 template <>
@@ -793,15 +795,15 @@ struct numeric_limits<long long>
     BOOST_MATH_STATIC constexpr bool tinyness_before = false;
 
     // Member Functions
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return -9223372036854775808LL; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 9223372036854775807LL; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return -9223372036854775808LL; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long long (min)         () { return -9223372036854775808LL; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long long (max)         () { return 9223372036854775807LL; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long long lowest        () { return -9223372036854775808LL; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long long epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long long round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long long infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long long quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long long signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr long long denorm_min    () { return 0; }
 };
 
 template <>
@@ -830,15 +832,15 @@ struct numeric_limits<unsigned long long>
     BOOST_MATH_STATIC constexpr bool tinyness_before = false;
 
     // Member Functions
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 18446744073709551615UL; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
-    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long long (min)         () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long long (max)         () { return 18446744073709551615UL; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long long lowest        () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long long epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long long round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long long infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long long quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long long signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr unsigned long long denorm_min    () { return 0; }
 };
 
 template <>

--- a/include/boost/math/tools/numeric_limits.hpp
+++ b/include/boost/math/tools/numeric_limits.hpp
@@ -7,22 +7,35 @@
 //  GPU platforms like CUDA since they are missing the __device__ marker
 //  and libcu++ does not provide something analogous.
 //  Rather than using giant if else blocks make our own version of numeric limits
+//
+//  On the CUDA NVRTC platform we use a best attempt at emulating the functions
+//  and values since we do not have any macros to go off of.
+//  Use the values as found on GCC 11.4 RHEL 9.4 x64
 
 #ifndef BOOST_MATH_TOOLS_NUMERIC_LIMITS_HPP
 #define BOOST_MATH_TOOLS_NUMERIC_LIMITS_HPP
 
 #include <boost/math/tools/config.hpp>
+
+#ifndef BOOST_MATH_HAS_NVRTC
+
 #include <type_traits>
 #include <limits>
 #include <climits>
+#include <cfloat>
+
+#endif
 
 namespace boost {
 namespace math {
 
 template <typename T>
-struct numeric_limits : public std::numeric_limits<T> {};
+struct numeric_limits 
+#ifndef BOOST_MATH_HAS_NVRTC
+: public std::numeric_limits<T> {};
+#endif
 
-#ifdef BOOST_MATH_HAS_GPU_SUPPORT
+#if defined(BOOST_MATH_HAS_GPU_SUPPORT) && !defined(BOOST_MATH_HAS_NVRTC)
 
 template <>
 struct numeric_limits<float>
@@ -443,6 +456,415 @@ struct numeric_limits<bool>
     BOOST_MATH_STATIC constexpr int max_exponent10 = std::numeric_limits<bool>::max_exponent10;
     BOOST_MATH_STATIC constexpr bool traps = std::numeric_limits<bool>::traps;
     BOOST_MATH_STATIC constexpr bool tinyness_before = std::numeric_limits<bool>::tinyness_before;
+
+    // Member Functions
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr bool (min)         () { return false; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr bool (max)         () { return true; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr bool lowest        () { return false; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr bool epsilon       () { return false; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr bool round_error   () { return false; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr bool infinity      () { return false; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr bool quiet_NaN     () { return false; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr bool signaling_NaN () { return false; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr bool denorm_min    () { return false; }
+};
+
+#elif defined(BOOST_MATH_HAS_NVRTC) // Pure NVRTC support - Removes rounding style and approximates the traits
+
+template <>
+struct numeric_limits<float>
+{
+    BOOST_MATH_STATIC constexpr bool is_specialized = true;
+    BOOST_MATH_STATIC constexpr bool is_signed = true;
+    BOOST_MATH_STATIC constexpr bool is_integer = false;
+    BOOST_MATH_STATIC constexpr bool is_exact = false;
+    BOOST_MATH_STATIC constexpr bool has_infinity = true;
+    BOOST_MATH_STATIC constexpr bool has_quiet_NaN = true;
+    BOOST_MATH_STATIC constexpr bool has_signaling_NaN = true;
+
+    BOOST_MATH_STATIC constexpr bool is_iec559 = true;
+    BOOST_MATH_STATIC constexpr bool is_bounded = true;
+    BOOST_MATH_STATIC constexpr bool is_modulo = false;
+    BOOST_MATH_STATIC constexpr int digits = 24;
+    BOOST_MATH_STATIC constexpr int digits10 = 6;
+    BOOST_MATH_STATIC constexpr int max_digits10 = 9;
+    BOOST_MATH_STATIC constexpr int radix = 2;
+    BOOST_MATH_STATIC constexpr int min_exponent = -125;
+    BOOST_MATH_STATIC constexpr int min_exponent10 = -37;
+    BOOST_MATH_STATIC constexpr int max_exponent = 128;
+    BOOST_MATH_STATIC constexpr int max_exponent10 = 38;
+    BOOST_MATH_STATIC constexpr bool traps = false;
+    BOOST_MATH_STATIC constexpr bool tinyness_before = false;
+
+    // Member Functions
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr float (min)         () { return 1.17549435e-38F; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr float (max)         () { return 3.40282347e+38F; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr float lowest        () { return -3.40282347e+38F; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr float epsilon       () { return 1.1920929e-07; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr float round_error   () { return 0.5F; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr float infinity      () { return __int_as_float(0x7f800000); }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr float quiet_NaN     () { return __int_as_float(0x7fc00000); }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr float signaling_NaN () { return __int_as_float(0x7fa00000); }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr float denorm_min    () { return 1.4013e-45F; }
+};
+
+template <>
+struct numeric_limits<double>
+{
+    BOOST_MATH_STATIC constexpr bool is_specialized = true;
+    BOOST_MATH_STATIC constexpr bool is_signed = true;
+    BOOST_MATH_STATIC constexpr bool is_integer = false;
+    BOOST_MATH_STATIC constexpr bool is_exact = false;
+    BOOST_MATH_STATIC constexpr bool has_infinity = true;
+    BOOST_MATH_STATIC constexpr bool has_quiet_NaN = true;
+    BOOST_MATH_STATIC constexpr bool has_signaling_NaN = true;
+
+    BOOST_MATH_STATIC constexpr bool is_iec559 = true;
+    BOOST_MATH_STATIC constexpr bool is_bounded = true;
+    BOOST_MATH_STATIC constexpr bool is_modulo = false;
+    BOOST_MATH_STATIC constexpr int digits = 53;
+    BOOST_MATH_STATIC constexpr int digits10 = 15;
+    BOOST_MATH_STATIC constexpr int max_digits10 = 21;
+    BOOST_MATH_STATIC constexpr int radix = 2;
+    BOOST_MATH_STATIC constexpr int min_exponent = -1021;
+    BOOST_MATH_STATIC constexpr int min_exponent10 = -307;
+    BOOST_MATH_STATIC constexpr int max_exponent = 1024;
+    BOOST_MATH_STATIC constexpr int max_exponent10 = 308;
+    BOOST_MATH_STATIC constexpr bool traps = false;
+    BOOST_MATH_STATIC constexpr bool tinyness_before = false;
+
+    // Member Functions
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr double (min)         () { return 2.2250738585072014e-308; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr double (max)         () { return 1.7976931348623157e+308; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr double lowest        () { return -1.7976931348623157e+308; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr double epsilon       () { return 2.2204460492503131e-16; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr double round_error   () { return 0.5; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr double infinity      () { return __longlong_as_double(0x7ff0000000000000ULL); }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr double quiet_NaN     () { return __longlong_as_double(0x7ff8000000000000ULL); }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr double signaling_NaN () { return __longlong_as_double(0x7ff4000000000000ULL); }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr double denorm_min    () { return 4.9406564584124654e-324; }
+};
+
+template <>
+struct numeric_limits<short>
+{
+    BOOST_MATH_STATIC constexpr bool is_specialized = true;
+    BOOST_MATH_STATIC constexpr bool is_signed = true;
+    BOOST_MATH_STATIC constexpr bool is_integer = true;
+    BOOST_MATH_STATIC constexpr bool is_exact = true;
+    BOOST_MATH_STATIC constexpr bool has_infinity = false;
+    BOOST_MATH_STATIC constexpr bool has_quiet_NaN = false;
+    BOOST_MATH_STATIC constexpr bool has_signaling_NaN = false;
+
+    BOOST_MATH_STATIC constexpr bool is_iec559 = false;
+    BOOST_MATH_STATIC constexpr bool is_bounded = true;
+    BOOST_MATH_STATIC constexpr bool is_modulo = false;
+    BOOST_MATH_STATIC constexpr int digits = 15;
+    BOOST_MATH_STATIC constexpr int digits10 = 4;
+    BOOST_MATH_STATIC constexpr int max_digits10 = 0;
+    BOOST_MATH_STATIC constexpr int radix = 2;
+    BOOST_MATH_STATIC constexpr int min_exponent = 0;
+    BOOST_MATH_STATIC constexpr int min_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr bool traps = true;
+    BOOST_MATH_STATIC constexpr bool tinyness_before = false;
+
+    // Member Functions
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return -32768; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 32767; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return -32768; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+};
+
+template <>
+struct numeric_limits<unsigned short>
+{
+    BOOST_MATH_STATIC constexpr bool is_specialized = true;
+    BOOST_MATH_STATIC constexpr bool is_signed = false;
+    BOOST_MATH_STATIC constexpr bool is_integer = true;
+    BOOST_MATH_STATIC constexpr bool is_exact = true;
+    BOOST_MATH_STATIC constexpr bool has_infinity = false;
+    BOOST_MATH_STATIC constexpr bool has_quiet_NaN = false;
+    BOOST_MATH_STATIC constexpr bool has_signaling_NaN = false;
+
+    BOOST_MATH_STATIC constexpr bool is_iec559 = false;
+    BOOST_MATH_STATIC constexpr bool is_bounded = true;
+    BOOST_MATH_STATIC constexpr bool is_modulo = true;
+    BOOST_MATH_STATIC constexpr int digits = 16;
+    BOOST_MATH_STATIC constexpr int digits10 = 4;
+    BOOST_MATH_STATIC constexpr int max_digits10 = 0;
+    BOOST_MATH_STATIC constexpr int radix = 2;
+    BOOST_MATH_STATIC constexpr int min_exponent = 0;
+    BOOST_MATH_STATIC constexpr int min_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr bool traps = true;
+    BOOST_MATH_STATIC constexpr bool tinyness_before = false;
+
+    // Member Functions
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 65535; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+};
+
+template <>
+struct numeric_limits<int>
+{
+    BOOST_MATH_STATIC constexpr bool is_specialized = true;
+    BOOST_MATH_STATIC constexpr bool is_signed = true;
+    BOOST_MATH_STATIC constexpr bool is_integer = true;
+    BOOST_MATH_STATIC constexpr bool is_exact = true;
+    BOOST_MATH_STATIC constexpr bool has_infinity = false;
+    BOOST_MATH_STATIC constexpr bool has_quiet_NaN = false;
+    BOOST_MATH_STATIC constexpr bool has_signaling_NaN = false;
+
+    BOOST_MATH_STATIC constexpr bool is_iec559 = false;
+    BOOST_MATH_STATIC constexpr bool is_bounded = true;
+    BOOST_MATH_STATIC constexpr bool is_modulo = false;
+    BOOST_MATH_STATIC constexpr int digits = 31;
+    BOOST_MATH_STATIC constexpr int digits10 = 9;
+    BOOST_MATH_STATIC constexpr int max_digits10 = 0;
+    BOOST_MATH_STATIC constexpr int radix = 2;
+    BOOST_MATH_STATIC constexpr int min_exponent = 0;
+    BOOST_MATH_STATIC constexpr int min_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr bool traps = true;
+    BOOST_MATH_STATIC constexpr bool tinyness_before = false;
+
+    // Member Functions
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return -2147483648; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 2147483647; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return -2147483648; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+};
+
+template <>
+struct numeric_limits<unsigned int>
+{
+    BOOST_MATH_STATIC constexpr bool is_specialized = true;
+    BOOST_MATH_STATIC constexpr bool is_signed = false;
+    BOOST_MATH_STATIC constexpr bool is_integer = true;
+    BOOST_MATH_STATIC constexpr bool is_exact = true;
+    BOOST_MATH_STATIC constexpr bool has_infinity = false;
+    BOOST_MATH_STATIC constexpr bool has_quiet_NaN = false;
+    BOOST_MATH_STATIC constexpr bool has_signaling_NaN = false;
+
+    BOOST_MATH_STATIC constexpr bool is_iec559 = false;
+    BOOST_MATH_STATIC constexpr bool is_bounded = true;
+    BOOST_MATH_STATIC constexpr bool is_modulo = true;
+    BOOST_MATH_STATIC constexpr int digits = 32;
+    BOOST_MATH_STATIC constexpr int digits10 = 9;
+    BOOST_MATH_STATIC constexpr int max_digits10 = 0;
+    BOOST_MATH_STATIC constexpr int radix = 2;
+    BOOST_MATH_STATIC constexpr int min_exponent = 0;
+    BOOST_MATH_STATIC constexpr int min_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr bool traps = true;
+    BOOST_MATH_STATIC constexpr bool tinyness_before = false;
+
+    // Member Functions
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 4294967295U; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+};
+
+template <>
+struct numeric_limits<long>
+{
+    BOOST_MATH_STATIC constexpr bool is_specialized = true;
+    BOOST_MATH_STATIC constexpr bool is_signed = true;
+    BOOST_MATH_STATIC constexpr bool is_integer = true;
+    BOOST_MATH_STATIC constexpr bool is_exact = true;
+    BOOST_MATH_STATIC constexpr bool has_infinity = false;
+    BOOST_MATH_STATIC constexpr bool has_quiet_NaN = false;
+    BOOST_MATH_STATIC constexpr bool has_signaling_NaN = false;
+
+    BOOST_MATH_STATIC constexpr bool is_iec559 = false;
+    BOOST_MATH_STATIC constexpr bool is_bounded = true;
+    BOOST_MATH_STATIC constexpr bool is_modulo = false;
+    BOOST_MATH_STATIC constexpr int digits = 63;
+    BOOST_MATH_STATIC constexpr int digits10 = 18;
+    BOOST_MATH_STATIC constexpr int max_digits10 = 0;
+    BOOST_MATH_STATIC constexpr int radix = 2;
+    BOOST_MATH_STATIC constexpr int min_exponent = 0;
+    BOOST_MATH_STATIC constexpr int min_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr bool traps = true;
+    BOOST_MATH_STATIC constexpr bool tinyness_before = false;
+
+    // Member Functions
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return -9223372036854775808L; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 9223372036854775807L; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return -9223372036854775808L; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+};
+
+template <>
+struct numeric_limits<unsigned long>
+{
+    BOOST_MATH_STATIC constexpr bool is_specialized = true;
+    BOOST_MATH_STATIC constexpr bool is_signed = false;
+    BOOST_MATH_STATIC constexpr bool is_integer = true;
+    BOOST_MATH_STATIC constexpr bool is_exact = true;
+    BOOST_MATH_STATIC constexpr bool has_infinity = false;
+    BOOST_MATH_STATIC constexpr bool has_quiet_NaN = false;
+    BOOST_MATH_STATIC constexpr bool has_signaling_NaN = false;
+
+    BOOST_MATH_STATIC constexpr bool is_iec559 = false;
+    BOOST_MATH_STATIC constexpr bool is_bounded = true;
+    BOOST_MATH_STATIC constexpr bool is_modulo = true;
+    BOOST_MATH_STATIC constexpr int digits = 64;
+    BOOST_MATH_STATIC constexpr int digits10 = 19;
+    BOOST_MATH_STATIC constexpr int max_digits10 = 0;
+    BOOST_MATH_STATIC constexpr int radix = 2;
+    BOOST_MATH_STATIC constexpr int min_exponent = 0;
+    BOOST_MATH_STATIC constexpr int min_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr bool traps = true;
+    BOOST_MATH_STATIC constexpr bool tinyness_before = false;
+
+    // Member Functions
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 18446744073709551615UL; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+};
+
+template <>
+struct numeric_limits<long long>
+{
+    BOOST_MATH_STATIC constexpr bool is_specialized = true;
+    BOOST_MATH_STATIC constexpr bool is_signed = true;
+    BOOST_MATH_STATIC constexpr bool is_integer = true;
+    BOOST_MATH_STATIC constexpr bool is_exact = true;
+    BOOST_MATH_STATIC constexpr bool has_infinity = false;
+    BOOST_MATH_STATIC constexpr bool has_quiet_NaN = false;
+    BOOST_MATH_STATIC constexpr bool has_signaling_NaN = false;
+
+    BOOST_MATH_STATIC constexpr bool is_iec559 = false;
+    BOOST_MATH_STATIC constexpr bool is_bounded = true;
+    BOOST_MATH_STATIC constexpr bool is_modulo = false;
+    BOOST_MATH_STATIC constexpr int digits = 63;
+    BOOST_MATH_STATIC constexpr int digits10 = 18;
+    BOOST_MATH_STATIC constexpr int max_digits10 = 0;
+    BOOST_MATH_STATIC constexpr int radix = 2;
+    BOOST_MATH_STATIC constexpr int min_exponent = 0;
+    BOOST_MATH_STATIC constexpr int min_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr bool traps = true;
+    BOOST_MATH_STATIC constexpr bool tinyness_before = false;
+
+    // Member Functions
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return -9223372036854775808LL; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 9223372036854775807LL; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return -9223372036854775808LL; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+};
+
+template <>
+struct numeric_limits<unsigned long long>
+{
+    BOOST_MATH_STATIC constexpr bool is_specialized = true;
+    BOOST_MATH_STATIC constexpr bool is_signed = false;
+    BOOST_MATH_STATIC constexpr bool is_integer = true;
+    BOOST_MATH_STATIC constexpr bool is_exact = true;
+    BOOST_MATH_STATIC constexpr bool has_infinity = false;
+    BOOST_MATH_STATIC constexpr bool has_quiet_NaN = false;
+    BOOST_MATH_STATIC constexpr bool has_signaling_NaN = false;
+
+    BOOST_MATH_STATIC constexpr bool is_iec559 = false;
+    BOOST_MATH_STATIC constexpr bool is_bounded = true;
+    BOOST_MATH_STATIC constexpr bool is_modulo = true;
+    BOOST_MATH_STATIC constexpr int digits = 64;
+    BOOST_MATH_STATIC constexpr int digits10 = 19;
+    BOOST_MATH_STATIC constexpr int max_digits10 = 0;
+    BOOST_MATH_STATIC constexpr int radix = 2;
+    BOOST_MATH_STATIC constexpr int min_exponent = 0;
+    BOOST_MATH_STATIC constexpr int min_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr bool traps = true;
+    BOOST_MATH_STATIC constexpr bool tinyness_before = false;
+
+    // Member Functions
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (min)         () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short (max)         () { return 18446744073709551615UL; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short lowest        () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short epsilon       () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short round_error   () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short infinity      () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short quiet_NaN     () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short signaling_NaN () { return 0; }
+    BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr short denorm_min    () { return 0; }
+};
+
+template <>
+struct numeric_limits<bool>
+{
+    BOOST_MATH_STATIC constexpr bool is_specialized = true;
+    BOOST_MATH_STATIC constexpr bool is_signed = false;
+    BOOST_MATH_STATIC constexpr bool is_integer = true;
+    BOOST_MATH_STATIC constexpr bool is_exact = true;
+    BOOST_MATH_STATIC constexpr bool has_infinity = false;
+    BOOST_MATH_STATIC constexpr bool has_quiet_NaN = false;
+    BOOST_MATH_STATIC constexpr bool has_signaling_NaN = false;
+
+    BOOST_MATH_STATIC constexpr bool is_iec559 = false;
+    BOOST_MATH_STATIC constexpr bool is_bounded = true;
+    BOOST_MATH_STATIC constexpr bool is_modulo = false;
+    BOOST_MATH_STATIC constexpr int digits = 1;
+    BOOST_MATH_STATIC constexpr int digits10 = 0;
+    BOOST_MATH_STATIC constexpr int max_digits10 = 0;
+    BOOST_MATH_STATIC constexpr int radix = 2;
+    BOOST_MATH_STATIC constexpr int min_exponent = 0;
+    BOOST_MATH_STATIC constexpr int min_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent = 0;
+    BOOST_MATH_STATIC constexpr int max_exponent10 = 0;
+    BOOST_MATH_STATIC constexpr bool traps = false;
+    BOOST_MATH_STATIC constexpr bool tinyness_before = false;
 
     // Member Functions
     BOOST_MATH_GPU_ENABLED BOOST_MATH_STATIC constexpr bool (min)         () { return false; }

--- a/include/boost/math/tools/precision.hpp
+++ b/include/boost/math/tools/precision.hpp
@@ -12,6 +12,8 @@
 
 #include <boost/math/tools/config.hpp>
 #include <boost/math/tools/assert.hpp>
+#include <boost/math/tools/type_traits.hpp>
+#include <boost/math/tools/numeric_limits.hpp>
 #include <boost/math/policies/policy.hpp>
 #include <type_traits>
 #include <limits>
@@ -279,7 +281,7 @@ BOOST_MATH_GPU_ENABLED inline constexpr T log_min_value(BOOST_MATH_EXPLICIT_TEMP
 #endif
 
 template <class T>
-BOOST_MATH_GPU_ENABLED constexpr T epsilon(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE_SPEC(T)) noexcept(std::is_floating_point<T>::value)
+BOOST_MATH_GPU_ENABLED constexpr T epsilon(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE_SPEC(T)) noexcept(boost::math::is_floating_point<T>::value)
 {
 #ifndef BOOST_NO_LIMITS_COMPILE_TIME_CONSTANTS
    return detail::epsilon<T>(std::integral_constant<bool, ::std::numeric_limits<T>::is_specialized>());

--- a/include/boost/math/tools/type_traits.hpp
+++ b/include/boost/math/tools/type_traits.hpp
@@ -404,14 +404,14 @@ BOOST_MATH_INLINE_CONSTEXPR bool is_signed_v = boost::math::is_signed<T>::value;
 template <typename T>
 BOOST_MATH_INLINE_CONSTEXPR bool is_unsigned_v = boost::math::is_unsigned<T>::value;
 
-template <typename T>
-BOOST_MATH_INLINE_CONSTEXPR bool is_constructible_v = boost::math::is_constructible<T>::value;
+template <typename T, typename... Args>
+BOOST_MATH_INLINE_CONSTEXPR bool is_constructible_v = boost::math::is_constructible<T, Args...>::value;
 
-template <typename T>
-BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_constructible_v = boost::math::is_trivially_constructible<T>::value;
+template <typename T, typename... Args>
+BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_constructible_v = boost::math::is_trivially_constructible<T, Args...>::value;
 
-template <typename T>
-BOOST_MATH_INLINE_CONSTEXPR bool is_nothrow_constructible_v = boost::math::is_nothrow_constructible<T>::value;
+template <typename T, typename... Args>
+BOOST_MATH_INLINE_CONSTEXPR bool is_nothrow_constructible_v = boost::math::is_nothrow_constructible<T, Args...>::value;
 
 template <typename T>
 BOOST_MATH_INLINE_CONSTEXPR bool is_default_constructible_v = boost::math::is_default_constructible<T>::value;

--- a/test/nvrtc_jamfile
+++ b/test/nvrtc_jamfile
@@ -12,6 +12,8 @@ project : requirements
 # Special Functions
 run test_cbrt_nvrtc_double.cpp ;
 run test_cbrt_nvrtc_float.cpp ;
+run test_expm1_nvrtc_double.cpp ;
+run test_expm1_nvrtc_float.cpp ;
 run test_fpclassify_nvrtc_double.cpp ;
 run test_fpclassify_nvrtc_float.cpp ;
 run test_gamma_nvrtc_double.cpp ;

--- a/test/nvrtc_jamfile
+++ b/test/nvrtc_jamfile
@@ -16,5 +16,7 @@ run test_fpclassify_nvrtc_double.cpp ;
 run test_fpclassify_nvrtc_float.cpp ;
 run test_gamma_nvrtc_double.cpp ;
 run test_gamma_nvrtc_float.cpp ;
+run test_round_nvrtc_double.cpp ;
+run test_round_nvrtc_float.cpp ;
 run test_sign_nvrtc_double.cpp ;
 run test_sign_nvrtc_float.cpp ;

--- a/test/nvrtc_jamfile
+++ b/test/nvrtc_jamfile
@@ -18,6 +18,8 @@ run test_fpclassify_nvrtc_double.cpp ;
 run test_fpclassify_nvrtc_float.cpp ;
 run test_gamma_nvrtc_double.cpp ;
 run test_gamma_nvrtc_float.cpp ;
+run test_log1p_nvrtc_double.cpp ;
+run test_log1p_nvrtc_float.cpp ;
 run test_round_nvrtc_double.cpp ;
 run test_round_nvrtc_float.cpp ;
 run test_sign_nvrtc_double.cpp ;

--- a/test/nvrtc_jamfile
+++ b/test/nvrtc_jamfile
@@ -20,3 +20,4 @@ run test_round_nvrtc_double.cpp ;
 run test_round_nvrtc_float.cpp ;
 run test_sign_nvrtc_double.cpp ;
 run test_sign_nvrtc_float.cpp ;
+run test_trunc_nvrtc_double.cpp ;

--- a/test/pow_test.cpp
+++ b/test/pow_test.cpp
@@ -18,7 +18,6 @@
 #include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <boost/typeof/typeof.hpp>
-#include <boost/type_traits/is_same.hpp>
 #include <boost/math/tools/assert.hpp>
 
 #include <boost/math/special_functions/pow.hpp>
@@ -103,15 +102,15 @@ void test_with_big_exponents()
 
 void test_return_types()
 {
-    static_assert((is_same<BOOST_TYPEOF(pow<2>('\1')), double>::value), "Return type mismatch");
-    static_assert((is_same<BOOST_TYPEOF(pow<2>(L'\2')), double>::value), "Return type mismatch");
-    static_assert((is_same<BOOST_TYPEOF(pow<2>(3)), double>::value), "Return type mismatch");
-    static_assert((is_same<BOOST_TYPEOF(pow<2>(4u)), double>::value), "Return type mismatch");
-    static_assert((is_same<BOOST_TYPEOF(pow<2>(5ul)), double>::value), "Return type mismatch");
-    static_assert((is_same<BOOST_TYPEOF(pow<2>(6.0f)), float>::value), "Return type mismatch");
-    static_assert((is_same<BOOST_TYPEOF(pow<2>(7.0)), double>::value), "Return type mismatch");
+    static_assert((boost::math::is_same<BOOST_TYPEOF(pow<2>('\1')), double>::value), "Return type mismatch");
+    static_assert((boost::math::is_same<BOOST_TYPEOF(pow<2>(L'\2')), double>::value), "Return type mismatch");
+    static_assert((boost::math::is_same<BOOST_TYPEOF(pow<2>(3)), double>::value), "Return type mismatch");
+    static_assert((boost::math::is_same<BOOST_TYPEOF(pow<2>(4u)), double>::value), "Return type mismatch");
+    static_assert((boost::math::is_same<BOOST_TYPEOF(pow<2>(5ul)), double>::value), "Return type mismatch");
+    static_assert((boost::math::is_same<BOOST_TYPEOF(pow<2>(6.0f)), float>::value), "Return type mismatch");
+    static_assert((boost::math::is_same<BOOST_TYPEOF(pow<2>(7.0)), double>::value), "Return type mismatch");
 #ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-    static_assert((is_same<BOOST_TYPEOF(pow<2>(7.0l)), long double>::value), "Return type mismatch");
+    static_assert((boost::math::is_same<BOOST_TYPEOF(pow<2>(7.0l)), long double>::value), "Return type mismatch");
 #endif
 }
 

--- a/test/test_expm1_nvrtc_double.cpp
+++ b/test/test_expm1_nvrtc_double.cpp
@@ -1,0 +1,186 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/expm1.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <nvrtc.h>
+
+typedef double float_type;
+
+const char* cuda_kernel = R"(
+typedef double float_type;
+#include <boost/math/special_functions/expm1.hpp>
+extern "C" __global__ 
+void test_expm1_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::expm1(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_expm1_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_expm1_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_expm1_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            auto res = boost::math::expm1(h_in1[i]);
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/test/test_expm1_nvrtc_float.cpp
+++ b/test/test_expm1_nvrtc_float.cpp
@@ -1,0 +1,186 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/expm1.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <nvrtc.h>
+
+typedef float float_type;
+
+const char* cuda_kernel = R"(
+typedef float float_type;
+#include <boost/math/special_functions/expm1.hpp>
+extern "C" __global__ 
+void test_expm1_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::expm1(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_expm1_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_expm1_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_expm1_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            auto res = boost::math::expm1(h_in1[i]);
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/test/test_fpclassify_nvrtc_double.cpp
+++ b/test/test_fpclassify_nvrtc_double.cpp
@@ -20,10 +20,10 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/math/special_functions/relative_difference.hpp>
 
-typedef float float_type;
+typedef double float_type;
 
 const char* cuda_kernel = R"(
-typedef float float_type;
+typedef double float_type;
 #include <cuda/std/type_traits>
 #include <boost/math/special_functions/fpclassify.hpp>
 extern "C" __global__ 

--- a/test/test_log1p_nvrtc_double.cpp
+++ b/test/test_log1p_nvrtc_double.cpp
@@ -1,0 +1,186 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/log1p.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <nvrtc.h>
+
+typedef double float_type;
+
+const char* cuda_kernel = R"(
+typedef double float_type;
+#include <boost/math/special_functions/log1p.hpp>
+extern "C" __global__ 
+void test_log1p_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::log1p(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_log1p_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_log1p_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_log1p_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            auto res = boost::math::log1p(h_in1[i]);
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/test/test_log1p_nvrtc_float.cpp
+++ b/test/test_log1p_nvrtc_float.cpp
@@ -1,0 +1,186 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/log1p.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <nvrtc.h>
+
+typedef float float_type;
+
+const char* cuda_kernel = R"(
+typedef float float_type;
+#include <boost/math/special_functions/log1p.hpp>
+extern "C" __global__ 
+void test_log1p_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::log1p(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_log1p_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_log1p_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_log1p_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            auto res = boost::math::log1p(h_in1[i]);
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/test/test_round_nvrtc_double.cpp
+++ b/test/test_round_nvrtc_double.cpp
@@ -1,0 +1,194 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+// Must be included first
+#include <nvrtc.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/round.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+
+typedef double float_type;
+
+const char* cuda_kernel = R"(
+typedef double float_type;
+#include <cuda/std/type_traits>
+#include <boost/math/special_functions/round.hpp>
+extern "C" __global__ 
+void test_round_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::round(in1[i]) + 
+                 boost::math::lround(in1[i]) + 
+                 boost::math::llround(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_round_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_round_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_round_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            auto res = boost::math::round(h_in1[i]) + 
+                       boost::math::lround(h_in1[i]) + 
+                       boost::math::llround(h_in1[i]);
+                       
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/test/test_round_nvrtc_float.cpp
+++ b/test/test_round_nvrtc_float.cpp
@@ -1,0 +1,194 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+// Must be included first
+#include <nvrtc.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/round.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+
+typedef float float_type;
+
+const char* cuda_kernel = R"(
+typedef float float_type;
+#include <cuda/std/type_traits>
+#include <boost/math/special_functions/round.hpp>
+extern "C" __global__ 
+void test_round_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::round(in1[i]) + 
+                 boost::math::lround(in1[i]) + 
+                 boost::math::llround(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_round_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_round_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_round_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            auto res = boost::math::round(h_in1[i]) + 
+                       boost::math::lround(h_in1[i]) + 
+                       boost::math::llround(h_in1[i]);
+                       
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/test/test_trunc_nvrtc_double.cpp
+++ b/test/test_trunc_nvrtc_double.cpp
@@ -1,0 +1,196 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+// Must be included first
+#include <nvrtc.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/trunc.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+
+typedef double float_type;
+
+const char* cuda_kernel = R"(
+typedef double float_type;
+#include <cuda/std/type_traits>
+#include <boost/math/special_functions/trunc.hpp>
+extern "C" __global__ 
+void test_trunc_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::trunc(in1[i]) + 
+                 boost::math::itrunc(in1[i]) +
+                 boost::math::ltrunc(in1[i]) + 
+                 boost::math::lltrunc(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_trunc_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_trunc_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_trunc_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1000.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            const auto res = boost::math::trunc(h_in1[i]) + 
+                             boost::math::itrunc(h_in1[i]) +
+                             boost::math::ltrunc(h_in1[i]) + 
+                             boost::math::lltrunc(h_in1[i]);
+                       
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/test/test_trunc_nvrtc_float.cpp
+++ b/test/test_trunc_nvrtc_float.cpp
@@ -1,0 +1,196 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+// Must be included first
+#include <nvrtc.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/trunc.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+
+typedef float float_type;
+
+const char* cuda_kernel = R"(
+typedef float float_type;
+#include <cuda/std/type_traits>
+#include <boost/math/special_functions/trunc.hpp>
+extern "C" __global__ 
+void test_trunc_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::trunc(in1[i]) + 
+                 boost::math::itrunc(in1[i]) +
+                 boost::math::ltrunc(in1[i]) + 
+                 boost::math::lltrunc(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_trunc_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_trunc_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_trunc_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1000.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            const auto res = boost::math::trunc(h_in1[i]) + 
+                             boost::math::itrunc(h_in1[i]) +
+                             boost::math::ltrunc(h_in1[i]) + 
+                             boost::math::lltrunc(h_in1[i]);
+                       
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}


### PR DESCRIPTION
Adds support for: `numeric_limits`, `round`, `trunc`, `expm1`, `log1p`, and most importantly policy mechanisms

Completed CI runs can be found at: https://github.com/cppalliance/cuda-math/pull/10

Also deprecates miss-spelled overloads of `llconvert`: https://github.com/boostorg/math/commit/cb23c0756f194187a8398b346506599d2bc79f27. I assume this was a control replace error from some time ago.