### PR TITLE
igamma_inv query on double_fp_backend

### DIFF
--- a/include/boost/math/special_functions/detail/igamma_inverse.hpp
+++ b/include/boost/math/special_functions/detail/igamma_inverse.hpp
@@ -390,7 +390,9 @@ struct gamma_p_inverse_func
          f2 = -f2;
       }
 
-      return boost::math::make_tuple(static_cast<T>(f - p), f1, f2);
+      const T rela_diff_or_diff { (fabs(1 - p / f) <= 4 * tools::epsilon<T>()) ? T { 0 } : static_cast<T>(f - p) };
+
+      return boost::math::make_tuple(rela_diff_or_diff, f1, f2);
    }
 private:
    T a, p;

--- a/include/boost/math/special_functions/detail/igamma_inverse.hpp
+++ b/include/boost/math/special_functions/detail/igamma_inverse.hpp
@@ -390,7 +390,7 @@ struct gamma_p_inverse_func
          f2 = -f2;
       }
 
-      const T rela_diff_or_diff { (fabs(1 - p / f) <= 4 * tools::epsilon<T>()) ? T { 0 } : static_cast<T>(f - p) };
+      const T rela_diff_or_diff { (fabs(1 - p / f) < tools::epsilon<T>()) ? T { 0 } : static_cast<T>(f - p) };
 
       return boost::math::make_tuple(rela_diff_or_diff, f1, f2);
    }


### PR DESCRIPTION
Hi John (@jzmaddock)

This may (hopefully) be my last query on _specfun_ for the newly proposed `cpp_double_fp_backend`.

The final problems that the `cpp_double_fp_backend<double>` backend are facing in the _specfun_ test-suite arise in the tests of `igamma_inv`. The Halley-iteration in some (very few like two or three) cases would run and not exit (until max-Halley-iterations was reached and throw). The culprit was the exact floating-point delta-comparison needed for exit condition.

In the iteration code, I replaced the exact difference of `(f - p)` with either a relative difference or an exact difference. I do not know why, but the `cpp_double_fp_backend` would sometimes have 1-eps or so of convergence _fuzz_ that I could neither explain nor eliminate in two or three `igamma_inv` cases.

The one, single change you find proposed in `igamma_inverse.hpp` works around this problem. This change seems somewhat bold to me and I'm not exactly sure why my new double-double backend was experiencing 1-eps _fuzz_. The change was harmless for `cpp_dec_float` and `cpp_bin_float` tests locally.

And I'm now running this change through Math's CI and requesting your opinion on this change?

Cc: @mborland