### PR TITLE
Handle various conversion warnings

### DIFF
--- a/include/boost/math/constants/info.hpp
+++ b/include/boost/math/constants/info.hpp
@@ -13,7 +13,9 @@
 #include <boost/math/constants/constants.hpp>
 #include <iostream>
 #include <iomanip>
+#ifndef BOOST_MATH_NO_RTTI
 #include <typeinfo>
+#endif
 
 namespace boost{ namespace math{ namespace constants{
 
@@ -22,7 +24,11 @@ namespace boost{ namespace math{ namespace constants{
       template <class T>
       const char* nameof(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE_SPEC(T))
       {
+         #ifndef BOOST_MATH_NO_RTTI
          return typeid(T).name();
+         #else
+         return "unknown";
+         #endif
       }
       template <>
       const char* nameof<float>(BOOST_MATH_EXPLICIT_TEMPLATE_TYPE_SPEC(float))

--- a/include/boost/math/distributions/landau.hpp
+++ b/include/boost/math/distributions/landau.hpp
@@ -3382,7 +3382,7 @@ BOOST_MATH_GPU_ENABLED inline RealType landau_quantile_lower_imp_prec(const Real
 
         // Rational Approximation
         // Maximum Relative Error: 5.3064e-35
-        //LCOV_EXCL_START
+        // LCOV_EXCL_START
         BOOST_MATH_STATIC const RealType P[14] = {
             BOOST_MATH_BIG_CONSTANT(RealType, 113, -5.09971143249822249471944441552701756051e0),
             BOOST_MATH_BIG_CONSTANT(RealType, 113, -3.00154235169065403254826962372636417554e-2),

--- a/include/boost/math/policies/error_handling.hpp
+++ b/include/boost/math/policies/error_handling.hpp
@@ -8,29 +8,32 @@
 #ifndef BOOST_MATH_POLICY_ERROR_HANDLING_HPP
 #define BOOST_MATH_POLICY_ERROR_HANDLING_HPP
 
+#include <boost/math/policies/policy.hpp>
 #include <boost/math/tools/config.hpp>
 #include <boost/math/tools/numeric_limits.hpp>
-#include <boost/math/tools/type_traits.hpp>
-#include <boost/math/tools/cstdint.hpp>
-#include <boost/math/tools/tuple.hpp>
-#include <boost/math/policies/policy.hpp>
 #include <boost/math/tools/precision.hpp>
+#include <boost/math/tools/tuple.hpp>
+#include <boost/math/tools/type_traits.hpp>
 
 #ifndef BOOST_MATH_HAS_NVRTC
 
-#include <iomanip>
-#include <string>
-#include <cstring>
-#ifndef BOOST_MATH_NO_RTTI
-#include <typeinfo>
+#ifndef BOOST_MATH_NO_EXCEPTIONS
+#include <boost/math/tools/throw_exception.hpp>
 #endif
+
 #include <cerrno>
-#include <complex>
 #include <cmath>
+#include <complex>
 #include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <sstream>
 #ifndef BOOST_MATH_NO_EXCEPTIONS
 #include <stdexcept>
-#include <boost/math/tools/throw_exception.hpp>
+#endif
+#include <string>
+#ifndef BOOST_MATH_NO_RTTI
+#include <typeinfo>
 #endif
 
 #ifdef _MSC_VER
@@ -43,7 +46,6 @@
 // Note that this only occurs when the compiler can deduce code is unreachable,
 // for example when policy macros are used to ignore errors rather than throw.
 #endif
-#include <sstream>
 
 namespace boost{ namespace math{
 
@@ -91,15 +93,20 @@ namespace detail
 template <class T>
 inline std::string prec_format(const T& val)
 {
-   typedef typename boost::math::policies::precision<T, boost::math::policies::policy<> >::type prec_type;
-   std::stringstream ss;
-   if(prec_type::value)
+   using prec_type = typename boost::math::policies::precision<T, boost::math::policies::policy<> >::type;
+
+   std::stringstream strm { };
+
+   if(prec_type::value != prec_type { 0 })
    {
-      int prec = 2 + (prec_type::value * 30103UL) / 100000UL;
-      ss << std::setprecision(prec);
+      const std::streamsize prec { static_cast<std::streamsize>(2UL + (prec_type::value * 30103UL) / 100000UL) };
+
+      strm << std::setprecision(prec);
    }
-   ss << val;
-   return ss.str();
+
+   strm << val;
+
+   return strm.str();
 }
 
 #ifdef BOOST_MATH_USE_CHARCONV_FOR_CONVERSION

--- a/include/boost/math/policies/error_handling.hpp
+++ b/include/boost/math/policies/error_handling.hpp
@@ -97,7 +97,7 @@ inline std::string prec_format(const T& val)
 
    std::stringstream strm { };
 
-   if(prec_type::value != prec_type { 0 })
+   if(prec_type::value)
    {
       const std::streamsize prec { static_cast<std::streamsize>(2UL + (prec_type::value * 30103UL) / 100000UL) };
 

--- a/include/boost/math/policies/policy.hpp
+++ b/include/boost/math/policies/policy.hpp
@@ -132,7 +132,7 @@ namespace policies{
 
 #define BOOST_MATH_META_INT(Type, name, Default)                                                \
    template <Type N = Default>                                                                  \
-   class name : public boost::math::integral_constant<int, N>{};                                \
+   class name : public boost::math::integral_constant<int, static_cast<int>(N)>{};              \
                                                                                                 \
    namespace detail{                                                                            \
    template <Type N>                                                                            \

--- a/include/boost/math/policies/policy.hpp
+++ b/include/boost/math/policies/policy.hpp
@@ -132,7 +132,7 @@ namespace policies{
 
 #define BOOST_MATH_META_INT(Type, name, Default)                                                \
    template <Type N = Default>                                                                  \
-   class name : public boost::math::integral_constant<int, static_cast<int>(N)>{};              \
+   class name : public boost::math::integral_constant<Type, N> { };                             \
                                                                                                 \
    namespace detail{                                                                            \
    template <Type N>                                                                            \

--- a/include/boost/math/special_functions/bessel.hpp
+++ b/include/boost/math/special_functions/bessel.hpp
@@ -524,7 +524,7 @@ BOOST_MATH_GPU_ENABLED inline T cyl_neumann_zero_imp(T v, int m, const Policy& p
 
    if(number_of_iterations >= policies::get_max_root_iterations<Policy>())
    {
-      return policies::raise_evaluation_error<T>(function, "Unable to locate root in a reasonable time: Current best guess is %1%", yvm, Policy()); //LCOV_EXCL_LINE
+      return policies::raise_evaluation_error<T>(function, "Unable to locate root in a reasonable time: Current best guess is %1%", yvm, Policy()); // LCOV_EXCL_LINE
    }
 
    return yvm;

--- a/include/boost/math/special_functions/detail/bernoulli_details.hpp
+++ b/include/boost/math/special_functions/detail/bernoulli_details.hpp
@@ -108,7 +108,7 @@ inline std::size_t find_bernoulli_overflow_limit(const std::false_type&)
    // Set a limit on how large the result can ever be:
    static const auto max_result = static_cast<double>((std::numeric_limits<std::size_t>::max)() - 1000u);
 
-   unsigned long long t = lltrunc(boost::math::tools::log_max_value<T>());
+   unsigned long long t = static_cast<unsigned long long>(lltrunc(boost::math::tools::log_max_value<T>()));
    max_bernoulli_root_functor fun(t);
    boost::math::tools::equal_floor tol;
    std::uintmax_t max_iter = boost::math::policies::get_max_root_iterations<Policy>();
@@ -372,7 +372,7 @@ public:
          {
             for(; n; ++start, --n)
             {
-               *out = b2n_asymptotic<T, Policy>(static_cast<typename container_type::size_type>(start * 2U));
+               *out = b2n_asymptotic<T, Policy>(static_cast<int>(start * 2U));
                ++out;
             }
          }

--- a/include/boost/math/special_functions/detail/bessel_jn.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jn.hpp
@@ -76,7 +76,7 @@ BOOST_MATH_GPU_ENABLED T bessel_jn(int n, T x, const Policy& pol)
     {
         prev = bessel_j0(x);
         current = bessel_j1(x);
-        policies::check_series_iterations<T>("boost::math::bessel_j_n<%1%>(%1%,%1%)", n, pol);
+        policies::check_series_iterations<T>("boost::math::bessel_j_n<%1%>(%1%,%1%)", static_cast<unsigned>(n), pol);
         for (int k = 1; k < n; k++)
         {
             value = (2 * k * current / x) - prev;
@@ -96,7 +96,7 @@ BOOST_MATH_GPU_ENABLED T bessel_jn(int n, T x, const Policy& pol)
         prev = fn;
         current = 1;
         // Check recursion won't go on too far:
-        policies::check_series_iterations<T>("boost::math::bessel_j_n<%1%>(%1%,%1%)", n, pol);
+        policies::check_series_iterations<T>("boost::math::bessel_j_n<%1%>(%1%,%1%)", static_cast<unsigned>(n), pol);
         for (int k = n; k > 0; k--)
         {
             T fact = 2 * k / x;

--- a/include/boost/math/special_functions/detail/bessel_jy.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jy.hpp
@@ -227,7 +227,7 @@ namespace boost { namespace math {
          fi = temp * delta_i + fi * delta_r;
          for (k = 2; k < policies::get_max_series_iterations<Policy>(); k++)
          {
-            a = k - 0.5f;
+            a = static_cast<T>(k) - 0.5f;
             a *= a;
             a -= v2;
             bi += 2;
@@ -291,7 +291,7 @@ namespace boost { namespace math {
             *J = *Y = policies::raise_evaluation_error<T>(function, "Order of Bessel function is too large to evaluate: got %1%", v, pol);
             return 1;  // LCOV_EXCL_LINE previous line will throw.
          }
-         n = iround(v, pol);
+         n = static_cast<unsigned>(iround(v, pol));
          u = v - n;                              // -1/2 <= u < 1/2
 
          if(reflect)
@@ -370,7 +370,7 @@ namespace boost { namespace math {
                || (org_kind & need_j && (reflect && (sp != 0))))
             {
                // Only calculate if we need it, and if the reflection formula will actually use it:
-               Yv = bessel_yn_small_z(n, x, &Yv_scale, pol);
+               Yv = bessel_yn_small_z(static_cast<int>(n), x, &Yv_scale, pol);
             }
             else
                Yv = boost::math::numeric_limits<T>::quiet_NaN();

--- a/include/boost/math/special_functions/detail/bessel_jy.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jy.hpp
@@ -361,7 +361,8 @@ namespace boost { namespace math {
             // Truncated series evaluation for small x and v an integer,
             // much quicker in this area than temme_jy below.
             // This code is only used in the multiprecision case, otherwise
-            // we go via bessel_jn.  LCOV_EXCL_START
+            // we go via bessel_jn.
+            // LCOV_EXCL_START
             if(kind&need_j)
                Jv = bessel_j_small_z_series(v, x, pol);
             else

--- a/include/boost/math/special_functions/detail/bessel_jy_series.hpp
+++ b/include/boost/math/special_functions/detail/bessel_jy_series.hpp
@@ -245,7 +245,7 @@ BOOST_MATH_GPU_ENABLED T bessel_yn_small_z(int n, T z, T* scale, const Policy& p
       auto p = static_cast<T>(pow(z / 2, n));
       #endif
       
-      T result = -((boost::math::factorial<T>(n - 1, pol) / constants::pi<T>()));
+      T result = -((boost::math::factorial<T>(static_cast<unsigned>(n - 1), pol) / constants::pi<T>()));
       if(p * tools::max_value<T>() < fabs(result))
       {
          T div = tools::max_value<T>() / 8;

--- a/include/boost/math/special_functions/detail/igamma_large.hpp
+++ b/include/boost/math/special_functions/detail/igamma_large.hpp
@@ -273,7 +273,7 @@ BOOST_MATH_GPU_ENABLED T igamma_temme_large(T a, T x, const Policy& pol, const b
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.00640336283380806979482),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.00404101610816766177474),
    };
-   // LCOV_EXCL_END
+   // LCOV_EXCL_STOP
 
    workspace[12] = tools::evaluate_polynomial(C12, z);
 
@@ -420,7 +420,7 @@ BOOST_MATH_GPU_ENABLED T igamma_temme_large(T a, T x, const Policy& pol, const b
       static_cast<T>(0.00083949872067208728L),
       static_cast<T>(-0.00043829709854172101L),
    };
-   // LCOV_EXCL_END
+   // LCOV_EXCL_STOP
    workspace[8] = tools::evaluate_polynomial(C8, z);
    workspace[9] = static_cast<T>(-0.00059676129019274625L);
 
@@ -488,7 +488,7 @@ BOOST_MATH_GPU_ENABLED T igamma_temme_large(T a, T x, const Policy& pol, const b
       static_cast<T>(0.000771604938L),
    };
    workspace[2] = tools::evaluate_polynomial(C2, z);
-   // LCOV_EXCL_END
+   // LCOV_EXCL_STOP
 
    T result = tools::evaluate_polynomial(workspace, 1/a);
    result *= exp(-y) / sqrt(2 * constants::pi<T>() * a);
@@ -810,7 +810,7 @@ BOOST_MATH_GPU_ENABLED T igamma_temme_large(T a, T x, const Policy& pol, const b
 
    return result;
 }
-// LCOV_EXCL_END
+// LCOV_EXCL_STOP
 
 #endif
 

--- a/include/boost/math/special_functions/detail/lgamma_small.hpp
+++ b/include/boost/math/special_functions/detail/lgamma_small.hpp
@@ -119,7 +119,7 @@ BOOST_MATH_GPU_ENABLED T lgamma_small_imp(T z, T zm1, T zm2, const boost::math::
          static_cast<T>(BOOST_MATH_BIG_CONSTANT(T, 64, -0.223352763208617092964e-6))
       };
 
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       constexpr float Y = 0.158963680267333984375e0f;
 
       T r = zm2 * (z + 1);
@@ -185,7 +185,7 @@ BOOST_MATH_GPU_ENABLED T lgamma_small_imp(T z, T zm1, T zm2, const boost::math::
             static_cast<T>(BOOST_MATH_BIG_CONSTANT(T, 64, 0.577039722690451849648e-1)),
             static_cast<T>(BOOST_MATH_BIG_CONSTANT(T, 64, 0.195768102601107189171e-2))
          };
-         // LCOV_EXCL_END
+         // LCOV_EXCL_STOP
 
          T r = tools::evaluate_polynomial(P, zm1) / tools::evaluate_polynomial(Q, zm1);
          T prefix = zm1 * zm2;
@@ -231,7 +231,7 @@ BOOST_MATH_GPU_ENABLED T lgamma_small_imp(T z, T zm1, T zm2, const boost::math::
             static_cast<T>(BOOST_MATH_BIG_CONSTANT(T, 64, -0.100666795539143372762e-2)),
             static_cast<T>(BOOST_MATH_BIG_CONSTANT(T, 64, -0.827193521891290553639e-6))
          };
-         // LCOV_EXCL_END
+         // LCOV_EXCL_STOP
 
          T r = zm2 * zm1;
          T R = tools::evaluate_polynomial(P, T(-zm2)) / tools::evaluate_polynomial(Q, T(-zm2));
@@ -509,7 +509,7 @@ T lgamma_small_imp(T z, T zm1, T zm2, const boost::math::integral_constant<int, 
    BOOST_MATH_INSTRUMENT_CODE(result);
    return result;
 }
-// LCOV_EXCL_END
+// LCOV_EXCL_STOP
 
 template <class T, class Policy, class Lanczos>
 BOOST_MATH_GPU_ENABLED T lgamma_small_imp(T z, T zm1, T zm2, const boost::math::integral_constant<int, 0>&, const Policy& pol, const Lanczos& l)

--- a/include/boost/math/special_functions/erf.hpp
+++ b/include/boost/math/special_functions/erf.hpp
@@ -713,12 +713,12 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
    BOOST_MATH_INSTRUMENT_CODE("113-bit precision erf_imp called");
 
    if ((boost::math::isnan)(z))
-      return policies::raise_domain_error("boost::math::erf<%1%>(%1%)", "Expected a finite argument but got %1%", z, pol); // LCOV_EXCL_LINE checked as covered.
+      return policies::raise_domain_error("boost::math::erf<%1%>(%1%)", "Expected a finite argument but got %1%", z, pol);
 
    if(z < 0)
    {
       if (!invert)
-         return -erf_imp(T(-z), invert, pol, t); // LCOV_EXCL_LINE confirmed as covered, not sure why lcov does see it.
+         return -erf_imp(T(-z), invert, pol, t);
       else if(z < -0.5)
          return 2 - erf_imp(T(-z), invert, pol, t);
       else
@@ -739,12 +739,12 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
       //
       if(z == 0)
       {
-         result = 0; // LCOV_EXCL_LINE confirmed as covered, not sure why lcov doesn't see this.
+         result = 0;
       }
       else if(z < 1e-20)
       {
-         static const T c = BOOST_MATH_BIG_CONSTANT(T, 113, 0.003379167095512573896158903121545171688); // LCOV_EXCL_LINE
-         result = z * 1.125 + z * c;  // LCOV_EXCL_LINE confirmed as covered, not sure why lcov doesn't see this.
+         static const T c = BOOST_MATH_BIG_CONSTANT(T, 113, 0.003379167095512573896158903121545171688);
+         result = z * 1.125 + z * c;
       }
       else
       {
@@ -752,7 +752,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
          // Maximum Deviation Found:                     6.124e-36
          // Expected Error Term:                         -6.124e-36
          // Maximum Relative Change in Control Points:   3.492e-10
-         // LCOV_EXCL_START
          static const T Y = 1.0841522216796875f;
          static const T P[] = {    
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.0442269454158250738961589031215451778),
@@ -774,7 +773,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.196230608502104324965623171516808796e-5),
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.313388521582925207734229967907890146e-7),
          };
-         // LCOV_EXCL_STOP
          result = z * (Y + tools::evaluate_polynomial(P, T(z * z)) / tools::evaluate_polynomial(Q, T(z * z)));
       }
    }
@@ -790,7 +788,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
          // Maximum Deviation Found:                     1.388e-35
          // Expected Error Term:                         1.387e-35
          // Maximum Relative Change in Control Points:   6.127e-05
-         // LCOV_EXCL_START
          static const T Y = 0.371877193450927734375f;
          static const T P[] = {    
             BOOST_MATH_BIG_CONSTANT(T, 113, -0.0640320213544647969396032886581290455),
@@ -817,14 +814,13 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.226988669466501655990637599399326874e-4),
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.270666232259029102353426738909226413e-10),
          };
-         // LCOV_EXCL_STOP
          result = Y + tools::evaluate_polynomial(P, T(z - 0.5f)) / tools::evaluate_polynomial(Q, T(z - 0.5f));
-         T hi, lo;  // LCOV_EXCL_LINE
+         T hi, lo;
          int expon;
          hi = floor(ldexp(frexp(z, &expon), 56));
          hi = ldexp(hi, expon - 56);
          lo = z - hi;
-         T sq = z * z;  // LCOV_EXCL_LINE strangely not seen by lcov.
+         T sq = z * z;
          T err_sqr = ((hi * hi - sq) + 2 * hi * lo) + lo * lo;
          result *= exp(-sq) * exp(-err_sqr) / z;
       }
@@ -834,7 +830,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
          // Maximum Deviation Found:                     1.539e-35
          // Expected Error Term:                         1.538e-35
          // Maximum Relative Change in Control Points:   6.104e-05
-         // LCOV_EXCL_START
          static const T Y = 0.45658016204833984375f;
          static const T P[] = {    
             BOOST_MATH_BIG_CONSTANT(T, 113, -0.0289965858925328393392496555094848345),
@@ -860,14 +855,13 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.000349871943711566546821198612518656486),
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.123749319840299552925421880481085392e-4),
          };
-         // LCOV_EXCL_STOP
          result = Y + tools::evaluate_polynomial(P, T(z - 1.0f)) / tools::evaluate_polynomial(Q, T(z - 1.0f));
-         T hi, lo;  // LCOV_EXCL_LINE
+         T hi, lo;
          int expon;
          hi = floor(ldexp(frexp(z, &expon), 56));
          hi = ldexp(hi, expon - 56);
          lo = z - hi;
-         T sq = z * z;  // LCOV_EXCL_LINE strangley not seen by lcov
+         T sq = z * z;
          T err_sqr = ((hi * hi - sq) + 2 * hi * lo) + lo * lo;
          result *= exp(-sq) * exp(-err_sqr) / z;
       }
@@ -877,7 +871,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
          // Expected Error Term:                         1.418e-35
          // Maximum Relative Change in Control Points:   1.316e-04
          // Max Error found at long double precision =   1.998462e-35
-         // LCOV_EXCL_START
          static const T Y = 0.50250148773193359375f;
          static const T P[] = {    
             BOOST_MATH_BIG_CONSTANT(T, 113, -0.0201233630504573402185161184151016606),
@@ -904,14 +897,13 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.507158721790721802724402992033269266e-5),
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.18647774409821470950544212696270639e-12),
          };
-         // LCOV_EXCL_STOP
          result = Y + tools::evaluate_polynomial(P, T(z - 1.5f)) / tools::evaluate_polynomial(Q, T(z - 1.5f));
-         T hi, lo;  // LCOV_EXCL_LINE
+         T hi, lo;
          int expon;
          hi = floor(ldexp(frexp(z, &expon), 56));
          hi = ldexp(hi, expon - 56);
          lo = z - hi;
-         T sq = z * z;  // LCOV_EXCL_LINE strangely not seen by lcov.
+         T sq = z * z;
          T err_sqr = ((hi * hi - sq) + 2 * hi * lo) + lo * lo;
          result *= exp(-sq) * exp(-err_sqr) / z;
       }
@@ -921,7 +913,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
          // Expected Error Term:                         3.575e-36
          // Maximum Relative Change in Control Points:   7.103e-05
          // Max Error found at long double precision =   5.794737e-36
-         // LCOV_EXCL_START
          static const T Y = 0.52896785736083984375f;
          static const T P[] = {    
             BOOST_MATH_BIG_CONSTANT(T, 113, -0.00902152521745813634562524098263360074),
@@ -947,14 +938,13 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.686843205749767250666787987163701209e-4),
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.192093541425429248675532015101904262e-5),
          };
-         // LCOV_EXCL_STOP
          result = Y + tools::evaluate_polynomial(P, T(z - 2.25f)) / tools::evaluate_polynomial(Q, T(z - 2.25f));
-         T hi, lo;  // LCOV_EXCL_LINE
+         T hi, lo;
          int expon;
          hi = floor(ldexp(frexp(z, &expon), 56));
          hi = ldexp(hi, expon - 56);
          lo = z - hi;
-         T sq = z * z;  // LCOV_EXCL_LINE strangely not seen by lcov.
+         T sq = z * z;
          T err_sqr = ((hi * hi - sq) + 2 * hi * lo) + lo * lo;
          result *= exp(-sq) * exp(-err_sqr) / z;
       }
@@ -964,7 +954,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
          // Expected Error Term:                         -8.126e-37
          // Maximum Relative Change in Control Points:   1.363e-04
          // Max Error found at long double precision =   1.747062e-36
-         // LCOV_EXCL_START
          static const T Y = 0.54037380218505859375f;
          static const T P[] = {    
             BOOST_MATH_BIG_CONSTANT(T, 113, -0.0033703486408887424921155540591370375),
@@ -988,14 +977,13 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.000144243326443913171313947613547085553),
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.407763415954267700941230249989140046e-5),
          };
-         // LCOV_EXCL_STOP
          result = Y + tools::evaluate_polynomial(P, T(z - 3.0f)) / tools::evaluate_polynomial(Q, T(z - 3.0f));
-         T hi, lo;  // LCOV_EXCL_LINE
+         T hi, lo;
          int expon;
          hi = floor(ldexp(frexp(z, &expon), 56));
          hi = ldexp(hi, expon - 56);
          lo = z - hi;
-         T sq = z * z;  // LCOV_EXCL_LINE strangely not seen by lcov.
+         T sq = z * z;
          T err_sqr = ((hi * hi - sq) + 2 * hi * lo) + lo * lo;
          result *= exp(-sq) * exp(-err_sqr) / z;
       }
@@ -1005,7 +993,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
          // Expected Error Term:                         -5.803e-36
          // Maximum Relative Change in Control Points:   2.475e-05
          // Max Error found at long double precision =   1.349545e-35
-         // LCOV_EXCL_START
          static const T Y = 0.55000019073486328125f;
          static const T P[] = {    
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.00118142849742309772151454518093813615),
@@ -1033,14 +1020,13 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.655068544833064069223029299070876623e-6),
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.11005507545746069573608988651927452e-7),
          };
-         // LCOV_EXCL_STOP
          result = Y + tools::evaluate_polynomial(P, T(z - 4.5f)) / tools::evaluate_polynomial(Q, T(z - 4.5f));
-         T hi, lo; // LCOV_EXCL_LINE
+         T hi, lo;
          int expon;
          hi = floor(ldexp(frexp(z, &expon), 56));
          hi = ldexp(hi, expon - 56);
          lo = z - hi;
-         T sq = z * z;  // LCOV_EXCL_LINE strangely not seen by lcov.
+         T sq = z * z;
          T err_sqr = ((hi * hi - sq) + 2 * hi * lo) + lo * lo;
          result *= exp(-sq) * exp(-err_sqr) / z;
       }
@@ -1050,7 +1036,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
          // Expected Error Term:                         1.007e-36
          // Maximum Relative Change in Control Points:   1.027e-03
          // Max Error found at long double precision =   2.646420e-36
-         // LCOV_EXCL_START
          static const T Y = 0.5574436187744140625f;
          static const T P[] = {    
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.000293236907400849056269309713064107674),
@@ -1076,8 +1061,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.674128352521481412232785122943508729e-6),
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.997637501418963696542159244436245077e-8),
          };
-         // LCOV_EXCL_STOP
-         // LCOV_EXCL_START confirmed as covered by the __float128 tests in GNU mode.
          result = Y + tools::evaluate_polynomial(P, T(z - 6.5f)) / tools::evaluate_polynomial(Q, T(z - 6.5f));
          T hi, lo;
          int expon;
@@ -1087,7 +1070,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
          T sq = z * z;
          T err_sqr = ((hi * hi - sq) + 2 * hi * lo) + lo * lo;
          result *= exp(-sq) * exp(-err_sqr) / z;
-         // LCOV_EXCL_STOP
       }
       else if(z < 11.5)
       {
@@ -1095,7 +1077,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
          // Expected Error Term:                         8.380e-36
          // Maximum Relative Change in Control Points:   2.632e-06
          // Max Error found at long double precision =   9.849522e-36
-         // LCOV_EXCL_START
          static const T Y = 0.56083202362060546875f;
          static const T P[] = {    
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.000282420728751494363613829834891390121),
@@ -1121,14 +1102,13 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.164033049810404773469413526427932109e-4),
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.356615210500531410114914617294694857e-6),
          };
