### PR TITLE
Begin documenting GPU support

### DIFF
--- a/doc/constants/constants.qbk
+++ b/doc/constants/constants.qbk
@@ -227,6 +227,11 @@ either construct from a decimal digit string or calculate on the fly depending u
 [[Any other value ['N]][Sets the compile time precision to ['N] bits.]]
 ]
 
+[h5 GPU Support]
+
+All Boost.Math constants are marked with `BOOST_MATH_GPU_ENABLED` and can be used on both host and device.
+Note that when running on device you are limited to using only `float` and `double` types.
+
 [h5 Custom Specializing a constant]
 
 In addition, for user-defined types that need special handling, it's possible to partially-specialize

--- a/doc/distributions/arcsine.qbk
+++ b/doc/distributions/arcsine.qbk
@@ -21,11 +21,11 @@
       typedef Policy    policy_type;
 
       // Constructor from two range parameters, x_min and x_max:
-      arcsine_distribution(RealType x_min = 0, RealType x_max = 1);
+      BOOST_MATH_GPU_ENABLED arcsine_distribution(RealType x_min = 0, RealType x_max = 1);
 
       // Range Parameter accessors:
-      RealType x_min() const;
-      RealType x_max() const;
+      BOOST_MATH_GPU_ENABLED RealType x_min() const;
+      BOOST_MATH_GPU_ENABLED RealType x_max() const;
    };
    }} // namespaces
 
@@ -103,8 +103,8 @@ constructs a 'Standard 01' arcsine distribution.
 
 [h5 Parameter Accessors]
 
-   RealType x_min() const;
-   RealType x_max() const;
+   BOOST_MATH_GPU_ENABLED RealType x_min() const;
+   BOOST_MATH_GPU_ENABLED RealType x_max() const;
 
 Return the parameter ['x_min] or  ['x_max] from which this distribution was constructed.
 
@@ -116,6 +116,8 @@ So, for example:
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 The formulae for calculating these are shown in the table below, and at
 [@http://mathworld.wolfram.com/arcsineDistribution.html Wolfram Mathworld].

--- a/doc/distributions/bernoulli.qbk
+++ b/doc/distributions/bernoulli.qbk
@@ -16,9 +16,9 @@
        typedef RealType  value_type;
        typedef Policy    policy_type;
 
-       bernoulli_distribution(RealType p); // Constructor.
+       BOOST_MATH_GPU_ENABLED bernoulli_distribution(RealType p); // Constructor.
        // Accessor function.
-       RealType success_fraction() const
+       BOOST_MATH_GPU_ENABLED RealType success_fraction() const
        // Probability of success (as a fraction).
     };
    }} // namespaces
