### PR TITLE
Fix parameter inconsistencies in distribution docs

### DIFF
--- a/doc/distributions/chi_squared.qbk
+++ b/doc/distributions/chi_squared.qbk
@@ -25,10 +25,10 @@
 
       // Parameter estimation:
       BOOST_MATH_GPU_ENABLED static RealType find_degrees_of_freedom(
-         RealType difference_from_mean,
+         RealType difference_from_variance,
          RealType alpha,
          RealType beta,
-         RealType sd,
+         RealType variance,
          RealType hint = 100);
    };
    

--- a/doc/distributions/geometric.qbk
+++ b/doc/distributions/geometric.qbk
@@ -26,11 +26,9 @@
       // Bounds on success fraction:
       BOOST_MATH_GPU_ENABLED static RealType find_lower_bound_on_p(
          RealType trials, 
-         RealType successes,
          RealType probability); // alpha
       BOOST_MATH_GPU_ENABLED static RealType find_upper_bound_on_p(
          RealType trials, 
-         RealType successes,
          RealType probability); // alpha
          
       // Estimate min/max number of trials:
@@ -141,8 +139,8 @@ see __binomial_distrib and __negative_binomial_distrib for more discussion.
 [h5 Lower Bound on success_fraction Parameter ['p]]
 
       static RealType find_lower_bound_on_p(
-        RealType failures, 
-        RealType probability) // (0 <= alpha <= 1), 0.05 equivalent to 95% confidence.
+        RealType trials, 
+        RealType alpha) // (0 <= alpha <= 1), 0.05 equivalent to 95% confidence.
       
 Returns a *lower bound* on the success fraction:
 

--- a/doc/distributions/negative_binomial.qbk
+++ b/doc/distributions/negative_binomial.qbk
@@ -135,14 +135,14 @@ see __binomial_distrib for more discussion.
 [h5 Lower Bound on Parameter p]
 
       BOOST_MATH_GPU_ENABLED static RealType find_lower_bound_on_p(
-        RealType failures,
+        RealType trials,
         RealType successes,
         RealType probability) // (0 <= alpha <= 1), 0.05 equivalent to 95% confidence.
 
 Returns a *lower bound* on the success fraction:
 
 [variablelist
-[[failures][The total number of failures before the ['r]th success.]]
+[[trials][The total number of trials conducted.]]
 [[successes][The number of successes required.]]
 [[alpha][The largest acceptable probability that the true value of
          the success fraction is [*less than] the value returned.]]


### PR DESCRIPTION
This PR fixes a handful of parameters/names in the statistical distribution docs which don't align with the headers themselves