### PR TITLE
Fix warning C4701: "potentially uninitialized local variable used"

### DIFF
--- a/include/boost/math/special_functions/detail/bessel_ik.hpp
+++ b/include/boost/math/special_functions/detail/bessel_ik.hpp
@@ -18,7 +18,6 @@
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/policies/error_handling.hpp>
 #include <boost/math/tools/config.hpp>
-#include <iostream>
 
 // Modified Bessel functions of the first and second kind of fractional order
 

--- a/include/boost/math/special_functions/detail/bessel_ik.hpp
+++ b/include/boost/math/special_functions/detail/bessel_ik.hpp
@@ -18,6 +18,7 @@
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/policies/error_handling.hpp>
 #include <boost/math/tools/config.hpp>
+#include <iostream>
 
 // Modified Bessel functions of the first and second kind of fractional order
 
@@ -334,8 +335,6 @@ int bessel_ik(T v, T x, T* result_I, T* result_K, int kind, const Policy& pol)
        T eight_z = 8 * x;
        Kv = 1 + (mu - 1) / eight_z + (mu - 1) * (mu - 9) / (2 * eight_z * eight_z) + (mu - 1) * (mu - 9) * (mu - 25) / (6 * eight_z * eight_z * eight_z);
        Kv *= exp(-x) * constants::root_pi<T>() / sqrt(2 * x);
-       n = 0;
-       u = 0;
     }
     else
     {
@@ -416,6 +415,7 @@ int bessel_ik(T v, T x, T* result_I, T* result_K, int kind, const Policy& pol)
     }
     if (reflect)
     {
+        BOOST_MATH_ASSERT(fabs(v - n - u) < tools::forth_root_epsilon<T>());
         T z = (u + n % 2);
         T fact = (2 / pi<T>()) * (boost::math::sin_pi(z, pol) * Kv);
         if(fact == 0)

--- a/include/boost/math/special_functions/detail/bessel_ik.hpp
+++ b/include/boost/math/special_functions/detail/bessel_ik.hpp
@@ -334,6 +334,8 @@ int bessel_ik(T v, T x, T* result_I, T* result_K, int kind, const Policy& pol)
        T eight_z = 8 * x;
        Kv = 1 + (mu - 1) / eight_z + (mu - 1) * (mu - 9) / (2 * eight_z * eight_z) + (mu - 1) * (mu - 9) * (mu - 25) / (6 * eight_z * eight_z * eight_z);
        Kv *= exp(-x) * constants::root_pi<T>() / sqrt(2 * x);
+       n = 0;
+       u = 0;
     }
     else
     {

--- a/include/boost/math/special_functions/detail/bessel_ik.hpp
+++ b/include/boost/math/special_functions/detail/bessel_ik.hpp
@@ -327,6 +327,11 @@ int bessel_ik(T v, T x, T* result_I, T* result_K, int kind, const Policy& pol)
     T scale = 1;
     T scale_sign = 1;
 
+    n = iround(v, pol);
+    u = v - n;                              // -1/2 <= u < 1/2
+    BOOST_MATH_INSTRUMENT_VARIABLE(n);
+    BOOST_MATH_INSTRUMENT_VARIABLE(u);
+
     if (((kind & need_i) == 0) && (fabs(4 * v * v - 25) / (8 * x) < tools::forth_root_epsilon<T>()))
     {
        // A&S 9.7.2
@@ -338,11 +343,6 @@ int bessel_ik(T v, T x, T* result_I, T* result_K, int kind, const Policy& pol)
     }
     else
     {
-       n = iround(v, pol);
-       u = v - n;                              // -1/2 <= u < 1/2
-       BOOST_MATH_INSTRUMENT_VARIABLE(n);
-       BOOST_MATH_INSTRUMENT_VARIABLE(u);
-
        BOOST_MATH_ASSERT(x > 0); // Error handling for x <= 0 handled in cyl_bessel_i and cyl_bessel_k
 
        // x is positive until reflection

--- a/test/test_bessel_j.hpp
+++ b/test/test_bessel_j.hpp
@@ -288,6 +288,7 @@ void test_bessel(T, const char* name)
        BOOST_CHECK_EQUAL(boost::math::cyl_bessel_j(T(0), std::numeric_limits<T>::infinity()), T(0));
        BOOST_CHECK_EQUAL(boost::math::cyl_bessel_j(T(2), std::numeric_limits<T>::infinity()), T(0));
        BOOST_CHECK_EQUAL(boost::math::cyl_bessel_j(T(1.25), std::numeric_limits<T>::infinity()), T(0));
+       BOOST_CHECK_EQUAL(boost::math::cyl_bessel_j(T(-1.25), std::numeric_limits<T>::infinity()), T(0));
        BOOST_CHECK_EQUAL(boost::math::sph_bessel(0, std::numeric_limits<T>::infinity()), T(0));
        BOOST_CHECK_EQUAL(boost::math::sph_bessel(1, std::numeric_limits<T>::infinity()), T(0));
        BOOST_CHECK_EQUAL(boost::math::sph_bessel(2, std::numeric_limits<T>::infinity()), T(0));


### PR DESCRIPTION
Hello.
I tried to use your library (1.86.0)  and I faced with an issue. I didn't have the issue with 1.85.0.
I use VS 2022 and I get an error.
```
boost-math\include\boost\math\special_functions\detail\bessel_ik.hpp(417) : error C2220: the following warning is treated as an error
boost-math\include\boost\math\special_functions\detail\bessel_ik.hpp(417) : warning C4701: potentially uninitialized local variable 'n' used
boost-math\include\boost\math\special_functions\detail\bessel_ik.hpp(417) : warning C4701: potentially uninitialized local variable 'u' used
```
As you can see we initialize `n` and `u` only in the `else` branch and later we use them in `if (reflect)`. We might not get into this `if` if we haven't been in that `else` but the compiler don't know about it. I tried to fix the issue.