@@ -51,12 +51,12 @@ and the [@http://en.wikipedia.org/wiki/Cumulative_Distribution_Function Cumulati
 
 [h4 Member Functions]
 
-   bernoulli_distribution(RealType p);
+   BOOST_MATH_GPU_ENABLED bernoulli_distribution(RealType p);
 
 Constructs a [@http://en.wikipedia.org/wiki/bernoulli_distribution
 bernoulli distribution] with success_fraction /p/.
 
-   RealType success_fraction() const
+   BOOST_MATH_GPU_ENABLED RealType success_fraction() const
 
 Returns the /success_fraction/ parameter of this distribution.
 
@@ -64,6 +64,8 @@ Returns the /success_fraction/ parameter of this distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 The domain of the random variable is 0 and 1,
 and the useful supported range is only 0 or 1.

--- a/doc/distributions/beta.qbk
+++ b/doc/distributions/beta.qbk
@@ -19,30 +19,30 @@
       typedef RealType  value_type;
       typedef Policy    policy_type;
       // Constructor from two shape parameters, alpha & beta:
-      beta_distribution(RealType a, RealType b);
+      BOOST_MATH_GPU_ENABLED beta_distribution(RealType a, RealType b);
       
       // Parameter accessors:
-      RealType alpha() const;
-      RealType beta() const;
+      BOOST_MATH_GPU_ENABLED RealType alpha() const;
+      BOOST_MATH_GPU_ENABLED RealType beta() const;
       
       // Parameter estimators of alpha or beta from mean and variance.
-      static RealType find_alpha(
+      BOOST_MATH_GPU_ENABLED static RealType find_alpha(
         RealType mean, // Expected value of mean.
         RealType variance); // Expected value of variance.
       
-      static RealType find_beta(
+      BOOST_MATH_GPU_ENABLED static RealType find_beta(
         RealType mean, // Expected value of mean.
         RealType variance); // Expected value of variance.
   
       // Parameter estimators from
       // either alpha or beta, and x and probability.
       
-      static RealType find_alpha(
+      BOOST_MATH_GPU_ENABLED static RealType find_alpha(
         RealType beta, // from beta.
         RealType x, //  x.
         RealType probability); // cdf
       
-      static RealType find_beta(
+      BOOST_MATH_GPU_ENABLED static RealType find_beta(
         RealType alpha, // alpha.
         RealType x, // probability x.
         RealType probability); // probability cdf.
@@ -98,7 +98,7 @@ whose apex is away from the centre (where x = half).
 
 [h5 Constructor]
 
-   beta_distribution(RealType alpha, RealType beta);
+   BOOST_MATH_GPU_ENABLED beta_distribution(RealType alpha, RealType beta);
 
 Constructs a beta distribution with shape parameters /alpha/ and /beta/.
 
@@ -117,11 +117,11 @@ in the graph above).
 
 [h5 Parameter Accessors]
 
-   RealType alpha() const;
+   BOOST_MATH_GPU_ENABLED RealType alpha() const;
    
 Returns the parameter /alpha/ from which this distribution was constructed.
    
-   RealType beta() const;
+   BOOST_MATH_GPU_ENABLED RealType beta() const;
    
 Returns the parameter /beta/ from which this distribution was constructed.
 
@@ -182,6 +182,8 @@ Returns the value of [beta] that gives:
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 The formulae for calculating these are shown in the table below, and at
 [@http://mathworld.wolfram.com/BetaDistribution.html Wolfram Mathworld].

--- a/doc/distributions/cauchy.qbk
+++ b/doc/distributions/cauchy.qbk
@@ -15,10 +15,10 @@
       typedef RealType  value_type;
       typedef Policy    policy_type;
 
-      cauchy_distribution(RealType location = 0, RealType scale = 1);
+      BOOST_MATH_GPU_ENABLED cauchy_distribution(RealType location = 0, RealType scale = 1);
       
-      RealType location()const;
-      RealType scale()const;
+      BOOST_MATH_GPU_ENABLED RealType location()const;
+      BOOST_MATH_GPU_ENABLED RealType scale()const;
    };
    
 The [@http://en.wikipedia.org/wiki/Cauchy_distribution Cauchy-Lorentz distribution]
@@ -53,7 +53,7 @@ the distribution:
 
 [h4 Member Functions]
 
-   cauchy_distribution(RealType location = 0, RealType scale = 1);
+   BOOST_MATH_GPU_ENABLED cauchy_distribution(RealType location = 0, RealType scale = 1);
    
 Constructs a Cauchy distribution, with location parameter /location/
 and scale parameter /scale/.  When these parameters take their default
@@ -62,11 +62,11 @@ then the result is a Standard Cauchy Distribution.
 
 Requires scale > 0, otherwise calls __domain_error.
    
-   RealType location()const;
+   BOOST_MATH_GPU_ENABLED RealType location()const;
    
 Returns the location parameter of the distribution.
    
-   RealType scale()const;
+   BOOST_MATH_GPU_ENABLED RealType scale()const;
    
 Returns the scale parameter of the distribution.
 
@@ -74,6 +74,8 @@ Returns the scale parameter of the distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 Note however that the Cauchy distribution does not have a mean,
 standard deviation, etc. See __math_undefined

--- a/doc/distributions/chi_squared.qbk
+++ b/doc/distributions/chi_squared.qbk
@@ -18,13 +18,13 @@
       typedef Policy    policy_type;
 
       // Constructor:
-      chi_squared_distribution(RealType i);
+      BOOST_MATH_GPU_ENABLED chi_squared_distribution(RealType i);
 
       // Accessor to parameter:
-      RealType degrees_of_freedom()const;
+      BOOST_MATH_GPU_ENABLED RealType degrees_of_freedom()const;
 
       // Parameter estimation:
-      static RealType find_degrees_of_freedom(
+      BOOST_MATH_GPU_ENABLED static RealType find_degrees_of_freedom(
          RealType difference_from_mean,
          RealType alpha,
          RealType beta,
@@ -104,6 +104,8 @@ See also section on Sample sizes required in
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 (We have followed the usual restriction of the mode to degrees of freedom >= 2,
 but note that the maximum of the pdf is actually zero for degrees of freedom from 2 down to 0,

--- a/doc/distributions/exponential.qbk
+++ b/doc/distributions/exponential.qbk
@@ -15,9 +15,9 @@
       typedef RealType value_type;
       typedef Policy   policy_type;
 
-      exponential_distribution(RealType lambda = 1);
+      BOOST_MATH_GPU_ENABLED exponential_distribution(RealType lambda = 1);
 
-      RealType lambda()const;
+      BOOST_MATH_GPU_ENABLED RealType lambda()const;
    };
 
 
@@ -37,7 +37,7 @@ values of the rate parameter lambda:
 
 [h4 Member Functions]
 
-   exponential_distribution(RealType lambda = 1);
+   BOOST_MATH_GPU_ENABLED exponential_distribution(RealType lambda = 1);
    
 Constructs an
 [@http://en.wikipedia.org/wiki/Exponential_distribution Exponential distribution]
@@ -46,7 +46,7 @@ Lambda is defined as the reciprocal of the scale parameter.
 
 Requires lambda > 0, otherwise calls __domain_error.
 
-   RealType lambda()const;
+   BOOST_MATH_GPU_ENABLED RealType lambda()const;
    
 Accessor function returns the lambda parameter of the distribution.
    
@@ -54,6 +54,8 @@ Accessor function returns the lambda parameter of the distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 The domain of the random variable is \[0, +[infin]\].
 

--- a/doc/distributions/extreme_value.qbk
+++ b/doc/distributions/extreme_value.qbk
@@ -14,10 +14,10 @@
    public:
       typedef RealType value_type;
 
-      extreme_value_distribution(RealType location = 0, RealType scale = 1);
+      BOOST_MATH_GPU_ENABLED extreme_value_distribution(RealType location = 0, RealType scale = 1);
 
-      RealType scale()const;
-      RealType location()const;
+      BOOST_MATH_GPU_ENABLED RealType scale()const;
+      BOOST_MATH_GPU_ENABLED RealType location()const;
    };
 
 There are various
@@ -59,18 +59,18 @@ And this graph illustrates how the PDF varies with the shape parameter:
 
 [h4 Member Functions]
 
-   extreme_value_distribution(RealType location = 0, RealType scale = 1);
+   BOOST_MATH_GPU_ENABLED extreme_value_distribution(RealType location = 0, RealType scale = 1);
    
 Constructs an Extreme Value distribution with the specified location and scale
 parameters.
 
 Requires `scale > 0`, otherwise calls __domain_error.
 
-   RealType location()const;
+   BOOST_MATH_GPU_ENABLED RealType location()const;
    
 Returns the location parameter of the distribution.
    
-   RealType scale()const;
+   BOOST_MATH_GPU_ENABLED RealType scale()const;
    
 Returns the scale parameter of the distribution.
    
@@ -78,6 +78,8 @@ Returns the scale parameter of the distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 The domain of the random parameter is \[-[infin], +[infin]\].
 

--- a/doc/distributions/fisher.qbk
+++ b/doc/distributions/fisher.qbk
@@ -17,11 +17,11 @@
       typedef RealType value_type;
       
       // Construct:
-      fisher_f_distribution(const RealType& i, const RealType& j);
+      BOOST_MATH_GPU_ENABLED fisher_f_distribution(const RealType& i, const RealType& j);
       
       // Accessors:
-      RealType degrees_of_freedom1()const;
-      RealType degrees_of_freedom2()const;
+      BOOST_MATH_GPU_ENABLED RealType degrees_of_freedom1()const;
+      BOOST_MATH_GPU_ENABLED RealType degrees_of_freedom2()const;
    };
    
    }} //namespaces
@@ -46,7 +46,7 @@ two degrees of freedom parameters.
 
 [h4 Member Functions]
 
-      fisher_f_distribution(const RealType& df1, const RealType& df2);
+      BOOST_MATH_GPU_ENABLED fisher_f_distribution(const RealType& df1, const RealType& df2);
       
 Constructs an F-distribution with numerator degrees of freedom /df1/
 and denominator degrees of freedom /df2/.
@@ -54,11 +54,11 @@ and denominator degrees of freedom /df2/.
 Requires that /df1/ and /df2/ are both greater than zero, otherwise __domain_error
 is called.
       
-      RealType degrees_of_freedom1()const;
+      BOOST_MATH_GPU_ENABLED RealType degrees_of_freedom1()const;
       
 Returns the numerator degrees of freedom parameter of the distribution.
 
-      RealType degrees_of_freedom2()const;
+      BOOST_MATH_GPU_ENABLED RealType degrees_of_freedom2()const;
       
 Returns the denominator degrees of freedom parameter of the distribution.
 
@@ -66,6 +66,8 @@ Returns the denominator degrees of freedom parameter of the distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 The domain of the random variable is \[0, +[infin]\].
 

--- a/doc/distributions/gamma.qbk
+++ b/doc/distributions/gamma.qbk
@@ -12,10 +12,10 @@
       typedef RealType value_type;
       typedef Policy   policy_type;
 
-      gamma_distribution(RealType shape, RealType scale = 1)
+      BOOST_MATH_GPU_ENABLED gamma_distribution(RealType shape, RealType scale = 1)
 
-      RealType shape()const;
-      RealType scale()const;
+      BOOST_MATH_GPU_ENABLED RealType shape()const;
+      BOOST_MATH_GPU_ENABLED RealType scale()const;
    };
    
    }} // namespaces
@@ -76,7 +76,7 @@ a dedicated Erlang Distribution.
 
 [h4 Member Functions]
 
-   gamma_distribution(RealType shape, RealType scale = 1);
+   BOOST_MATH_GPU_ENABLED gamma_distribution(RealType shape, RealType scale = 1);
    
 Constructs a gamma distribution with shape /shape/ and 
 scale /scale/.
@@ -84,11 +84,11 @@ scale /scale/.
 Requires that the shape and scale parameters are greater than zero, otherwise calls
 __domain_error.
 
-   RealType shape()const;
+   BOOST_MATH_GPU_ENABLED RealType shape()const;
    
 Returns the /shape/ parameter of this distribution.
    
-   RealType scale()const;
+   BOOST_MATH_GPU_ENABLED RealType scale()const;
       
 Returns the /scale/ parameter of this distribution.
 
@@ -96,6 +96,8 @@ Returns the /scale/ parameter of this distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions] that are generic to all
 distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 The domain of the random variable is \[0,+[infin]\].
 

--- a/doc/distributions/geometric.qbk
+++ b/doc/distributions/geometric.qbk
@@ -17,28 +17,28 @@
       typedef RealType value_type;
       typedef Policy   policy_type;
       // Constructor from success_fraction:
-      geometric_distribution(RealType p);
+      BOOST_MATH_GPU_ENABLED geometric_distribution(RealType p);
       
       // Parameter accessors:
-      RealType success_fraction() const;
-      RealType successes() const;
+      BOOST_MATH_GPU_ENABLED RealType success_fraction() const;
+      BOOST_MATH_GPU_ENABLED RealType successes() const;
      
       // Bounds on success fraction:
