### PR TITLE
Fix clang warning when compiling with -ffast-math: use of infinity is undefined behavior due to the currently enabled floating-point options

### DIFF
--- a/include/boost/math/ccmath/isinf.hpp
+++ b/include/boost/math/ccmath/isinf.hpp
@@ -25,6 +25,7 @@ constexpr bool isinf BOOST_MATH_PREVENT_MACRO_SUBSTITUTION(T x) noexcept
 #if defined(__clang_major__) && __clang_major__ >= 6
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-constant-compare"
+#pragma clang diagnostic ignored "-Wnan-infinity-disabled"
 #endif
             return x == std::numeric_limits<T>::infinity() || -x == std::numeric_limits<T>::infinity();
 #if defined(__clang_major__) && __clang_major__ >= 6


### PR DESCRIPTION
Fixes the following warning:
```
C:\boost_1_86_0\boost/math/ccmath/isinf.hpp(29,69): warning : use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
C:\boost_1_86_0\boost/math/ccmath/isinf.hpp(29,25): warning : use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
C:\boost_1_86_0\boost/math/ccmath/ldexp.hpp(50,38): note: in instantiation of function template specialization 'boost::math::ccmath::isinf<float>' requested here
C:\boost_1_86_0\boost/math/ccmath/ldexp.hpp(69,33): note: in instantiation of function template specialization 'boost::math::ccmath::ldexp<float, true>' requested here
```