-         // LCOV_EXCL_STOP
          result = Y + tools::evaluate_polynomial(P, T(z / 2 - 4.75f)) / tools::evaluate_polynomial(Q, T(z / 2 - 4.75f));
-         T hi, lo;  // LCOV_EXCL_LINE
+         T hi, lo;
          int expon;
          hi = floor(ldexp(frexp(z, &expon), 56));
          hi = ldexp(hi, expon - 56);
          lo = z - hi;
-         T sq = z * z; // LCOV_EXCL_LINE  strangely not seen by lcov.
+         T sq = z * z;
          T err_sqr = ((hi * hi - sq) + 2 * hi * lo) + lo * lo;
          result *= exp(-sq) * exp(-err_sqr) / z;
       }
@@ -1138,7 +1118,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
          // Expected Error Term:                         -1.132e-35
          // Maximum Relative Change in Control Points:   4.674e-04
          // Max Error found at long double precision =   1.162590e-35
-         // LCOV_EXCL_START
          static const T Y = 0.5632686614990234375f;
          static const T P[] = {    
             BOOST_MATH_BIG_CONSTANT(T, 113, 0.000920922048732849448079451574171836943),
@@ -1168,7 +1147,6 @@ T erf_imp(T z, bool invert, const Policy& pol, const std::integral_constant<int,
             BOOST_MATH_BIG_CONSTANT(T, 113, 799.359797306084372350264298361110448),
             BOOST_MATH_BIG_CONSTANT(T, 113, 72.7415265778588087243442792401576737),
          };
-         // LCOV_EXCL_STOP
          result = Y + tools::evaluate_polynomial(P, T(1 / z)) / tools::evaluate_polynomial(Q, T(1 / z));
          T hi, lo;
          int expon;

--- a/include/boost/math/special_functions/expm1.hpp
+++ b/include/boost/math/special_functions/expm1.hpp
@@ -16,7 +16,7 @@
 #ifndef BOOST_MATH_HAS_NVRTC
 
 #if defined __has_include
-#  if __cplusplus > 202002L || _MSVC_LANG > 202002L 
+#  if ((__cplusplus > 202002L) || (defined(_MSVC_LANG) && (_MSVC_LANG > 202002L)))
 #    if __has_include (<stdfloat>)
 #    include <stdfloat>
 #    endif

--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -141,7 +141,7 @@ BOOST_MATH_GPU_ENABLED T gamma_imp_final(T z, const Policy& pol, const Lanczos& 
    BOOST_MATH_INSTRUMENT_VARIABLE(result);
    if((floor(z) == z) && (z < max_factorial<T>::value))
    {
-      result *= unchecked_factorial<T>(itrunc(z, pol) - 1);
+      result *= unchecked_factorial<T>(static_cast<unsigned>(itrunc(z, pol) - 1));
       BOOST_MATH_INSTRUMENT_VARIABLE(result);
    }
    else if (z < tools::root_epsilon<T>())
@@ -568,7 +568,7 @@ T gamma_imp(T z, const Policy& pol, const lanczos::undefined_lanczos&)
    // Special case handling of small factorials:
    if((!b_neg) && floor_of_z_is_equal_to_z && (z < boost::math::max_factorial<T>::value))
    {
-      return boost::math::unchecked_factorial<T>(itrunc(z) - 1);
+      return boost::math::unchecked_factorial<T>(static_cast<unsigned>(itrunc(z) - 1));
    }
 
    // Make a local, unsigned copy of the input argument.

--- a/include/boost/math/special_functions/log1p.hpp
+++ b/include/boost/math/special_functions/log1p.hpp
@@ -13,7 +13,7 @@
 #endif
 
 #if defined __has_include
-#  if __cplusplus > 202002L || _MSVC_LANG > 202002L 
+#  if ((__cplusplus > 202002L) || (defined(_MSVC_LANG) && (_MSVC_LANG > 202002L)))
 #    if __has_include (<stdfloat>)
 #    include <stdfloat>
 #    endif

--- a/include/boost/math/special_functions/owens_t.hpp
+++ b/include/boost/math/special_functions/owens_t.hpp
@@ -98,7 +98,7 @@ namespace boost
                1  ,  2   , 3  ,  3  ,  5  ,  5   , 7  ,  7  , 16 ,  16  , 16 ,  16 ,  16  , 11 ,  11,
                1  ,  2   , 3   , 3   , 5  ,  5 ,  17  , 17  , 17 ,  17  , 16 ,  16 ,  16 ,  11 ,  11
             };
-            // LCOV_EXCL_END
+            // LCOV_EXCL_STOP
 
             unsigned short ihint = 14, iaint = 7;
             for(unsigned short i = 0; i != 14; i++)
@@ -129,7 +129,7 @@ namespace boost
          {
             // LCOV_EXCL_START
             static const unsigned short ord[] = {2, 3, 4, 5, 7, 10, 12, 18, 10, 20, 30, 0, 4, 7, 8, 20, 0, 0}; // 18 entries
-            // LCOV_EXCL_END
+            // LCOV_EXCL_STOP
 
             BOOST_MATH_ASSERT(icode<18);
 
@@ -142,7 +142,7 @@ namespace boost
            // method ================>>>       {1, 1, 1, 1, 1,  1,  1,  1,  2,  2,  2,  3, 4,  4,  4,  4,  5, 6}
           // LCOV_EXCL_START
           static const unsigned short ord[] = {3, 4, 5, 6, 8, 11, 13, 19, 10, 20, 30,  0, 7, 10, 11, 23,  0, 0}; // 18 entries
-          // LCOV_EXCL_END
+          // LCOV_EXCL_STOP
 
           BOOST_MATH_ASSERT(icode<18);
 
@@ -254,7 +254,7 @@ namespace boost
                static_cast<RealType>(-0.82813631607004984866E-01),  static_cast<RealType>(0.24167984735759576523E-01),
                static_cast<RealType>(-0.44676566663971825242E-02),  static_cast<RealType>(0.39141169402373836468E-03)
             };
-            // LCOV_EXCL_END
+            // LCOV_EXCL_STOP
 
             const RealType as = a*a;
             const RealType hs = h*h;
@@ -328,7 +328,7 @@ namespace boost
              BOOST_MATH_BIG_CONSTANT(RealType, 260, -1.489155613350368934073453260689881330166342484405529981510694514036264969925132e-4),
              BOOST_MATH_BIG_CONSTANT(RealType, 260, 9.072354320794357587710929507988814669454281514268844884841547607134260303118208e-6)
           };