-      static RealType find_lower_bound_on_p(
+      BOOST_MATH_GPU_ENABLED static RealType find_lower_bound_on_p(
          RealType trials, 
          RealType successes,
          RealType probability); // alpha
-      static RealType find_upper_bound_on_p(
+      BOOST_MATH_GPU_ENABLED static RealType find_upper_bound_on_p(
          RealType trials, 
          RealType successes,
          RealType probability); // alpha
          
       // Estimate min/max number of trials:
-      static RealType find_minimum_number_of_trials(
+      BOOST_MATH_GPU_ENABLED static RealType find_minimum_number_of_trials(
          RealType k,     // Number of failures.
          RealType p,     // Success fraction.
          RealType probability); // Probability threshold alpha.
-      static RealType find_maximum_number_of_trials(
+      BOOST_MATH_GPU_ENABLED static RealType find_maximum_number_of_trials(
          RealType k,     // Number of failures.
          RealType p,     // Success fraction.
          RealType probability); // Probability threshold alpha.
@@ -268,6 +268,8 @@ of observing more than k failures.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 However it's worth taking a moment to define what these actually mean in 
 the context of this distribution:

--- a/doc/distributions/holtsmark.qbk
+++ b/doc/distributions/holtsmark.qbk
@@ -15,10 +15,10 @@
       typedef RealType  value_type;
       typedef Policy    policy_type;
 
-      holtsmark_distribution(RealType location = 0, RealType scale = 1);
+      BOOST_MATH_GPU_ENABLED holtsmark_distribution(RealType location = 0, RealType scale = 1);
 
-      RealType location()const;
-      RealType scale()const;
+      BOOST_MATH_GPU_ENABLED RealType location()const;
+      BOOST_MATH_GPU_ENABLED RealType scale()const;
    };
 
 The [@http://en.wikipedia.org/wiki/holtsmark_distribution Holtsmark distribution]
@@ -51,7 +51,7 @@ the distribution:
 
 [h4 Member Functions]
 
-   holtsmark_distribution(RealType location = 0, RealType scale = 1);
+   BOOST_MATH_GPU_ENABLED holtsmark_distribution(RealType location = 0, RealType scale = 1);
 
 Constructs a holtsmark distribution, with location parameter /location/
 and scale parameter /scale/.  When these parameters take their default
@@ -60,11 +60,11 @@ then the result is a Standard holtsmark Distribution.
 
 Requires scale > 0, otherwise calls __domain_error.
 
-   RealType location()const;
+   BOOST_MATH_GPU_ENABLED RealType location()const;
 
 Returns the location parameter of the distribution.
 
-   RealType scale()const;
+   BOOST_MATH_GPU_ENABLED RealType scale()const;
 
 Returns the scale parameter of the distribution.
 
@@ -72,6 +72,8 @@ Returns the scale parameter of the distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 Note however that the holtsmark distribution does not have a skewness,
 kurtosis, etc. See __math_undefined

--- a/doc/distributions/inverse_chi_squared.qbk
+++ b/doc/distributions/inverse_chi_squared.qbk
@@ -12,11 +12,11 @@
       typedef RealType value_type;
       typedef Policy   policy_type;
 
-      inverse_chi_squared_distribution(RealType df = 1); // Not explicitly scaled, default 1/df.
-      inverse_chi_squared_distribution(RealType df, RealType scale = 1/df);  // Scaled.
+      BOOST_MATH_GPU_ENABLED inverse_chi_squared_distribution(RealType df = 1); // Not explicitly scaled, default 1/df.
+      BOOST_MATH_GPU_ENABLED inverse_chi_squared_distribution(RealType df, RealType scale = 1/df);  // Scaled.
 
-      RealType degrees_of_freedom()const; // Default 1.
-      RealType scale()const; // Optional scale [xi] (variance), default 1/degrees_of_freedom.
+      BOOST_MATH_GPU_ENABLED RealType degrees_of_freedom()const; // Default 1.
+      BOOST_MATH_GPU_ENABLED RealType scale()const; // Optional scale [xi] (variance), default 1/degrees_of_freedom.
    };
    
    }} // namespace boost // namespace math
@@ -99,8 +99,8 @@ varies for a few values of parameters [nu] and [xi]:
 
 [h4 Member Functions]
 
-   inverse_chi_squared_distribution(RealType df = 1); // Implicitly scaled 1/df.
-   inverse_chi_squared_distribution(RealType df = 1, RealType scale); // Explicitly scaled.
+   BOOST_MATH_GPU_ENABLED inverse_chi_squared_distribution(RealType df = 1); // Implicitly scaled 1/df.
+   BOOST_MATH_GPU_ENABLED inverse_chi_squared_distribution(RealType df = 1, RealType scale); // Explicitly scaled.
 
 Constructs an inverse chi_squared distribution with [nu] degrees of freedom ['df],
 and scale ['scale] with default value 1\/df.
@@ -108,11 +108,11 @@ and scale ['scale] with default value 1\/df.
 Requires that the degrees of freedom [nu] parameter is greater than zero, otherwise calls
 __domain_error.
 
-   RealType degrees_of_freedom()const; 
+   BOOST_MATH_GPU_ENABLED RealType degrees_of_freedom()const; 
    
 Returns the degrees_of_freedom [nu] parameter of this distribution.
 
-   RealType scale()const; 
+   BOOST_MATH_GPU_ENABLED RealType scale()const; 
    
 Returns the scale [xi] parameter of this distribution.
 
@@ -120,6 +120,8 @@ Returns the scale [xi] parameter of this distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions] that are generic to all
 distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 The domain of the random variate is \[0,+[infin]\].
 [note Unlike some definitions, this implementation supports a random variate 

--- a/doc/distributions/inverse_gamma.qbk
+++ b/doc/distributions/inverse_gamma.qbk
@@ -12,10 +12,10 @@
       typedef RealType value_type;
       typedef Policy   policy_type;
 
-      inverse_gamma_distribution(RealType shape, RealType scale = 1)
+      BOOST_MATH_GPU_ENABLED inverse_gamma_distribution(RealType shape, RealType scale = 1)
 
-      RealType shape()const;
-      RealType scale()const;
+      BOOST_MATH_GPU_ENABLED RealType shape()const;
+      BOOST_MATH_GPU_ENABLED RealType scale()const;
    };
    
    }} // namespaces
@@ -63,18 +63,18 @@ varies as the parameters vary:
 
 [h4 Member Functions]
 
-   inverse_gamma_distribution(RealType shape = 1, RealType scale = 1);
+   BOOST_MATH_GPU_ENABLED inverse_gamma_distribution(RealType shape = 1, RealType scale = 1);
    
 Constructs an inverse gamma distribution with shape [alpha] and scale [beta].
 
 Requires that the shape and scale parameters are greater than zero, otherwise calls
 __domain_error.
 
-   RealType shape()const;
+   BOOST_MATH_GPU_ENABLED RealType shape()const;
    
 Returns the [alpha] shape parameter of this inverse gamma distribution.
    
-   RealType scale()const;
+   BOOST_MATH_GPU_ENABLED RealType scale()const;
       
 Returns the [beta] scale parameter of this inverse gamma distribution.
 
@@ -82,6 +82,8 @@ Returns the [beta] scale parameter of this inverse gamma distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions] that are generic to all
 distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 The domain of the random variate is \[0,+[infin]\].
 [note Unlike some definitions, this implementation supports a random variate 

--- a/doc/distributions/landau.qbk
+++ b/doc/distributions/landau.qbk
@@ -15,11 +15,11 @@
       typedef RealType  value_type;
       typedef Policy    policy_type;
 
-      landau_distribution(RealType location = 0, RealType scale = 1);
+      BOOST_MATH_GPU_ENABLED landau_distribution(RealType location = 0, RealType scale = 1);
 
-      RealType location()const;
-      RealType scale()const;
-      RealType bias()const;
+      BOOST_MATH_GPU_ENABLED RealType location()const;
+      BOOST_MATH_GPU_ENABLED RealType scale()const;
+      BOOST_MATH_GPU_ENABLED RealType bias()const;
    };
 
 The [@http://en.wikipedia.org/wiki/landau_distribution Landau distribution]
@@ -54,7 +54,7 @@ the distribution:
 
 [h4 Member Functions]
 
-   landau_distribution(RealType location = 0, RealType scale = 1);
+   BOOST_MATH_GPU_ENABLED landau_distribution(RealType location = 0, RealType scale = 1);
 
 Constructs a landau distribution, with location parameter /location/
 and scale parameter /scale/.  When these parameters take their default
@@ -63,15 +63,15 @@ then the result is a Standard landau Distribution.
 
 Requires scale > 0, otherwise calls __domain_error.
 
-   RealType location()const;
+   BOOST_MATH_GPU_ENABLED RealType location()const;
 
 Returns the location parameter of the distribution.
 
-   RealType scale()const;
+   BOOST_MATH_GPU_ENABLED RealType scale()const;
 
 Returns the scale parameter of the distribution.
 
-   RealType bias()const;
+   BOOST_MATH_GPU_ENABLED RealType bias()const;
 
 Returns the amount of translation by the scale parameter.
 [expression bias = - 2 / [pi] log(c)]
@@ -80,6 +80,8 @@ Returns the amount of translation by the scale parameter.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 Note however that the landau distribution does not have a mean,
 standard deviation, etc. See __math_undefined

--- a/doc/distributions/laplace.qbk
+++ b/doc/distributions/laplace.qbk
@@ -17,10 +17,10 @@
       typedef RealType value_type;
       typedef Policy   policy_type;
       // Construct:
-      laplace_distribution(RealType location = 0, RealType scale = 1);
+      BOOST_MATH_GPU_ENABLED laplace_distribution(RealType location = 0, RealType scale = 1);
       // Accessors:
-      RealType location()const;
-      RealType scale()const;
+      BOOST_MATH_GPU_ENABLED RealType location()const;
+      BOOST_MATH_GPU_ENABLED RealType scale()const;
    };
 
    }} // namespaces
@@ -49,7 +49,7 @@ Note that the domain of the random variable remains
 
 [h4 Member Functions]
 
-   laplace_distribution(RealType location = 0, RealType scale = 1);
+   BOOST_MATH_GPU_ENABLED laplace_distribution(RealType location = 0, RealType scale = 1);
 
 Constructs a laplace distribution with location /location/ and
 scale /scale/.
@@ -61,11 +61,11 @@ The scale parameter is proportional to the standard deviation of the random vari
 Requires that the scale parameter is greater than zero, otherwise calls
 __domain_error.
 
-   RealType location()const;
+   BOOST_MATH_GPU_ENABLED RealType location()const;
 
 Returns the /location/ parameter of this distribution.
 
