### PR TITLE
Fix constexpr cmath floor of 1 returning 0 #1232

### DIFF
--- a/include/boost/math/ccmath/floor.hpp
+++ b/include/boost/math/ccmath/floor.hpp
@@ -33,7 +33,7 @@ inline constexpr T floor_pos_impl(T arg) noexcept
 
     T result = 1;
 
-    if(result < arg)
+    if(result <= arg)
     {
         while(result < arg)
         {

--- a/test/ccmath_floor_test.cpp
+++ b/test/ccmath_floor_test.cpp
@@ -32,6 +32,7 @@ constexpr void test()
     static_assert(boost::math::ccmath::isinf(boost::math::ccmath::floor(-std::numeric_limits<T>::infinity())), 
                   "If x is +- inf, it is returned, unmodified");
 
+    static_assert(boost::math::ccmath::floor(T(1.0)) == T(1.0));
     static_assert(boost::math::ccmath::floor(T(2)) == T(2));
     static_assert(boost::math::ccmath::floor(T(2.4)) == T(2));
     static_assert(boost::math::ccmath::floor(T(2.9)) == T(2));


### PR DESCRIPTION
### Problem
The `boost::math::ccmath::floor` function incorrectly returns `0.0` for `1.0` in a `constexpr` context.

### Solution
- Fixed the implementation to correctly handle `1.0`.
- Added test cases in `ccmath_floor_test.cpp`.

### Linked Issue
Fixes #1232