### PR TITLE
Avoid using long double in fourier integrals when not supported

### DIFF
--- a/include/boost/math/quadrature/detail/ooura_fourier_integrals_detail.hpp
+++ b/include/boost/math/quadrature/detail/ooura_fourier_integrals_detail.hpp
@@ -199,7 +199,11 @@ public:
                 add_level<double>(i);
             }
             else if (std::is_same<Real, double>::value) {
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
                 add_level<long double>(i);
+#else
+                add_level<double>(i);
+#endif
             }
             else {
                 add_level<Real>(i);
@@ -270,7 +274,11 @@ public:
                 add_level<double>(ii);
             }
             else if (std::is_same<Real, double>::value) {
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
                 add_level<long double>(ii);
+#else
+                add_level<double>(ii);
+#endif
             }
             else {
                 add_level<Real>(ii);
@@ -468,7 +476,11 @@ public:
                 add_level<double>(i);
             }
             else if (std::is_same<Real, double>::value) {
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
                 add_level<long double>(i);
+#else
+                add_level<double>(i);
+#endif
             }
             else {
                 add_level<Real>(i);
@@ -516,7 +528,11 @@ public:
                 add_level<double>(ii);
             }
             else if (std::is_same<Real, double>::value) {
+#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
                 add_level<long double>(ii);
+#else
+                add_level<double>(ii);
+#endif
             }
             else {
                 add_level<Real>(ii);


### PR DESCRIPTION
When initialising a fourier integral class with double precision (e.g., `quadrature::ooura_fourier_sin<double>`) the internals always call the `add_level` member function with `long double`, even if the platform does not support it