### PR TITLE
Prevent std::ldexp underflowing/overflowing because of hard-coded flo…

### DIFF
--- a/include/boost/math/special_functions/detail/t_distribution_inv.hpp
+++ b/include/boost/math/special_functions/detail/t_distribution_inv.hpp
@@ -404,8 +404,10 @@ calculate_real:
          // where we use Shaw's tail series.
          // The crossover point is roughly exponential in -df:
          //
-         T crossover = ldexp(1.0f, iround(T(df / -0.654f), typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type()));
-         if(u > crossover)
+         int u_exp;
+         T m_exp = frexp(u, &u_exp);
+         // The following is equivalent to: u > 2^df/-0.654
+         if(m_exp > 0 && u_exp < df / 0.654f)
          {
             result = boost::math::detail::inverse_students_t_hill(df, u, pol);
          }

--- a/test/test_students_t.cpp
+++ b/test/test_students_t.cpp
@@ -258,6 +258,21 @@ void test_spots(RealType)
          static_cast<RealType>(0.1)),  // probability.
          static_cast<RealType>(-1.475884049), // t
          tolerance);
+   errno = 0;
+   BOOST_CHECK_CLOSE( // Tests of df high and p low.
+      ::boost::math::cdf(
+         students_t_distribution<RealType>(1000.),  // degrees_of_freedom
+         static_cast<RealType>(-3.30028272)),  // t
+         static_cast<RealType>(0.0005), // probability.
+         tolerance);
+   BOOST_CHECK_EQUAL(errno, 0);
+   BOOST_CHECK_CLOSE(
+      ::boost::math::quantile(
+         students_t_distribution<RealType>(1000.),  // degrees_of_freedom.
+         static_cast<RealType>(0.0005)),  //  probability.
+         static_cast<RealType>(-3.30028272),  // t.
+         tolerance);
+   BOOST_CHECK_EQUAL(errno, 0);
 
    BOOST_CHECK_CLOSE(
       ::boost::math::cdf(


### PR DESCRIPTION
Prevent `std::ldexp` underflowing/overflowing because of hard-coded float type.
With exceptions disabled, I would expect `errno` to be set only on real issues. However I was hit by errno set to `ERANGE` for following example:

```
T crossover = ldexp(1.0f, iround(99 / -0.654f));
```

This means that `float` is not able to fit `crossover` even for `df` as small as 99.