-          // LCOV_EXCL_END
+          // LCOV_EXCL_STOP
 
           const RealType as = a*a;
           const RealType hs = h*h;
@@ -434,7 +434,7 @@ namespace boost
 
             const RealType as = a*a;
             const RealType hs = -h*h*boost::math::constants::half<RealType>();
-            // LCOV_EXCL_END
+            // LCOV_EXCL_STOP
 
             RealType val = 0;
             for(unsigned short i = 0; i < m; ++i)
@@ -505,7 +505,7 @@ namespace boost
                BOOST_MATH_BIG_CONSTANT(RealType, 64, 0.0018483371329504443947),
                BOOST_MATH_BIG_CONSTANT(RealType, 64, 0.00079623320100438873578)
           };
-          // LCOV_EXCL_END
+          // LCOV_EXCL_STOP
 
           const RealType as = a*a;
           const RealType hs = -h*h*boost::math::constants::half<RealType>();

--- a/include/boost/math/special_functions/zeta.hpp
+++ b/include/boost/math/special_functions/zeta.hpp
@@ -947,7 +947,7 @@ T zeta_imp_odd_integer(int s, const T& sc, const Policy& pol, const std::false_t
          results[k] = zeta_polynomial_series(arg, c_arg, pol);
       }
    }
-   unsigned index = (s - 3) / 2;
+   const unsigned index = static_cast<unsigned>((s - 3) / 2);
    return index >= sizeof(results) / sizeof(results[0]) ? zeta_polynomial_series(T(s), sc, pol): results[index];
 }
 

