### PR TITLE
Update project version and cmake minimum versions, require C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,9 @@
 # Distributed under the Boost Software License, Version 1.0.
 # https://www.boost.org/LICENSE_1_0.txt
 
-cmake_minimum_required(VERSION 3.5...3.16)
+cmake_minimum_required(VERSION 3.8...3.16)
 
-project(boost_math VERSION 1.89.0 LANGUAGES CXX)
+project(boost_math VERSION 1.90.0 LANGUAGES CXX)
 
 add_library(boost_math INTERFACE)
 
@@ -44,6 +44,8 @@ else()
   )
 
 endif()
+
+target_compile_features(boost_math INTERFACE cxx_std_14)
 
 if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
 


### PR DESCRIPTION
Cmake minimum version required was posted to the ML. Version 1.89 of boost was released a while ago so we need to increment to 1.90