### PR TITLE
Make sure we don't activate float128 use when explicitly disabled

### DIFF
--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -465,7 +465,7 @@ struct non_type {};
 #if defined(BOOST_MATH_STANDALONE) && defined(_GLIBCXX_USE_FLOAT128) && defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__) && !defined(__STRICT_ANSI__) \
    && !defined(BOOST_MATH_DISABLE_FLOAT128) && !defined(BOOST_MATH_USE_FLOAT128)
 #  define BOOST_MATH_USE_FLOAT128
-#elif defined(BOOST_HAS_FLOAT128) && !defined(BOOST_MATH_USE_FLOAT128)
+#elif defined(BOOST_HAS_FLOAT128) && !defined(BOOST_MATH_USE_FLOAT128) && !defined(BOOST_MATH_DISABLE_FLOAT128)
 #  define BOOST_MATH_USE_FLOAT128
 #endif
 #ifdef BOOST_MATH_USE_FLOAT128


### PR DESCRIPTION
@kursatyurt can you please give this patch a go and see if it solves your issue? If not can you please add a minimal reproducer and toolchain used to your issue. Thanks