### PR TITLE
Fix check for clang warning -Wnan-infinity-disabled

### DIFF
--- a/include/boost/math/ccmath/isinf.hpp
+++ b/include/boost/math/ccmath/isinf.hpp
@@ -25,8 +25,10 @@ constexpr bool isinf BOOST_MATH_PREVENT_MACRO_SUBSTITUTION(T x) noexcept
 #if defined(__clang_major__) && __clang_major__ >= 6
 #  pragma clang diagnostic push
 #  pragma clang diagnostic ignored "-Wtautological-constant-compare"
-#  if __clang_major__ >= 18
-#    pragma clang diagnostic ignored "-Wnan-infinity-disabled"
+#  if defined(__has_warning)
+#    if __has_warning("-Wnan-infinity-disabled")
+#      pragma clang diagnostic ignored "-Wnan-infinity-disabled"
+#    endif
 #  endif
 #endif
             return x == std::numeric_limits<T>::infinity() || -x == std::numeric_limits<T>::infinity();


### PR DESCRIPTION
with latest changes I still had warnings with icx2024 (intel's new compiler version 2024).
