### PR TITLE
Improve check for incomplete <execution> header

### DIFF
--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -84,7 +84,9 @@
 
 #else // Things from boost/config that are required, and easy to replicate
 
+#if __has_include(<version>)
 #include <version>
+#endif
 
 #define BOOST_MATH_PREVENT_MACRO_SUBSTITUTION
 #define BOOST_MATH_NO_REAL_CONCEPT_TESTS


### PR DESCRIPTION
All versions of libc++ currently include a useless <execution> header by default, not just the version shipped with Apple Clang. For example, IBM Open XL C/C++ 17.1.3 on AIX is affected as well.