### PR TITLE
Update mingw failures to end at GCC-15

### DIFF
--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -655,7 +655,8 @@ namespace boost{ namespace math{
 //
 // When running windows-2022 or 2025 we see this issue again with GCC 12 and 14
 //
-#if (defined(__MINGW32__) && ((__GNUC__ < 9) || (__GNUC__ >= 12)) && !defined(__clang__))
+// See Also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83562#c6
+#if (defined(__MINGW32__) && ((__GNUC__ < 9) || ((__GNUC__ >= 12) && __GNUC__ < 15 )) && !defined(__clang__))
 #  define BOOST_MATH_NO_THREAD_LOCAL_WITH_NON_TRIVIAL_TYPES
 #endif
 


### PR DESCRIPTION
Got a report on the mailing list that a user hit this configuration error. Checked our links again, and it looks like the bug has finally been fixed in 10/24