--- a/include/boost/math/special_functions/zeta.hpp
+++ b/include/boost/math/special_functions/zeta.hpp
@@ -226,7 +226,7 @@ inline T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<in
          static_cast<T>(0.00024978985622317935355L),
          static_cast<T>(-0.101855788418564031874e-4L),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, sc) / tools::evaluate_polynomial(Q, sc);
       result -= 1.2433929443359375F;
       result += (sc);
@@ -253,7 +253,7 @@ inline T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<in
          static_cast<T>(0.000255784226140488490982L),
          static_cast<T>(0.10991819782396112081e-4L),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(-sc)) / tools::evaluate_polynomial(Q, T(-sc));
       result += 1 / (-sc);
    }
@@ -280,7 +280,7 @@ inline T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<in
          static_cast<T>(0.106951867532057341359e-4L),
          static_cast<T>(0.236276623974978646399e-7L),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 2)) / tools::evaluate_polynomial(Q, T(s - 2));
       result += Y + 1 / (-sc);
    }
@@ -309,7 +309,7 @@ inline T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<in
          static_cast<T>(0.718833729365459760664e-8L),
          static_cast<T>(-0.1129200113474947419e-9L),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 4)) / tools::evaluate_polynomial(Q, T(s - 4));
       result = 1 + exp(result);
    }