-   RealType scale()const;
+   BOOST_MATH_GPU_ENABLED RealType scale()const;
 
 Returns the /scale/ parameter of this distribution.
 
@@ -73,6 +73,8 @@ Returns the /scale/ parameter of this distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions] that are generic to all
 distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 The domain of the random variable is \[-[infin],+[infin]\].
 

--- a/doc/distributions/logistic.qbk
+++ b/doc/distributions/logistic.qbk
@@ -15,10 +15,10 @@
       typedef RealType value_type;
       typedef Policy   policy_type;
       // Construct:
-      logistic_distribution(RealType location = 0, RealType scale = 1);
+      BOOST_MATH_GPU_ENABLED logistic_distribution(RealType location = 0, RealType scale = 1);
       // Accessors:
-      RealType location()const; // location.
-      RealType scale()const; // scale.
+      BOOST_MATH_GPU_ENABLED RealType location()const; // location.
+      BOOST_MATH_GPU_ENABLED RealType scale()const; // scale.
       
    };
 
@@ -39,17 +39,17 @@ parameters change:
 
 [h4 Member Functions]
 
-   logistic_distribution(RealType u = 0, RealType s = 1);
+   BOOST_MATH_GPU_ENABLED logistic_distribution(RealType u = 0, RealType s = 1);
 
 Constructs a logistic distribution with location /u/ and scale /s/.
 
 Requires `scale > 0`, otherwise a __domain_error is raised.
 
-   RealType location()const;   
+   BOOST_MATH_GPU_ENABLED RealType location()const;   
 
 Returns the location of this distribution.
 
-   RealType scale()const;
+   BOOST_MATH_GPU_ENABLED RealType scale()const;
 
 Returns the scale of this distribution. 
 
@@ -57,6 +57,8 @@ Returns the scale of this distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 The domain of the random variable is \[-\[max_value\], +\[min_value\]\]. 
 However, the pdf and cdf support inputs of +[infin] and -[infin]

--- a/doc/distributions/mapairy.qbk
+++ b/doc/distributions/mapairy.qbk
@@ -15,10 +15,10 @@
       typedef RealType  value_type;
       typedef Policy    policy_type;
 
-      mapairy_distribution(RealType location = 0, RealType scale = 1);
+      BOOST_MATH_GPU_ENABLED mapairy_distribution(RealType location = 0, RealType scale = 1);
 
-      RealType location()const;
-      RealType scale()const;
+      BOOST_MATH_GPU_ENABLED RealType location()const;
+      BOOST_MATH_GPU_ENABLED RealType scale()const;
    };
 
 It is special case of a [@http://en.wikipedia.org/wiki/Stable_distribution stable distribution]
@@ -50,7 +50,7 @@ the distribution:
 
 [h4 Member Functions]
 
-   mapairy_distribution(RealType location = 0, RealType scale = 1);
+   BOOST_MATH_GPU_ENABLED mapairy_distribution(RealType location = 0, RealType scale = 1);
 
 Constructs a mapairy distribution, with location parameter /location/
 and scale parameter /scale/.  When these parameters take their default
@@ -59,11 +59,11 @@ then the result is a Standard map-airy Distribution.
 
 Requires scale > 0, otherwise calls __domain_error.
 
-   RealType location()const;
+   BOOST_MATH_GPU_ENABLED RealType location()const;
 
 Returns the location parameter of the distribution.
 
-   RealType scale()const;
+   BOOST_MATH_GPU_ENABLED RealType scale()const;
 
 Returns the scale parameter of the distribution.
 
@@ -71,6 +71,8 @@ Returns the scale parameter of the distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 Note however that the map-airy distribution does not have a skewness,
 kurtosis, etc. See __math_undefined

--- a/doc/distributions/saspoint5.qbk
+++ b/doc/distributions/saspoint5.qbk
@@ -15,10 +15,10 @@
       typedef RealType  value_type;
       typedef Policy    policy_type;
 
-      saspoint5_distribution(RealType location = 0, RealType scale = 1);
+      BOOST_MATH_GPU_ENABLED saspoint5_distribution(RealType location = 0, RealType scale = 1);
 
-      RealType location()const;
-      RealType scale()const;
+      BOOST_MATH_GPU_ENABLED RealType location()const;
+      BOOST_MATH_GPU_ENABLED RealType scale()const;
    };
 
 It is special case of a [@http://en.wikipedia.org/wiki/Stable_distribution stable distribution]
@@ -49,7 +49,7 @@ the distribution:
 
 [h4 Member Functions]
 
-   saspoint5_distribution(RealType location = 0, RealType scale = 1);
+   BOOST_MATH_GPU_ENABLED saspoint5_distribution(RealType location = 0, RealType scale = 1);
 
 Constructs a S[alpha]S Point5 distribution, with location parameter /location/
 and scale parameter /scale/.  When these parameters take their default
@@ -58,11 +58,11 @@ then the result is a Standard S[alpha]S Point5 Distribution.
 
 Requires scale > 0, otherwise calls __domain_error.
 
-   RealType location()const;
+   BOOST_MATH_GPU_ENABLED RealType location()const;
 
 Returns the location parameter of the distribution.
 
-   RealType scale()const;
+   BOOST_MATH_GPU_ENABLED RealType scale()const;
 
 Returns the scale parameter of the distribution.
 
@@ -70,6 +70,8 @@ Returns the scale parameter of the distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions]
 that are generic to all distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 Note however that the S[alpha]S Point5 distribution does not have a mean,
 standard deviation, etc. See __math_undefined

--- a/doc/distributions/weibull.qbk
+++ b/doc/distributions/weibull.qbk
@@ -17,10 +17,10 @@
       typedef RealType value_type;
       typedef Policy   policy_type;
       // Construct:
-      weibull_distribution(RealType shape, RealType scale = 1)
+      BOOST_MATH_GPU_ENABLED weibull_distribution(RealType shape, RealType scale = 1)
       // Accessors:
-      RealType shape()const;
-      RealType scale()const;
+      BOOST_MATH_GPU_ENABLED RealType shape()const;
+      BOOST_MATH_GPU_ENABLED RealType scale()const;
    };
    
    }} // namespaces
@@ -65,7 +65,7 @@ Samuel Kotz & Saralees Nadarajah].
    
 [h4 Member Functions]
 
-   weibull_distribution(RealType shape, RealType scale = 1);
+   BOOST_MATH_GPU_ENABLED weibull_distribution(RealType shape, RealType scale = 1);
    
 Constructs a [@http://en.wikipedia.org/wiki/Weibull_distribution 
 Weibull distribution] with shape /shape/ and scale /scale/.
@@ -73,11 +73,11 @@ Weibull distribution] with shape /shape/ and scale /scale/.
 Requires that the /shape/ and /scale/ parameters are both greater than zero, 
 otherwise calls __domain_error.
 
-   RealType shape()const;
+   BOOST_MATH_GPU_ENABLED RealType shape()const;
    
 Returns the /shape/ parameter of this distribution.
    
-   RealType scale()const;
+   BOOST_MATH_GPU_ENABLED RealType scale()const;
       
 Returns the /scale/ parameter of this distribution.
 
@@ -85,6 +85,8 @@ Returns the /scale/ parameter of this distribution.
 
 All the [link math_toolkit.dist_ref.nmp usual non-member accessor functions] that are generic to all
 distributions are supported: __usual_accessors.
+For this distribution all non-member accessor functions are marked with `BOOST_MATH_GPU_ENABLED` and can
+be run on both host and device.
 
 The domain of the random variable is \[0, [infin]\].
 

--- a/doc/math.qbk
+++ b/doc/math.qbk
@@ -557,6 +557,7 @@ and as a CD ISBN 0-9504833-2-X  978-0-9504833-2-0, Classification 519.2-dc22.
 [include overview/standalone.qbk]
 [include overview/result_type_calc.qbk]
 [include overview/error_handling.qbk]
+[include overview/gpu.qbk]
 
 [section:compilers_overview Compilers]
 [compilers_overview]

