### PR TITLE
Fix: Corrected the external archive error in the jSO algorithm

### DIFF
--- a/include/boost/math/optimization/jso.hpp
+++ b/include/boost/math/optimization/jso.hpp
@@ -349,13 +349,14 @@ jso(const Func cost_function, jso_parameters<ArgumentContainer> &jso_params,
           delta_f.push_back(abs(cost[i] - trial_cost));
         }
         // Build the historical archive:
+        // The historical archive stores inferior solutions for the purpose of maintaining diversity.
         if (archive.size() < cost.size()) {
-          archive.push_back(trial_vector);
+          archive.push_back(population[i]);
         } else {
-          // If it's already built, then put the successful trial in a random index:
+          // If it's already built, then put the eliminated individual in a random index:
           archive.resize(cost.size());
           auto idx = gen() % archive.size();
-          archive[idx] = trial_vector;
+          archive[idx] = population[i];
         }
         cost[i] = trial_cost;
         population[i] = trial_vector;


### PR DESCRIPTION
Problem Description: In the jSO algorithm, the external archive was storing successful trials, but according to the original paper, it should store eliminated individuals. The external archive is meant to maintain diversity, and storing successful trials fails to achieve this effect.

Solution: Modified the jSO algorithm's external archive update to store eliminated individuals.