### PR TITLE
Fix CUDA support with logistic distribution

### DIFF
--- a/include/boost/math/special_functions/logistic_sigmoid.hpp
+++ b/include/boost/math/special_functions/logistic_sigmoid.hpp
@@ -15,7 +15,7 @@ namespace boost {
 namespace math {
 
 template <typename RealType, typename Policy>
-RealType logistic_sigmoid(RealType x, const Policy&)
+BOOST_MATH_GPU_ENABLED RealType logistic_sigmoid(RealType x, const Policy&)
 {
     BOOST_MATH_STD_USING
 
@@ -35,7 +35,7 @@ RealType logistic_sigmoid(RealType x, const Policy&)
 }
 
 template <typename RealType>
-RealType logistic_sigmoid(RealType x)
+BOOST_MATH_GPU_ENABLED RealType logistic_sigmoid(RealType x)
 {
     return logistic_sigmoid(x, policies::policy<>());
 }

--- a/include/boost/math/special_functions/logit.hpp
+++ b/include/boost/math/special_functions/logit.hpp
@@ -17,7 +17,7 @@ namespace boost {
 namespace math {
 
 template <typename RealType, typename Policy>
-RealType logit(RealType p, const Policy&)
+BOOST_MATH_GPU_ENABLED RealType logit(RealType p, const Policy&)
 {
     BOOST_MATH_STD_USING
     using std::atanh;
@@ -45,7 +45,7 @@ RealType logit(RealType p, const Policy&)
 }
 
 template <typename RealType>
-RealType logit(RealType p)
+BOOST_MATH_GPU_ENABLED RealType logit(RealType p)
 {
     return logit(p, policies::policy<>());
 }


### PR DESCRIPTION
These functions were recently added, but were missing the gpu macro. This caused runtime failures of the logistic dis