@@ -339,7 +339,7 @@ inline T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<in
          static_cast<T>(-0.833378440625385520576e-10L),
          static_cast<T>(0.699841545204845636531e-12L),
         };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 7)) / tools::evaluate_polynomial(Q, T(s - 7));
       result = 1 + exp(result);
    }
@@ -368,7 +368,7 @@ inline T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<in
          static_cast<T>(0.118507153474022900583e-7L),
          static_cast<T>(0.222609483627352615142e-14L),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 15)) / tools::evaluate_polynomial(Q, T(s - 15));
       result = 1 + exp(result);
    }
@@ -412,7 +412,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 64>&
          BOOST_MATH_BIG_CONSTANT(T, 64, -0.159600883054550987633e-4),
          BOOST_MATH_BIG_CONSTANT(T, 64, 0.339770279812410586032e-6),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, sc) / tools::evaluate_polynomial(Q, sc);
       result -= 1.2433929443359375F;
       result += (sc);
@@ -441,7 +441,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 64>&
          BOOST_MATH_BIG_CONSTANT(T, 64, 0.635994377921861930071e-5),
          BOOST_MATH_BIG_CONSTANT(T, 64, 0.226583954978371199405e-7),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(-sc)) / tools::evaluate_polynomial(Q, T(-sc));
       result += 1 / (-sc);
    }
