### PR TITLE
Fix remez incl test

### DIFF
--- a/include_private/boost/math/tools/remez.hpp
+++ b/include_private/boost/math/tools/remez.hpp
@@ -10,7 +10,7 @@
 #pragma once
 #endif
 
-#include <boost/math/tools/solve.hpp>
+#include "solve.hpp"
 #include <boost/math/tools/minima.hpp>
 #include <boost/math/tools/roots.hpp>
 #include <boost/math/tools/polynomial.hpp>

--- a/test/compile_test/CMakeLists.txt
+++ b/test/compile_test/CMakeLists.txt
@@ -5,4 +5,4 @@
 file(GLOB SOURCES "*.cpp")
 add_library(boost_math-compile_tests STATIC ${SOURCES})
 target_compile_features(boost_math-compile_tests PRIVATE cxx_std_17)
-target_link_libraries(boost_math-compile_tests PUBLIC Boost::math Boost::multiprecision)
+target_link_libraries(boost_math-compile_tests PUBLIC Boost::math Boost::multiprecision Boost::numeric_ublas)

--- a/test/compile_test/tools_remez_inc_test.cpp
+++ b/test/compile_test/tools_remez_inc_test.cpp
@@ -8,5 +8,5 @@
 //
 
 #ifndef BOOST_MATH_STANDALONE
-#include <boost/math/tools/remez.hpp>
+#include "../../include_private/boost/math/tools/remez.hpp"
 #endif


### PR DESCRIPTION
`<boost/math/tools/remez.hpp>` is actually in `include_private` and solve requires Boost.Numeric.Ublas.