--- a/doc/overview/gpu.qbk
+++ b/doc/overview/gpu.qbk
@@ -1,0 +1,59 @@
+[section:gpu Support for GPU programming in Boost.Math]
+
+[h4 GPU Support]
+
+Selected functions, distributions, tools, etc. support running on both host and devices.
+These functions will have the annotation `BOOST_MATH_GPU_ENABLED` next to their individual documentation.
+We test using CUDA (both NVCC and NVRTC) as well as SYCL to provide a wide range of support.
+
+[h4 How to build with device support]
+
+When compiling with CUDA or SYCL you will have to ensure that your code is being run inside of a kernel function.
+It is not enough to simply compile existing code with the NVCC compiler to run the code on the device.
+A simple CUDA kernel to run the Beta Distribution CDF on NVCC would be:
+
+    __global__ void cuda_beta_dist(const double* in, double* out, int num_elements)
+    {
+        const int i = blockDim.x * blockIdx.x + threadIdx.x;
+
+        if (i < num_elements)
+        {
+            out[i] = cdf(boost::math::beta_distribution<double>(), in[i]);
+        }
+    }
+
+And on CUDA on NVRTC:
+
+    const char* cuda_kernel = R"(
+    #include <boost/math/distributions/beta.hpp>
+    extern "C" __global__ 
+    void test_beta_dist_kernel(const double* in, double* out, int num_elements)
+    {
+        const int i = blockDim.x * blockIdx.x + threadIdx.x;
+        if (i < num_elements)
+        {
+            out[i] = boost::math::cdf(boost::math::beta_distribution<double>(), in[i]);
+        }
+    }
+    )";
+
+And lastly on SYCL:
+
+    void sycl_beta_dist(const double* in, double* out, int num_elements, sycl::queue& q)
+    {
+        q.submit([&](sycl::handler& h) {
+            h.parallel_for(sycl::range<1>(num_elements), [=](sycl::id<1> i) {
+                out[i] = boost::math::cdf(boost::math::beta_distribution<double>(), in[i]);
+            });
+        });
+    }
+
+Once your kernel function has been written then use the framework mechanism for launching the kernel.
+
+[/ 
+  Copyright 2024. Matt Borland
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt).
+]
+

--- a/doc/overview/gpu.qbk
+++ b/doc/overview/gpu.qbk
@@ -55,6 +55,8 @@ And lastly on SYCL:
 
 Once your kernel function has been written then use the framework mechanism for launching the kernel.
 
