### PR TITLE
constants: Protect F which is defined as a macro by some frameworks

### DIFF
--- a/include/boost/math/constants/constants.hpp
+++ b/include/boost/math/constants/constants.hpp
@@ -129,7 +129,7 @@ namespace boost{ namespace math
          {
             initializer()
             {
-               F();
+               (F)();
             }
             void force_instantiate()const{}
          };


### PR DESCRIPTION
For instance, ESP32 platform globally defines:

    esp32/WString.h: #define F(string_literal)  (FPSTR(PSTR(string_literal)))