### PR TITLE
Fix for inverse ibeta with large a,b.

### DIFF
--- a/include/boost/math/special_functions/detail/ibeta_inverse.hpp
+++ b/include/boost/math/special_functions/detail/ibeta_inverse.hpp
@@ -683,12 +683,12 @@ BOOST_MATH_GPU_ENABLED T ibeta_inv_imp(T a, T b, T p, T q, const Policy& pol, T*
             }
             else
                y = 1;
-            if((y > 1e-5) && (std::max)(a, b) < 1000)
+            if((y > 1e-5) && (std::min)(a, b) < 1000)
             {
                x = temme_method_3_ibeta_inverse(a, b, p, q, pol);
                y = 1 - x;
             }
-            else
+            else if ((y > 1e-5) && (std::min)(a, b) > 1000)
             {
                // All options have failed, use the saddle point as a starting location:
                x = (std::max)(a, b) / (a + b);

--- a/include/boost/math/special_functions/detail/ibeta_inverse.hpp
+++ b/include/boost/math/special_functions/detail/ibeta_inverse.hpp
@@ -692,7 +692,7 @@ BOOST_MATH_GPU_ENABLED T ibeta_inv_imp(T a, T b, T p, T q, const Policy& pol, T*
             {
                // All options have failed, use the saddle point as a starting location:
                x = (std::max)(a, b) / (a + b);
-               y = 1 - x;
+               y = (std::min)(a, b) / (a + b);
             }
          }
       }

--- a/include/boost/math/special_functions/detail/ibeta_inverse.hpp
+++ b/include/boost/math/special_functions/detail/ibeta_inverse.hpp
@@ -683,9 +683,15 @@ BOOST_MATH_GPU_ENABLED T ibeta_inv_imp(T a, T b, T p, T q, const Policy& pol, T*
             }
             else
                y = 1;
-            if(y > 1e-5)
+            if((y > 1e-5) && (std::max)(a, b) < 1000)
             {
                x = temme_method_3_ibeta_inverse(a, b, p, q, pol);
+               y = 1 - x;
+            }
+            else
+            {
+               // All options have failed, use the saddle point as a starting location:
+               x = (std::max)(a, b) / (a + b);
                y = 1 - x;
             }
          }

--- a/test/test_ibeta_inv.hpp
+++ b/test/test_ibeta_inv.hpp
@@ -328,6 +328,6 @@ void test_spots(T)
          static_cast<T>(1.0e11L),
          static_cast<T>(1.0e13L),
          static_cast<T>(0.995L)),
-      static_cast<T>(0.0099010703473402885173268397418009652L), 1e-10);
+      static_cast<T>(0.0099010703473402885173268397418009652L), 5e-10);
 }
 

--- a/test/test_ibeta_inv.hpp
+++ b/test/test_ibeta_inv.hpp
@@ -320,5 +320,14 @@ void test_spots(T)
       BOOST_CHECK((boost::math::isfinite)(boost::math::ibeta_inv(m, m, static_cast<T>(0.125))));
    }
    #endif
+   //
+   // scipy: https://github.com/scipy/scipy/issues/21725
+   //
+   BOOST_CHECK_CLOSE(
+      ::boost::math::ibeta_inv(
+         static_cast<T>(1.0e11L),
+         static_cast<T>(1.0e13L),
+         static_cast<T>(0.995L)),
+      static_cast<T>(0.0099010703473402885173268397418009652L), 1e-10);
 }
 


### PR DESCRIPTION
In this case Temme's method may fail as the incomplete gamma can't cope, but as the function changes over from 0 to 1 very rapidly, we can just use the saddle point as a reasonable starting location for iteration. See https://github.com/scipy/scipy/issues/21725.