### PR TITLE
Fix return type in catmull_rom doc

### DIFF
--- a/doc/interpolators/catmull_rom.qbk
+++ b/doc/interpolators/catmull_rom.qbk
@@ -24,7 +24,7 @@ namespace boost{ namespace math{
 
         catmull_rom(std::initializer_list<Point> l, bool closed = false, typename Point::value_type alpha = (typename Point::value_type) 1/ (typename Point::value_type) 2);
 
-        Real operator()(Real s) const;
+        Point operator()(Real s) const;
 
         Real max_parameter() const;
 


### PR DESCRIPTION
The doc for the [Catmull-Romm interpolator](https://www.boost.org/doc/libs/1_87_0/libs/math/doc/html/math_toolkit/catmull_rom.html) lists the return type for `operator()` as `Real` when it [should be `Point`](https://github.com/boostorg/math/blob/43239024883d0f4986bdfce4cb471b3563faf161/include/boost/math/interpolators/catmull_rom.hpp#L76)