### PR TITLE
Prevent spurious numeric underflow in ibeta_series.

### DIFF
--- a/include/boost/math/special_functions/beta.hpp
+++ b/include/boost/math/special_functions/beta.hpp
@@ -683,7 +683,15 @@ BOOST_MATH_GPU_ENABLED T ibeta_series(T a, T b, T x, T s0, const Lanczos&, bool 
       if ((a < tools::min_value<T>()) || (b < tools::min_value<T>()))
          result = 0;  // denorms cause overflow in the Lanzos series, result will be zero anyway
       else
-         result = Lanczos::lanczos_sum_expG_scaled(c) / (Lanczos::lanczos_sum_expG_scaled(a) * Lanczos::lanczos_sum_expG_scaled(b));
+      {
+         T l1 = Lanczos::lanczos_sum_expG_scaled(c);
+         T l2 = Lanczos::lanczos_sum_expG_scaled(a);
+         T l3 = Lanczos::lanczos_sum_expG_scaled(b);
+         if ((l2 > 1) && (l3 > 1) && (tools::max_value<T>() / l2 < l3))
+            result = (l1 / l2) / l3;
+         else
+         result = l1 / (l2 * l3);
+      }
 
       if (!(boost::math::isfinite)(result))
          result = 0;  // LCOV_EXCL_LINE we can probably never get here, covered already above?

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -190,6 +190,7 @@ test-suite special_fun :
    [ run git_issue_1175.cpp ]
    [ run git_issue_1194.cpp ]
    [ run git_issue_1255.cpp ]
+   [ run git_issue_1247.cpp ]
    [ run special_functions_test.cpp /boost/test//boost_unit_test_framework  ]
    [ run test_airy.cpp test_instances//test_instances pch_light /boost/test//boost_unit_test_framework  ]
    [ run test_bessel_j.cpp test_instances//test_instances pch_light /boost/test//boost_unit_test_framework  ]

--- a/test/git_issue_1247.cpp
+++ b/test/git_issue_1247.cpp
@@ -1,0 +1,21 @@
+//  (C) Copyright John Maddock 2025.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See also: https://godbolt.org/z/nhMsKb8Yr
+
+#include <boost/math/special_functions/beta.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+int main()
+{
+   float a = 1e-20;
+   float b = 1e-21;
+   float z = 0.5;
+   float p = boost::math::ibeta(a, b, z, boost::math::policies::make_policy(boost::math::policies::promote_float<false>()));
+
+   BOOST_TEST(p != 0);
+
+   return boost::report_errors();
+}


### PR DESCRIPTION
Fixes #1247.