### PR TITLE
fix: define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS for emscripten

### DIFF
--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -220,10 +220,14 @@
 
 #include <boost/math/tools/user.hpp>
 
-#if (defined(__NetBSD__) || defined(__EMSCRIPTEN__)\
+#if (defined(__NetBSD__)\
    || (defined(__hppa) && !defined(__OpenBSD__)) || (defined(__NO_LONG_DOUBLE_MATH) && (DBL_MANT_DIG != LDBL_MANT_DIG))) \
    && !defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS)
 //#  define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+#endif
+
+#if defined(__EMSCRIPTEN__) && !defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS)
+#  define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
 #endif
 
 #ifdef __IBMCPP__


### PR DESCRIPTION
Extracted check for `emscripten` and define `BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS` in case it wasn't previously defined.

This should fix #1215.