### PR TITLE
Add macOS long double to fp_traits for double precision

### DIFF
--- a/include/boost/math/special_functions/detail/fp_traits.hpp
+++ b/include/boost/math/special_functions/detail/fp_traits.hpp
@@ -270,7 +270,7 @@ template<> struct fp_traits_non_native<double, double_precision>
 // long double (64 bits) -------------------------------------------------------
 
 #if defined(BOOST_NO_INT64_T) || defined(BOOST_NO_INCLASS_MEMBER_INITIALIZATION)\
-   || defined(BOOST_BORLANDC) || defined(__CODEGEAR__) || (defined(__APPLE__) && defined(__aarch64__))
+   || defined(BOOST_BORLANDC) || defined(__CODEGEAR__) || (defined(__APPLE__) && defined(__aarch64__)) || defined(_MSC_VER)
 
 template<> struct fp_traits_non_native<long double, double_precision>
 {


### PR DESCRIPTION
Closes: #1282

Changes the traits to show that macOS long double on ARM64 is an alias for double. Removes what seems to be an improper fall through case because this allowed a definition of `<long double, double_precision>` and `<long double, extended_precsion>` of 128-bits of this platform which is the source of the linked issue error.