@@ -470,7 +470,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 64>&
          BOOST_MATH_BIG_CONSTANT(T, 64, 0.278090318191657278204e-6),
          BOOST_MATH_BIG_CONSTANT(T, 64, -0.19683620233222028478e-8),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 2)) / tools::evaluate_polynomial(Q, T(s - 2));
       result += Y + 1 / (-sc);
    }
@@ -499,7 +499,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 64>&
          BOOST_MATH_BIG_CONSTANT(T, 64, -0.927884739284359700764e-8),
          BOOST_MATH_BIG_CONSTANT(T, 64, 0.119810501805618894381e-9),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 4)) / tools::evaluate_polynomial(Q, T(s - 4));
       result = 1 + exp(result);
    }
@@ -530,7 +530,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 64>&
          BOOST_MATH_BIG_CONSTANT(T, 64, 0.117957556472335968146e-7),
          BOOST_MATH_BIG_CONSTANT(T, 64, -0.193432300973017671137e-12),
         };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 7)) / tools::evaluate_polynomial(Q, T(s - 7));
       result = 1 + exp(result);
    }
@@ -562,7 +562,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 64>&
          BOOST_MATH_BIG_CONSTANT(T, 64, -0.939798249922234703384e-16),
          BOOST_MATH_BIG_CONSTANT(T, 64, 0.264584017421245080294e-18),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 15)) / tools::evaluate_polynomial(Q, T(s - 15));
       result = 1 + exp(result);
    }
@@ -614,7 +614,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 113>
          BOOST_MATH_BIG_CONSTANT(T, 113, -0.217062446168217797598596496310953025e-9),
          BOOST_MATH_BIG_CONSTANT(T, 113, 0.315823200002384492377987848307151168e-11),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, sc) / tools::evaluate_polynomial(Q, sc);
       result += (sc);
       result /= (sc);
@@ -649,7 +649,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 113>
          BOOST_MATH_BIG_CONSTANT(T, 113, -0.377105263588822468076813329270698909e-11),
          BOOST_MATH_BIG_CONSTANT(T, 113, -0.581926559304525152432462127383600681e-13),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(-sc)) / tools::evaluate_polynomial(Q, T(-sc));
       result += 1 / (-sc);
    }
@@ -687,7 +687,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 113>
          BOOST_MATH_BIG_CONSTANT(T, 113, 0.105677416606909614301995218444080615e-11),
          BOOST_MATH_BIG_CONSTANT(T, 113, 0.547223964564003701979951154093005354e-15),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 2)) / tools::evaluate_polynomial(Q, T(s - 2));
       result += Y + 1 / (-sc);
    }
@@ -729,7 +729,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 113>
          BOOST_MATH_BIG_CONSTANT(T, 113, -0.275363878344548055574209713637734269e-13),
          BOOST_MATH_BIG_CONSTANT(T, 113, 0.221564186807357535475441900517843892e-15),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 4)) / tools::evaluate_polynomial(Q, T(s - 4));
       result -= Y;
       result = 1 + exp(result);
@@ -770,7 +770,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 113>
          BOOST_MATH_BIG_CONSTANT(T, 113, 0.294670713571839023181857795866134957e-16),
          BOOST_MATH_BIG_CONSTANT(T, 113, -0.147003914536437243143096875069813451e-18),
         };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 6)) / tools::evaluate_polynomial(Q, T(s - 6));
       result = 1 + exp(result);
    }
