### PR TITLE
Update gh actions checkout version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         standard: [ c++20 ]
         suite: [ github_ci_block_1, github_ci_block_2 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
       - name: Set TOOLSET
@@ -86,7 +86,7 @@ jobs:
         compiler: [ g++-13, clang++-19 ]
         standard: [ c++14, c++17, c++20, c++23 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
       - name: Set TOOLSET
@@ -145,7 +145,7 @@ jobs:
         standard: [ 14, 17, 20 ]
         suite: [ github_ci_block_1, github_ci_block_2 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
       - name: Checkout main boost
@@ -188,7 +188,7 @@ jobs:
         standard: [ 14 ]
         suite: [ github_ci_block_1, github_ci_block_2 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
       - name: Checkout main boost
@@ -231,7 +231,7 @@ jobs:
         standard: [ 14, 17, latest ]
         suite: [ github_ci_block_1, github_ci_block_2 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
       - name: Checkout main boost
@@ -271,7 +271,7 @@ jobs:
     env:
       TOOLSET: gcc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
       - name: Install Cygwin
@@ -305,7 +305,7 @@ jobs:
       matrix:
         compiler: [ g++-13 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
       - name: Add repository
@@ -345,7 +345,7 @@ jobs:
       matrix:
         compiler: [ clang++-19 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
       - name: Add repository
@@ -387,7 +387,7 @@ jobs:
         standard: [ c++14, c++17, c++20, c++23 ]
         suite: [ github_ci_block_1, github_ci_block_2 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
       - name: Set TOOLSET
@@ -448,7 +448,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install packages
         if: matrix.install
@@ -498,7 +498,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use library with add_subdirectory (header-only)
         run: |
@@ -520,7 +520,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Boost
         run: |
@@ -561,7 +561,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Boost
         run: |
@@ -613,7 +613,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Boost
         run: |
@@ -665,7 +665,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Boost
         run: |
@@ -733,7 +733,7 @@ jobs:
           printenv >> $GITHUB_ENV
 
       - name: checkout project code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Packages
         run: |
@@ -791,7 +791,7 @@ jobs:
           echo "Installed cuda version is: ${{steps.cuda-toolkit.outputs.cuda}}"+
           echo "Cuda install location: ${{steps.cuda-toolkit.outputs.CUDA_PATH}}"
           nvcc -V
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Packages
         run: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -92,7 +92,7 @@ jobs:
           fi
           git config --global pack.threads 0
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # For coverage builds fetch the whole history, else only 1 commit using a 'fake ternary'
           fetch-depth: ${{ matrix.coverage && '0' || '1' }}
@@ -106,7 +106,7 @@ jobs:
           restore-keys: ${{matrix.os}}-${{matrix.container}}-${{matrix.compiler}}-
 
       - name: Fetch Boost.CI
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: boostorg/boost-ci
           ref: master


### PR DESCRIPTION
Currently many CI jobs show the following deprecation warning (see for example [here](https://github.com/boostorg/math/actions/runs/24625235758/job/72002983064?pr=1385)):

<img width="1134" height="235" alt="image" src="https://github.com/user-attachments/assets/7a8d7336-2b72-409e-8a2b-d9910e395ca4" />

This PR updates the "checkout" gh action to the latest major release.