### PR TITLE
constants: Protect F which is defined as a macro by some frameworks - part 2

### DIFF
--- a/include/boost/math/constants/constants.hpp
+++ b/include/boost/math/constants/constants.hpp
@@ -151,7 +151,7 @@ namespace boost{ namespace math
          {
             initializer()
             {
-               F();
+               (F)();
             }
             void force_instantiate()const{}
          };


### PR DESCRIPTION

This is the twin sibling of : https://github.com/boostorg/math/pull/1391

The same issue occurs with unprotected macro. 
Had forgotten this one in previous correction.