@@ -810,7 +810,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 113>
          BOOST_MATH_BIG_CONSTANT(T, 113, 0.887948682401000153828241615760146728e-19),
          BOOST_MATH_BIG_CONSTANT(T, 113, -0.34980761098820347103967203948619072e-21),
         };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 10)) / tools::evaluate_polynomial(Q, T(s - 10));
       result = 1 + exp(result);
    }
@@ -850,7 +850,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 113>
          BOOST_MATH_BIG_CONSTANT(T, 113, -0.291354445847552426900293580511392459e-22),
          BOOST_MATH_BIG_CONSTANT(T, 113, 0.73614324724785855925025452085443636e-25),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 17)) / tools::evaluate_polynomial(Q, T(s - 17));
       result = 1 + exp(result);
    }
@@ -893,7 +893,7 @@ T zeta_imp_prec(T s, T sc, const Policy&, const std::integral_constant<int, 113>
          BOOST_MATH_BIG_CONSTANT(T, 113, -0.557103423021951053707162364713587374e-31),
          BOOST_MATH_BIG_CONSTANT(T, 113, 0.618708773442584843384712258199645166e-34),
       };
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
       result = tools::evaluate_polynomial(P, T(s - 30)) / tools::evaluate_polynomial(Q, T(s - 30));
       result = 1 + exp(result);
    }
@@ -915,7 +915,7 @@ T zeta_imp_odd_integer(int s, const T&, const Policy&, const std::true_type&)
    static const T results[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, 1.2020569031595942853997381615114500), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0369277551433699263313654864570342), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0083492773819228268397975498497968), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0020083928260822144178527692324121), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0004941886041194645587022825264699), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0001227133475784891467518365263574), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000305882363070204935517285106451), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000076371976378997622736002935630), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000019082127165539389256569577951), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000004769329867878064631167196044), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000001192199259653110730677887189), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000298035035146522801860637051), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000074507117898354294919810042), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000018626597235130490064039099), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000004656629065033784072989233), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000001164155017270051977592974), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000291038504449709968692943), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000072759598350574810145209), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000018189896503070659475848), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000004547473783042154026799), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000001136868407680227849349), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000284217097688930185546), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000071054273952108527129), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000017763568435791203275), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000004440892103143813364), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000001110223025141066134), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000277555756213612417), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000069388939045441537), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000017347234760475766), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000004336808690020650), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000001084202172494241), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000271050543122347), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000067762635780452), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000016940658945098), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000004235164736273), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000001058791184068), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000264697796017), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000066174449004), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000016543612251), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000004135903063), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000001033975766), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000258493941), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000064623485), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000016155871), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000004038968), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000001009742), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000000252435), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000000063109), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000000015777), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000000003944), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000000000986), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000000000247), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000000000062), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000000000015), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000000000004), BOOST_MATH_BIG_CONSTANT(T, 113, 1.0000000000000000000000000000000001),
    };
-   // LCOV_EXCL_END
+   // LCOV_EXCL_STOP
    return s > 113 ? 1 : results[(s - 3) / 2];
 }
 
