### PR TITLE
Update gamma.hpp

### DIFF
--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -111,7 +111,7 @@ BOOST_MATH_GPU_ENABLED T sinpx(T z)
 // tgamma(z), with Lanczos support:
 //
 template <class T, class Policy, class Lanczos>
-BOOST_MATH_GPU_ENABLED T gamma_imp_final(T z, const Policy& pol, const Lanczos&)
+BOOST_MATH_GPU_ENABLED T gamma_imp_final(T z, const Policy& pol, const Lanczos& l)
 {
    BOOST_MATH_STD_USING
 

--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -121,6 +121,7 @@ BOOST_MATH_GPU_ENABLED T gamma_imp_final(T z, const Policy& pol, const Lanczos& 
    static bool b = false;
    if(!b)
    {
+      (void)l;  
       std::cout << "tgamma_imp called with " << typeid(z).name() << " " << typeid(l).name() << std::endl;
       b = true;
    }

--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -114,14 +114,15 @@ template <class T, class Policy, class Lanczos>
 BOOST_MATH_GPU_ENABLED T gamma_imp_final(T z, const Policy& pol, const Lanczos& l)
 {
    BOOST_MATH_STD_USING
+   
+   (void)l; // Suppresses unused variable warning when BOOST_MATH_INSTRUMENT is not defined
 
-   T result = 1;
+   T result = 1;  
 
 #ifdef BOOST_MATH_INSTRUMENT
    static bool b = false;
    if(!b)
    {
-      (void)l;  
       std::cout << "tgamma_imp called with " << typeid(z).name() << " " << typeid(l).name() << std::endl;
       b = true;
    }


### PR DESCRIPTION
Missing name for Lanczos parameter in gamma_imp_final at line 114

It caused an error when compiling at line 124

     std::cout << "tgamma_imp called with " << typeid(z).name() << " " << typeid(l).name() << std::endl;
 
 
Checked on old code and the parameter has l name