+[endsect] [/section:gpu Support for GPU programming in Boost.Math]
+
 [/ 
   Copyright 2024. Matt Borland
   Distributed under the Boost Software License, Version 1.0.

--- a/doc/overview/gpu.qbk
+++ b/doc/overview/gpu.qbk
@@ -6,6 +6,11 @@ Selected functions, distributions, tools, etc. support running on both host and 
 These functions will have the annotation `BOOST_MATH_GPU_ENABLED` next to their individual documentation.
 We test using CUDA (both NVCC and NVRTC) as well as SYCL to provide a wide range of support.
 
+[h4 Policies]
+
+The default policy on all devices is ignore error due to the lack of throwing ability.
+A user can specify their own policy like usual, but when the code is run on device it will be ignored.
+
 [h4 How to build with device support]
 
 When compiling with CUDA or SYCL you will have to ensure that your code is being run inside of a kernel function.

--- a/doc/roots/roots.qbk
+++ b/doc/roots/roots.qbk
@@ -10,10 +10,10 @@
    namespace tools { // Note namespace boost::math::tools.
    // Newton-Raphson
    template <class F, class T>
-   T newton_raphson_iterate(F f, T guess, T min, T max, int digits);
+   BOOST_MATH_GPU_ENABLED T newton_raphson_iterate(F f, T guess, T min, T max, int digits);
 
    template <class F, class T>
-   T newton_raphson_iterate(F f, T guess, T min, T max, int digits, std::uintmax_t& max_iter);
+   BOOST_MATH_GPU_ENABLED T newton_raphson_iterate(F f, T guess, T min, T max, int digits, std::uintmax_t& max_iter);
 
    // Halley
    template <class F, class T>

--- a/doc/roots/roots.qbk
+++ b/doc/roots/roots.qbk
@@ -1,4 +1,4 @@
-[section:roots_deriv Root Finding With Derivatives: Newton-Raphson, Halley & Schr'''&#xf6;'''der]
+[section:roots_deriv Root Finding With Derivatives: Newton-Raphson, Halley & Schroeder]
 
 [h4 Synopsis]
 
@@ -22,7 +22,7 @@
    template <class F, class T>
    T halley_iterate(F f, T guess, T min, T max, int digits, std::uintmax_t& max_iter);
 
-   // Schr'''&#xf6;'''der
+   // Schroeder
    template <class F, class T>
    T schroder_iterate(F f, T guess, T min, T max, int digits);
 
@@ -61,7 +61,7 @@ For second-order iterative method ([@http://en.wikipedia.org/wiki/Newton_Raphson
 
 For the third-order methods
 ([@http://en.wikipedia.org/wiki/Halley%27s_method Halley] and
-Schr'''&#xf6;'''der)
+Schroeder)
         the `tuple` should have [*three] elements containing the evaluation of
         the function and its first and second derivatives.]]
 [[T guess] [The initial starting value. A good guess is crucial to quick convergence!]]
@@ -147,7 +147,7 @@ Out of bounds steps revert to bisection of the current bounds.
 
 Under ideal conditions, the number of correct digits trebles with each iteration.
 
-[h4:schroder Schr'''&#xf6;'''der's Method]
+[h4:schroder Schroeder's Method]
 
 Given an initial guess x0 the subsequent values are computed using:
 
@@ -162,8 +162,8 @@ Out of bounds steps revert to __bisection_wikipedia of the current bounds.
 
 Under ideal conditions, the number of correct digits trebles with each iteration.
 
-This is Schr'''&#xf6;'''der's general result (equation 18 from [@http://drum.lib.umd.edu/handle/1903/577 Stewart, G. W.
-"On Infinitely Many Algorithms for Solving Equations." English translation of Schr'''&#xf6;'''der's original paper.
+This is Schroeder's general result (equation 18 from [@http://drum.lib.umd.edu/handle/1903/577 Stewart, G. W.
+"On Infinitely Many Algorithms for Solving Equations." English translation of Schroeder's original paper.
 College Park, MD: University of Maryland, Institute for Advanced Computer Studies, Department of Computer Science, 1993].)
 
 This method guarantees at least quadratic convergence (the same as Newton's method), and is known to work well in the presence of multiple roots:

--- a/doc/sf/bessel_ik.qbk
+++ b/doc/sf/bessel_ik.qbk
@@ -5,16 +5,16 @@
 `#include <boost/math/special_functions/bessel.hpp>`
 
    template <class T1, class T2>
-   ``__sf_result`` cyl_bessel_i(T1 v, T2 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` cyl_bessel_i(T1 v, T2 x);
 
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` cyl_bessel_i(T1 v, T2 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` cyl_bessel_i(T1 v, T2 x, const ``__Policy``&);
 
    template <class T1, class T2>
-   ``__sf_result`` cyl_bessel_k(T1 v, T2 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` cyl_bessel_k(T1 v, T2 x);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` cyl_bessel_k(T1 v, T2 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` cyl_bessel_k(T1 v, T2 x, const ``__Policy``&);
    
    
 [h4 Description]

--- a/doc/sf/bessel_jy.qbk
+++ b/doc/sf/bessel_jy.qbk
@@ -5,16 +5,16 @@
 `#include <boost/math/special_functions/bessel.hpp>`
 
    template <class T1, class T2>
-   ``__sf_result`` cyl_bessel_j(T1 v, T2 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` cyl_bessel_j(T1 v, T2 x);
 
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` cyl_bessel_j(T1 v, T2 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` cyl_bessel_j(T1 v, T2 x, const ``__Policy``&);
 
    template <class T1, class T2>
-   ``__sf_result`` cyl_neumann(T1 v, T2 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` cyl_neumann(T1 v, T2 x);
 
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` cyl_neumann(T1 v, T2 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` cyl_neumann(T1 v, T2 x, const ``__Policy``&);
 
 
 [h4 Description]

--- a/doc/sf/bessel_spherical.qbk
+++ b/doc/sf/bessel_spherical.qbk
@@ -5,16 +5,16 @@
 `#include <boost/math/special_functions/bessel.hpp>`
 
    template <class T1, class T2>
-   ``__sf_result`` sph_bessel(unsigned v, T2 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` sph_bessel(unsigned v, T2 x);
 
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` sph_bessel(unsigned v, T2 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` sph_bessel(unsigned v, T2 x, const ``__Policy``&);
 
    template <class T1, class T2>
-   ``__sf_result`` sph_neumann(unsigned v, T2 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` sph_neumann(unsigned v, T2 x);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` sph_neumann(unsigned v, T2 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` sph_neumann(unsigned v, T2 x, const ``__Policy``&);
    
 [h4 Description]
 

--- a/doc/sf/beta.qbk
+++ b/doc/sf/beta.qbk
@@ -9,10 +9,10 @@
    namespace boost{ namespace math{
    
    template <class T1, class T2>
-   ``__sf_result`` beta(T1 a, T2 b);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` beta(T1 a, T2 b);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` beta(T1 a, T2 b, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` beta(T1 a, T2 b, const ``__Policy``&);
    
    }} // namespaces
 

--- a/doc/sf/beta_derivative.qbk
+++ b/doc/sf/beta_derivative.qbk
@@ -9,10 +9,10 @@
    namespace boost{ namespace math{ 
    
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibeta_derivative(T1 a, T2 b, T3 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_derivative(T1 a, T2 b, T3 x);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibeta_derivative(T1 a, T2 b, T3 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_derivative(T1 a, T2 b, T3 x, const ``__Policy``&);
    
    }} // namespaces
    

--- a/doc/sf/digamma.qbk
+++ b/doc/sf/digamma.qbk
@@ -9,10 +9,10 @@
   namespace boost{ namespace math{
   
   template <class T>
-  ``__sf_result`` digamma(T z);
+  BOOST_MATH_GPU_ENABLED ``__sf_result`` digamma(T z);
   
   template <class T, class ``__Policy``>
-  ``__sf_result`` digamma(T z, const ``__Policy``&);
+  BOOST_MATH_GPU_ENABLED ``__sf_result`` digamma(T z, const ``__Policy``&);
   
   }} // namespaces
   

--- a/doc/sf/erf.qbk
+++ b/doc/sf/erf.qbk
@@ -9,16 +9,16 @@
    namespace boost{ namespace math{
    
    template <class T>
-   ``__sf_result`` erf(T z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erf(T z);
    
    template <class T, class ``__Policy``>
-   ``__sf_result`` erf(T z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erf(T z, const ``__Policy``&);
    
    template <class T>
-   ``__sf_result`` erfc(T z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erfc(T z);
    
    template <class T, class ``__Policy``>
-   ``__sf_result`` erfc(T z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erfc(T z, const ``__Policy``&);
    
    }} // namespaces
    
@@ -30,10 +30,10 @@ the return type is `double` if T is an integer type, and T otherwise.
 [h4 Description]
 
    template <class T>
-   ``__sf_result`` erf(T z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erf(T z);
    
    template <class T, class ``__Policy``>
-   ``__sf_result`` erf(T z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erf(T z, const ``__Policy``&);
    
 Returns the [@http://en.wikipedia.org/wiki/Error_function error function]
 [@http://functions.wolfram.com/GammaBetaErf/Erf/ erf] of z:
@@ -43,10 +43,10 @@ Returns the [@http://en.wikipedia.org/wiki/Error_function error function]
 [graph erf]
 
    template <class T>
-   ``__sf_result`` erfc(T z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erfc(T z);
    
    template <class T, class ``__Policy``>
-   ``__sf_result`` erfc(T z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erfc(T z, const ``__Policy``&);
    
 Returns the complement of the [@http://functions.wolfram.com/GammaBetaErf/Erfc/ error function] of z:
 

--- a/doc/sf/erf_inv.qbk
+++ b/doc/sf/erf_inv.qbk
@@ -9,16 +9,16 @@
    namespace boost{ namespace math{
    
    template <class T>
-   ``__sf_result`` erf_inv(T p);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erf_inv(T p);
    
    template <class T, class ``__Policy``>
-   ``__sf_result`` erf_inv(T p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erf_inv(T p, const ``__Policy``&);
    
    template <class T>
-   ``__sf_result`` erfc_inv(T p);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erfc_inv(T p);
    
    template <class T, class ``__Policy``>
-   ``__sf_result`` erfc_inv(T p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erfc_inv(T p, const ``__Policy``&);
    
    }} // namespaces
    
@@ -30,10 +30,10 @@ the return type is `double` if T is an integer type, and T otherwise.
 [h4 Description]
 
    template <class T>
-   ``__sf_result`` erf_inv(T z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erf_inv(T z);
    
    template <class T, class ``__Policy``>
-   ``__sf_result`` erf_inv(T z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erf_inv(T z, const ``__Policy``&);
    
 Returns the [@http://functions.wolfram.com/GammaBetaErf/InverseErf/ inverse error function]
 of z, that is a value x such that:
@@ -43,10 +43,10 @@ of z, that is a value x such that:
 [graph erf_inv]
 
    template <class T>
-   ``__sf_result`` erfc_inv(T z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erfc_inv(T z);
    
    template <class T, class ``__Policy``>
-   ``__sf_result`` erfc_inv(T z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` erfc_inv(T z, const ``__Policy``&);
    
 Returns the inverse of the complement of the error function of z, that is a
 value x such that:

--- a/doc/sf/gamma_derivatives.qbk
+++ b/doc/sf/gamma_derivatives.qbk
@@ -9,10 +9,10 @@
    namespace boost{ namespace math{ 
    
    template <class T1, class T2>
-   ``__sf_result`` gamma_p_derivative(T1 a, T2 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p_derivative(T1 a, T2 x);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` gamma_p_derivative(T1 a, T2 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p_derivative(T1 a, T2 x, const ``__Policy``&);
    
    }} // namespaces
    

--- a/doc/sf/gamma_ratios.qbk
+++ b/doc/sf/gamma_ratios.qbk
@@ -7,26 +7,26 @@
    namespace boost{ namespace math{
    
    template <class T1, class T2>
-   ``__sf_result`` tgamma_ratio(T1 a, T2 b);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma_ratio(T1 a, T2 b);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` tgamma_ratio(T1 a, T2 b, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma_ratio(T1 a, T2 b, const ``__Policy``&);
    
    template <class T1, class T2>
-   ``__sf_result`` tgamma_delta_ratio(T1 a, T2 delta);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma_delta_ratio(T1 a, T2 delta);
    
    template <class T1, class T2, class Policy>
-   ``__sf_result`` tgamma_delta_ratio(T1 a, T2 delta, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma_delta_ratio(T1 a, T2 delta, const ``__Policy``&);
    
    }} // namespaces
    
 [h4 Description]
 
    template <class T1, class T2> 
-   ``__sf_result`` tgamma_ratio(T1 a, T2 b);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma_ratio(T1 a, T2 b);
    
    template <class T1, class T2, class ``__Policy``> 
-   ``__sf_result`` tgamma_ratio(T1 a, T2 b, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma_ratio(T1 a, T2 b, const ``__Policy``&);
    
 Returns the ratio of gamma functions:
 
@@ -37,10 +37,10 @@ Returns the ratio of gamma functions:
 Internally this just calls `tgamma_delta_ratio(a, b-a)`.
    
    template <class T1, class T2>
-   ``__sf_result`` tgamma_delta_ratio(T1 a, T2 delta);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma_delta_ratio(T1 a, T2 delta);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` tgamma_delta_ratio(T1 a, T2 delta, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma_delta_ratio(T1 a, T2 delta, const ``__Policy``&);
    
 Returns the ratio of gamma functions:
 

--- a/doc/sf/ibeta.qbk
+++ b/doc/sf/ibeta.qbk
@@ -9,28 +9,28 @@
    namespace boost{ namespace math{
    
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibeta(T1 a, T2 b, T3 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta(T1 a, T2 b, T3 x);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibeta(T1 a, T2 b, T3 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta(T1 a, T2 b, T3 x, const ``__Policy``&);
    
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibetac(T1 a, T2 b, T3 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac(T1 a, T2 b, T3 x);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibetac(T1 a, T2 b, T3 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac(T1 a, T2 b, T3 x, const ``__Policy``&);
    
    template <class T1, class T2, class T3>
-   ``__sf_result`` beta(T1 a, T2 b, T3 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` beta(T1 a, T2 b, T3 x);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` beta(T1 a, T2 b, T3 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` beta(T1 a, T2 b, T3 x, const ``__Policy``&);
    
    template <class T1, class T2, class T3>
-   ``__sf_result`` betac(T1 a, T2 b, T3 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` betac(T1 a, T2 b, T3 x);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` betac(T1 a, T2 b, T3 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` betac(T1 a, T2 b, T3 x, const ``__Policy``&);
    
    }} // namespaces
    
@@ -57,10 +57,10 @@ when T1, T2 and T3 are different types.
 [optional_policy]
 
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibeta(T1 a, T2 b, T3 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta(T1 a, T2 b, T3 x);
 
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibeta(T1 a, T2 b, T3 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta(T1 a, T2 b, T3 x, const ``__Policy``&);
 
 Returns the normalised incomplete beta function of a, b and x:
 
@@ -69,30 +69,30 @@ Returns the normalised incomplete beta function of a, b and x:
 [graph ibeta]
 
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibetac(T1 a, T2 b, T3 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac(T1 a, T2 b, T3 x);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibetac(T1 a, T2 b, T3 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac(T1 a, T2 b, T3 x, const ``__Policy``&);
    
 Returns the normalised complement of the incomplete beta function of a, b and x:
 
 [equation ibeta4]
 
    template <class T1, class T2, class T3>
-   ``__sf_result`` beta(T1 a, T2 b, T3 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` beta(T1 a, T2 b, T3 x);
 
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` beta(T1 a, T2 b, T3 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` beta(T1 a, T2 b, T3 x, const ``__Policy``&);
 
 Returns the full (non-normalised) incomplete beta function of a, b and x:
 
 [equation ibeta1]
 
    template <class T1, class T2, class T3>
-   ``__sf_result`` betac(T1 a, T2 b, T3 x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` betac(T1 a, T2 b, T3 x);
 
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` betac(T1 a, T2 b, T3 x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` betac(T1 a, T2 b, T3 x, const ``__Policy``&);
 
 Returns the full (non-normalised) complement of the incomplete beta function of a, b and x:
 

--- a/doc/sf/ibeta_inv.qbk
+++ b/doc/sf/ibeta_inv.qbk
@@ -7,52 +7,52 @@
    namespace boost{ namespace math{
    
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p, const ``__Policy``&);
    
    template <class T1, class T2, class T3, class T4>
-   ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p, T4* py);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p, T4* py);
    
    template <class T1, class T2, class T3, class T4, class ``__Policy``>
-   ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p, T4* py, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p, T4* py, const ``__Policy``&);
    
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q, const ``__Policy``&);
    
    template <class T1, class T2, class T3, class T4>
-   ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q, T4* py);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q, T4* py);
    
    template <class T1, class T2, class T3, class T4, class ``__Policy``>
-   ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q, T4* py, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q, T4* py, const ``__Policy``&);
    
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibeta_inva(T1 b, T2 x, T3 p);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_inva(T1 b, T2 x, T3 p);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibeta_inva(T1 b, T2 x, T3 p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_inva(T1 b, T2 x, T3 p, const ``__Policy``&);
    
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibetac_inva(T1 b, T2 x, T3 q);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac_inva(T1 b, T2 x, T3 q);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibetac_inva(T1 b, T2 x, T3 q, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac_inva(T1 b, T2 x, T3 q, const ``__Policy``&);
    
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibeta_invb(T1 a, T2 x, T3 p);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_invb(T1 a, T2 x, T3 p);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibeta_invb(T1 a, T2 x, T3 p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_invb(T1 a, T2 x, T3 p, const ``__Policy``&);
    
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibetac_invb(T1 a, T2 x, T3 q);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac_invb(T1 a, T2 x, T3 q);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibetac_invb(T1 a, T2 x, T3 q, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac_invb(T1 a, T2 x, T3 q, const ``__Policy``&);
    
    }} // namespaces
    
@@ -81,16 +81,16 @@ The return type of these functions is computed using the __arg_promotion_rules
 when called with arguments T1...TN of different types.
 
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p, const ``__Policy``&);
    
    template <class T1, class T2, class T3, class T4>
-   ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p, T4* py);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p, T4* py);
    
    template <class T1, class T2, class T3, class T4, class ``__Policy``>
-   ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p, T4* py, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibeta_inv(T1 a, T2 b, T3 p, T4* py, const ``__Policy``&);
    
 Returns a value /x/ such that: `p = ibeta(a, b, x);` 
 and sets `*py = 1 - x` when the `py` parameter is provided and is non-null.  
@@ -104,16 +104,16 @@ Requires:  /a,b > 0/ and /0 <= p <= 1/.
 [optional_policy]
 
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q);
+   BOOST_MATH_GPU_ENABLED``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q, const ``__Policy``&);
    
    template <class T1, class T2, class T3, class T4>
-   ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q, T4* py);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q, T4* py);
    
    template <class T1, class T2, class T3, class T4, class ``__Policy``>
-   ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q, T4* py, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac_inv(T1 a, T2 b, T3 q, T4* py, const ``__Policy``&);
    
 Returns a value /x/ such that: `q = ibetac(a, b, x);`
 and sets `*py = 1 - x` when the `py` parameter is provided and is non-null.  
@@ -127,10 +127,10 @@ Requires:  /a,b > 0/ and /0 <= q <= 1/.
 [optional_policy]
 
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibeta_inva(T1 b, T2 x, T3 p);
+   BOOST_MATH_GPU_ENABLED``__sf_result`` ibeta_inva(T1 b, T2 x, T3 p);
 
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibeta_inva(T1 b, T2 x, T3 p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED``__sf_result`` ibeta_inva(T1 b, T2 x, T3 p, const ``__Policy``&);
 
 Returns a value /a/ such that: `p = ibeta(a, b, x);`
 
@@ -139,10 +139,10 @@ Requires:  /b > 0/, /0 < x < 1/ and /0 <= p <= 1/.
 [optional_policy]
 
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibetac_inva(T1 b, T2 x, T3 p);
+   BOOST_MATH_GPU_ENABLED``__sf_result`` ibetac_inva(T1 b, T2 x, T3 p);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibetac_inva(T1 b, T2 x, T3 p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED``__sf_result`` ibetac_inva(T1 b, T2 x, T3 p, const ``__Policy``&);
    
 Returns a value /a/ such that: `q = ibetac(a, b, x);`
 
@@ -151,10 +151,10 @@ Requires:  /b > 0/, /0 < x < 1/ and /0 <= q <= 1/.
 [optional_policy]
 
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibeta_invb(T1 b, T2 x, T3 p);
+   BOOST_MATH_GPU_ENABLED``__sf_result`` ibeta_invb(T1 b, T2 x, T3 p);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibeta_invb(T1 b, T2 x, T3 p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED``__sf_result`` ibeta_invb(T1 b, T2 x, T3 p, const ``__Policy``&);
 
 Returns a value /b/ such that: `p = ibeta(a, b, x);`
 
@@ -163,10 +163,10 @@ Requires:  /a > 0/, /0 < x < 1/ and /0 <= p <= 1/.
 [optional_policy]
 
    template <class T1, class T2, class T3>
-   ``__sf_result`` ibetac_invb(T1 b, T2 x, T3 p);
+   BOOST_MATH_GPU_ENABLED``__sf_result`` ibetac_invb(T1 b, T2 x, T3 p);
    
    template <class T1, class T2, class T3, class ``__Policy``>
-   ``__sf_result`` ibetac_invb(T1 b, T2 x, T3 p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` ibetac_invb(T1 b, T2 x, T3 p, const ``__Policy``&);
    
 Returns a value /b/ such that: `q = ibetac(a, b, x);`
 

--- a/doc/sf/igamma.qbk
+++ b/doc/sf/igamma.qbk
@@ -9,28 +9,28 @@
    namespace boost{ namespace math{
    
    template <class T1, class T2>
-   ``__sf_result`` gamma_p(T1 a, T2 z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p(T1 a, T2 z);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` gamma_p(T1 a, T2 z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p(T1 a, T2 z, const ``__Policy``&);
    
    template <class T1, class T2>
-   ``__sf_result`` gamma_q(T1 a, T2 z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_q(T1 a, T2 z);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` gamma_q(T1 a, T2 z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_q(T1 a, T2 z, const ``__Policy``&);
    
    template <class T1, class T2>
-   ``__sf_result`` tgamma_lower(T1 a, T2 z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma_lower(T1 a, T2 z);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` tgamma_lower(T1 a, T2 z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma_lower(T1 a, T2 z, const ``__Policy``&);
    
    template <class T1, class T2>
-   ``__sf_result`` tgamma(T1 a, T2 z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma(T1 a, T2 z);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` tgamma(T1 a, T2 z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma(T1 a, T2 z, const ``__Policy``&);
    
    }} // namespaces
    
@@ -53,10 +53,10 @@ The return type of these functions is computed using the __arg_promotion_rules
 when T1 and T2 are different types, otherwise the return type is simply T1.
 
    template <class T1, class T2>
-   ``__sf_result`` gamma_p(T1 a, T2 z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p(T1 a, T2 z);
    
    template <class T1, class T2, class Policy>
-   ``__sf_result`` gamma_p(T1 a, T2 z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p(T1 a, T2 z, const ``__Policy``&);
    
 Returns the normalised lower incomplete gamma function of a and z:
 
@@ -67,10 +67,10 @@ This function changes rapidly from 0 to 1 around the point z == a:
 [graph gamma_p]
 
    template <class T1, class T2>
-   ``__sf_result`` gamma_q(T1 a, T2 z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_q(T1 a, T2 z);
 
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` gamma_q(T1 a, T2 z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_q(T1 a, T2 z, const ``__Policy``&);
 
 Returns the normalised upper incomplete gamma function of a and z:
 
@@ -81,20 +81,20 @@ This function changes rapidly from 1 to 0 around the point z == a:
 [graph gamma_q]
 
    template <class T1, class T2>
-   ``__sf_result`` tgamma_lower(T1 a, T2 z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma_lower(T1 a, T2 z);
 
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` tgamma_lower(T1 a, T2 z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma_lower(T1 a, T2 z, const ``__Policy``&);
 
 Returns the full (non-normalised) lower incomplete gamma function of a and z:
 
 [equation igamma2]
 
    template <class T1, class T2>
-   ``__sf_result`` tgamma(T1 a, T2 z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma(T1 a, T2 z);
 
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` tgamma(T1 a, T2 z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma(T1 a, T2 z, const ``__Policy``&);
 
 Returns the full (non-normalised) upper incomplete gamma function of a and z:
 

--- a/doc/sf/igamma_inv.qbk
+++ b/doc/sf/igamma_inv.qbk
@@ -9,28 +9,28 @@
    namespace boost{ namespace math{
    
    template <class T1, class T2>
-   ``__sf_result`` gamma_q_inv(T1 a, T2 q);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_q_inv(T1 a, T2 q);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` gamma_q_inv(T1 a, T2 q, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_q_inv(T1 a, T2 q, const ``__Policy``&);
    
    template <class T1, class T2>
-   ``__sf_result`` gamma_p_inv(T1 a, T2 p);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p_inv(T1 a, T2 p);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` gamma_p_inv(T1 a, T2 p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p_inv(T1 a, T2 p, const ``__Policy``&);
    
    template <class T1, class T2>
-   ``__sf_result`` gamma_q_inva(T1 x, T2 q);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_q_inva(T1 x, T2 q);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` gamma_q_inva(T1 x, T2 q, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_q_inva(T1 x, T2 q, const ``__Policy``&);
    
    template <class T1, class T2>
-   ``__sf_result`` gamma_p_inva(T1 x, T2 p);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p_inva(T1 x, T2 p);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` gamma_p_inva(T1 x, T2 p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p_inva(T1 x, T2 p, const ``__Policy``&);
    
    }} // namespaces
    
@@ -58,40 +58,40 @@ These are implemented here as `gamma_p_inva` and `gamma_q_inva`.]
 
 
    template <class T1, class T2>
-   ``__sf_result`` gamma_q_inv(T1 a, T2 q);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_q_inv(T1 a, T2 q);
 
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` gamma_q_inv(T1 a, T2 q, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_q_inv(T1 a, T2 q, const ``__Policy``&);
 
 Returns a value x such that: `q = gamma_q(a, x);`
 
 Requires: /a > 0/ and /1 >= p,q >= 0/.
 
    template <class T1, class T2>
-   ``__sf_result`` gamma_p_inv(T1 a, T2 p);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p_inv(T1 a, T2 p);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` gamma_p_inv(T1 a, T2 p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p_inv(T1 a, T2 p, const ``__Policy``&);
    
 Returns a value x such that: `p = gamma_p(a, x);`
 
 Requires: /a > 0/ and /1 >= p,q >= 0/.
 
    template <class T1, class T2>
-   ``__sf_result`` gamma_q_inva(T1 x, T2 q);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_q_inva(T1 x, T2 q);
 
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` gamma_q_inva(T1 x, T2 q, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_q_inva(T1 x, T2 q, const ``__Policy``&);
 
 Returns a value a such that: `q = gamma_q(a, x);`
 
 Requires: /x > 0/ and /1 >= p,q >= 0/.
 
    template <class T1, class T2>
-   ``__sf_result`` gamma_p_inva(T1 x, T2 p);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p_inva(T1 x, T2 p);
    
    template <class T1, class T2, class ``__Policy``>
-   ``__sf_result`` gamma_p_inva(T1 x, T2 p, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` gamma_p_inva(T1 x, T2 p, const ``__Policy``&);
    
 Returns a value a such that: `p = gamma_p(a, x);`
 

--- a/doc/sf/lgamma.qbk
+++ b/doc/sf/lgamma.qbk
@@ -9,16 +9,16 @@
    namespace boost{ namespace math{
    
    template <class T>
-   ``__sf_result`` lgamma(T z);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` lgamma(T z);
    
    template <class T, class ``__Policy``>
-   ``__sf_result`` lgamma(T z, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` lgamma(T z, const ``__Policy``&);
    
    template <class T>
-   ``__sf_result`` lgamma(T z, int* sign);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` lgamma(T z, int* sign);
    
    template <class T, class ``__Policy``>
-   ``__sf_result`` lgamma(T z, int* sign, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` lgamma(T z, int* sign, const ``__Policy``&);
    
    }} // namespaces
 

--- a/doc/sf/pow.qbk
+++ b/doc/sf/pow.qbk
@@ -10,10 +10,10 @@ power of a run-time base.
     namespace boost { namespace math {
 
     template <int N, typename T>
-    constexpr ``__sf_result`` pow(T base);
+    BOOST_MATH_GPU_ENABLED constexpr ``__sf_result`` pow(T base);
 
     template <int N, typename T, class Policy>
-    constexpr ``__sf_result`` pow(T base, const Policy& policy);
+    BOOST_MATH_GPU_ENABLED constexpr ``__sf_result`` pow(T base, const Policy& policy);
 
     }}
 

--- a/doc/sf/sinc.qbk
+++ b/doc/sf/sinc.qbk
@@ -43,16 +43,16 @@ and [@http://mathworld.wolfram.com/Octonion.html octonions].
 ``
 
    template<class T> 
-   ``__sf_result`` sinc_pi(const T x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` sinc_pi(const T x);
 
    template<class T, class ``__Policy``> 
-   ``__sf_result`` sinc_pi(const T x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` sinc_pi(const T x, const ``__Policy``&);
 
    template<class T, template<typename> class U> 
-   U<T> sinc_pi(const U<T> x);
+   BOOST_MATH_GPU_ENABLED U<T> sinc_pi(const U<T> x);
 
    template<class T, template<typename> class U, class ``__Policy``> 
-   U<T> sinc_pi(const U<T> x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED U<T> sinc_pi(const U<T> x, const ``__Policy``&);
 
 Computes 
 [link math_toolkit.sinc.sinc_overview 
@@ -78,10 +78,10 @@ to ensure accuracy.
 ``
 
    template<class T> 
-   ``__sf_result`` sinhc_pi(const T x);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` sinhc_pi(const T x);
 
    template<class T, class ``__Policy``> 
-   ``__sf_result`` sinhc_pi(const T x, const ``__Policy``&);
+   BOOST_MATH_GPU_ENABLED ``__sf_result`` sinhc_pi(const T x, const ``__Policy``&);
 
    template<typename T, template<typename> class U> 
    U<T> sinhc_pi(const U<T> x);

--- a/doc/sf/tgamma.qbk
+++ b/doc/sf/tgamma.qbk
@@ -9,26 +9,26 @@
   namespace boost{ namespace math{
   
   template <class T>
-  ``__sf_result`` tgamma(T z);
+  BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma(T z);
   
   template <class T, class ``__Policy``>
-  ``__sf_result`` tgamma(T z, const ``__Policy``&);
+  BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma(T z, const ``__Policy``&);
   
   template <class T>
-  ``__sf_result`` tgamma1pm1(T dz);
+  BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma1pm1(T dz);
   
   template <class T, class ``__Policy``>
-  ``__sf_result`` tgamma1pm1(T dz, const ``__Policy``&);
+  BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma1pm1(T dz, const ``__Policy``&);
   
   }} // namespaces
   
 [h4 Description]
 
   template <class T>
-  ``__sf_result`` tgamma(T z);
+  BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma(T z);
   
   template <class T, class ``__Policy``>
-  ``__sf_result`` tgamma(T z, const ``__Policy``&);
+  BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma(T z, const ``__Policy``&);
   
 Returns the "true gamma" (hence name tgamma) of value z:
 
@@ -42,10 +42,10 @@ The return type of this function is computed using the __arg_promotion_rules:
 the result is `double` when T is an integer type, and T otherwise.
 
   template <class T>
-  ``__sf_result`` tgamma1pm1(T dz);
+  BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma1pm1(T dz);
   
   template <class T, class ``__Policy``>
-  ``__sf_result`` tgamma1pm1(T dz, const ``__Policy``&);
+  BOOST_MATH_GPU_ENABLED ``__sf_result`` tgamma1pm1(T dz, const ``__Policy``&);
   
 Returns `tgamma(dz + 1) - 1`.  Internally the implementation does not make
 use of the addition and subtraction implied by the definition, leading to

--- a/doc/sf/trigamma.qbk
+++ b/doc/sf/trigamma.qbk
@@ -9,10 +9,10 @@
   namespace boost{ namespace math{
   
   template <class T>
-  ``__sf_result`` trigamma(T x);
+  BOOST_MATH_GPU_ENABLED ``__sf_result`` trigamma(T x);
   
   template <class T, class ``__Policy``>
-  ``__sf_result`` trigamma(T x, const ``__Policy``&);
+  BOOST_MATH_GPU_ENABLED ``__sf_result`` trigamma(T x, const ``__Policy``&);
   
   }} // namespaces
   


### PR DESCRIPTION
Adds to the overview of the documentation a section on GPU support and the very basics of using Boost.Math in kernel functions. Adds markers to all the currently supported functions and distributions. Also fixes a broken rendering of an umlaut-o.

@jzmaddock, @NAThompson, @ckormanyos, @izaid, @dschmitz89, and @steppi let me know if there is anything else that I should add.