@@ -929,7 +929,7 @@ T zeta_imp_odd_integer(int s, const T& sc, const Policy& pol, const std::false_t
    static BOOST_MATH_THREAD_LOCAL bool is_init = false;
    static BOOST_MATH_THREAD_LOCAL T results[50] = {};
    static BOOST_MATH_THREAD_LOCAL int digits = tools::digits<T>();
-   // LCOV_EXCL_END
+   // LCOV_EXCL_STOP
    int current_digits = tools::digits<T>();
    if(digits != current_digits)
    {

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -92,14 +92,14 @@
 // Since Boost.Multiprecision is in active development some tests do not fully cooperate yet.
 #define BOOST_MATH_NO_MP_TESTS
 
-#if (__cplusplus > 201400L || _MSVC_LANG > 201400L)
+#if ((__cplusplus > 201400L) || (defined(_MSVC_LANG) && (_MSVC_LANG > 201400L)))
 #define BOOST_MATH_CXX14_CONSTEXPR constexpr
 #else
 #define BOOST_MATH_CXX14_CONSTEXPR
 #define BOOST_MATH_NO_CXX14_CONSTEXPR
 #endif // BOOST_MATH_CXX14_CONSTEXPR
 
-#if (__cplusplus > 201700L || _MSVC_LANG > 201700L)
+#if ((__cplusplus > 201700L) || (defined(_MSVC_LANG) && (_MSVC_LANG > 201700L)))
 #define BOOST_MATH_IF_CONSTEXPR if constexpr
 
 // Clang on mac provides the execution header with none of the functionality. TODO: Check back on this
@@ -113,7 +113,7 @@
 #  define BOOST_MATH_NO_CXX17_HDR_EXECUTION
 #endif
 
-#if __cpp_lib_gcd_lcm >= 201606L
+#if (defined(__cpp_lib_gcd_lcm) && (__cpp_lib_gcd_lcm >= 201606L))
 #define BOOST_MATH_HAS_CXX17_NUMERIC
 #endif
 

--- a/include/boost/math/tools/rational.hpp
+++ b/include/boost/math/tools/rational.hpp
@@ -209,7 +209,7 @@ BOOST_MATH_GPU_ENABLED inline U evaluate_polynomial(const T* poly, U const& z, b
 template <boost::math::size_t N, class T, class V>
 BOOST_MATH_GPU_ENABLED BOOST_MATH_GPU_ENABLED inline V evaluate_polynomial(const T(&a)[N], const V& val) BOOST_MATH_NOEXCEPT(V)
 {
-   typedef boost::math::integral_constant<int, N> tag_type;
+   typedef boost::math::integral_constant<int, static_cast<int>(N)> tag_type;
    return detail::evaluate_polynomial_c_imp(static_cast<const T*>(a), val, static_cast<tag_type const*>(nullptr));
 }
 
@@ -217,7 +217,7 @@ BOOST_MATH_GPU_ENABLED BOOST_MATH_GPU_ENABLED inline V evaluate_polynomial(const
 template <boost::math::size_t N, class T, class V>
 BOOST_MATH_GPU_ENABLED BOOST_MATH_GPU_ENABLED inline V evaluate_polynomial(const std::array<T,N>& a, const V& val) BOOST_MATH_NOEXCEPT(V)
 {
-   typedef boost::math::integral_constant<int, N> tag_type;
+   typedef boost::math::integral_constant<int, static_cast<int>(N)> tag_type;
    return detail::evaluate_polynomial_c_imp(static_cast<const T*>(a.data()), val, static_cast<tag_type const*>(nullptr));
 }
 #endif
@@ -255,7 +255,7 @@ BOOST_MATH_GPU_ENABLED inline U evaluate_odd_polynomial(const T* poly, U z, boos
 template <boost::math::size_t N, class T, class V>
 BOOST_MATH_GPU_ENABLED BOOST_MATH_GPU_ENABLED inline V evaluate_odd_polynomial(const T(&a)[N], const V& z) BOOST_MATH_NOEXCEPT(V)
 {
-   typedef boost::math::integral_constant<int, N-1> tag_type;
+   typedef boost::math::integral_constant<int, static_cast<int>(N-1)> tag_type;
    return a[0] + z * detail::evaluate_polynomial_c_imp(static_cast<const T*>(a) + 1, V(z*z), static_cast<tag_type const*>(nullptr));
 }
 
@@ -263,7 +263,7 @@ BOOST_MATH_GPU_ENABLED BOOST_MATH_GPU_ENABLED inline V evaluate_odd_polynomial(c
 template <boost::math::size_t N, class T, class V>
 BOOST_MATH_GPU_ENABLED BOOST_MATH_GPU_ENABLED inline V evaluate_odd_polynomial(const std::array<T,N>& a, const V& z) BOOST_MATH_NOEXCEPT(V)
 {
-   typedef boost::math::integral_constant<int, N-1> tag_type;
+   typedef boost::math::integral_constant<int, static_cast<int>(N-1)> tag_type;
    return a[0] + z * detail::evaluate_polynomial_c_imp(static_cast<const T*>(a.data()) + 1, V(z*z), static_cast<tag_type const*>(nullptr));
 }
 #endif
@@ -324,14 +324,14 @@ BOOST_MATH_GPU_ENABLED V evaluate_rational(const T* num, const U* denom, const V
 template <boost::math::size_t N, class T, class U, class V>
 BOOST_MATH_GPU_ENABLED BOOST_MATH_GPU_ENABLED inline V evaluate_rational(const T(&a)[N], const U(&b)[N], const V& z) BOOST_MATH_NOEXCEPT(V)
 {
-   return detail::evaluate_rational_c_imp(a, b, z, static_cast<const boost::math::integral_constant<int, N>*>(nullptr));
+   return detail::evaluate_rational_c_imp(a, b, z, static_cast<const boost::math::integral_constant<int, static_cast<int>(N)>*>(nullptr));
 }
 
 #ifndef BOOST_MATH_HAS_NVRTC
 template <boost::math::size_t N, class T, class U, class V>
 BOOST_MATH_GPU_ENABLED BOOST_MATH_GPU_ENABLED inline V evaluate_rational(const std::array<T,N>& a, const std::array<U,N>& b, const V& z) BOOST_MATH_NOEXCEPT(V)
 {
-   return detail::evaluate_rational_c_imp(a.data(), b.data(), z, static_cast<boost::math::integral_constant<int, N>*>(nullptr));
+   return detail::evaluate_rational_c_imp(a.data(), b.data(), z, static_cast<boost::math::integral_constant<int, static_cast<int>(N)>*>(nullptr));
 }
 #endif
 

--- a/include/boost/math/tools/toms748_solve.hpp
+++ b/include/boost/math/tools/toms748_solve.hpp
@@ -548,7 +548,7 @@ BOOST_MATH_GPU_ENABLED boost::math::pair<T, T> bracket_and_solve_root(F f, const
          // magnitude out.  This happens most often if the guess is a small value (say 1) and the result
          // we're looking for is close to std::numeric_limits<T>::min().
          //
-         if((max_iter - count) % step == 0)
+         if((max_iter - count) % static_cast<unsigned>(step) == 0u)
          {
             factor *= 2;
             if(step > 1) step /= 2;
@@ -588,7 +588,7 @@ BOOST_MATH_GPU_ENABLED boost::math::pair<T, T> bracket_and_solve_root(F f, const
          // magnitude out.  This happens most often if the guess is a small value (say 1) and the result
          // we're looking for is close to std::numeric_limits<T>::min().
          //
-         if((max_iter - count) % step == 0)
+         if((max_iter - count) % static_cast<unsigned>(step) == 0u)
          {
             factor *= 2;
             if(step > 1) step /= 2;

--- a/test/test_recurrence.cpp
+++ b/test/test_recurrence.cpp
@@ -12,8 +12,7 @@
 #include <boost/math/tools/recurrence.hpp>
 #include <boost/math/special_functions/bessel.hpp>
 #include <boost/test/included/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
-//#include <boost/test/tools/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 #include <boost/math/concepts/real_concept.hpp>
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Hi folks,

I'm really happy with this one. After literally years of improvements in our combined work, it is now possible to run parts of Math + Multiprecision _unchanged_ off-the-rack on both PC as well as embedded targets.

The purpose of this PR is to handle a few last warnings found when cross-compiling and running Math + Multiprecision on both PC-based GCC as well as 32-bit embedded ARM(R) bare-metal `gcc-arrm-none-eabi`.

The microcontroller compiler found several warnings that seemed quite reasonable to deal with.

I used warnings:

```bash
WARN_FLAGS  :=  -Wall                             \
                -Wextra                           \
                -Wpedantic                        \
                -Wmain                            \
                -Wundef                           \
                -Wconversion                      \
                -Wsign-conversion                 \
                -Wunused-parameter                \
                -Wuninitialized                   \
                -Wshadow
```

This PR does not cover warnings in _all_ of Math, nor in _all_ of Multiprecision. But quite a bit of specfun and both `cpp_bin_float` (which also pulls in `cpp_int`) as well as `cpp_dec_float` at $101$ decimal digits + Math have been successfully executed on PC and microcontroller and become relatively warning-free.

For `cpp_bin_float` and `cpp_dec_float` small amounts of dynamic RAM were needed (primarily for `std::allocator` in the `std::string` template class). So I wrote a tiny one-shot allocator for the global `new()` function and dispensed with the heap.

The Multirpecision benchmark computes the $101$ decimal digit cube root value of

$$
\left(\frac{123456}{100}\right)^{1/3}~\approx~10.72763694322831704548693173735276478\ldots
$$

The Math benchmark computes a small series of cylindrical Bessel function values for 64-bit `::boost::float64_t`

$$
J_{1.23}\left(1/n\right), n=1{\ldots}10
$$

The FLASH/RAM consumptions and timings for the Multiprecision benchmark are shown below (target ARM(R) Cortex(R) M4F STM32F446 from ST-Microelectronics(R) clocked at $168~MHz$). The multiprecision numbers were instantiated with $101$ decimal digits. I also used stubbed functions for some C-language posix primitives such as those pulled in by I/O streaming (needed by Math's exception handling even when exceptions are turned off). I also used RTTI disabled, optimization `-O2`.

| type                 | FLASH                    | RAM                      | time [ms]    |
|-----------------|---------------------|----------------------|--------------|
| `cpp_bin_float` | 97k                        | 6.3k                        |  1.0              |
| `cpp_dec_float` | 80k                        | 26k                        |  2.8              |

Cc: @jzmaddock and @mborland
