### PR TITLE
100% Test coverage all (?) distributions

### DIFF
--- a/include/boost/math/distributions/binomial.hpp
+++ b/include/boost/math/distributions/binomial.hpp
@@ -88,7 +88,7 @@
 #include <boost/math/distributions/detail/inv_discrete_quantile.hpp> // error checks
 #include <boost/math/special_functions/fpclassify.hpp> // isnan.
 #include <boost/math/tools/roots.hpp> // for root finding.
-#include <iostream>
+
 #include <utility>
 
 namespace boost

--- a/include/boost/math/distributions/binomial.hpp
+++ b/include/boost/math/distributions/binomial.hpp
@@ -88,7 +88,7 @@
 #include <boost/math/distributions/detail/inv_discrete_quantile.hpp> // error checks
 #include <boost/math/special_functions/fpclassify.hpp> // isnan.
 #include <boost/math/tools/roots.hpp> // for root finding.
-
+#include <iostream>
 #include <utility>
 
 namespace boost
@@ -157,7 +157,7 @@ namespace boost
         template <class RealType, class Policy>
         BOOST_MATH_CUDA_ENABLED inline bool check_dist_and_prob(const char* function, const RealType& N, RealType p, RealType prob, RealType* result, const Policy& pol)
         {
-           if((check_dist(function, N, p, result, pol) && detail::check_probability(function, prob, result, pol)) == false)
+           if(!(check_dist(function, N, p, result, pol) && detail::check_probability(function, prob, result, pol)))
               return false;
            return true;
         }
@@ -321,11 +321,11 @@ namespace boost
         BOOST_MATH_STATIC const char* function = "boost::math::binomial_distribution<%1%>::find_lower_bound_on_p";
         // Error checks:
         RealType result = 0;
-        if(false == binomial_detail::check_dist_and_k(
+        if(!(binomial_detail::check_dist_and_k(
            function, trials, RealType(0), successes, &result, Policy())
             &&
            binomial_detail::check_dist_and_prob(
-           function, trials, RealType(0), probability, &result, Policy()))
+           function, trials, RealType(0), probability, &result, Policy())))
         { return result; }
 
         if(successes == 0)
@@ -346,11 +346,11 @@ namespace boost
         BOOST_MATH_STATIC const char* function = "boost::math::binomial_distribution<%1%>::find_upper_bound_on_p";
         // Error checks:
         RealType result = 0;
-        if(false == binomial_detail::check_dist_and_k(
+        if(!(binomial_detail::check_dist_and_k(
            function, trials, RealType(0), successes, &result, Policy())
             &&
            binomial_detail::check_dist_and_prob(
-           function, trials, RealType(0), probability, &result, Policy()))
+           function, trials, RealType(0), probability, &result, Policy())))
         { return result; }
 
         if(trials == successes)
@@ -373,11 +373,11 @@ namespace boost
         BOOST_MATH_STATIC const char* function = "boost::math::binomial_distribution<%1%>::find_minimum_number_of_trials";
         // Error checks:
         RealType result = 0;
-        if(false == binomial_detail::check_dist_and_k(
+        if(!(binomial_detail::check_dist_and_k(
            function, k, p, k, &result, Policy())
             &&
            binomial_detail::check_dist_and_prob(
-           function, k, p, alpha, &result, Policy()))
+           function, k, p, alpha, &result, Policy())))
         { return result; }
 
         result = ibetac_invb(k + 1, p, alpha, Policy());  // returns n - k
@@ -392,11 +392,11 @@ namespace boost
         BOOST_MATH_STATIC const char* function = "boost::math::binomial_distribution<%1%>::find_maximum_number_of_trials";
         // Error checks:
         RealType result = 0;
-        if(false == binomial_detail::check_dist_and_k(
+        if(!(binomial_detail::check_dist_and_k(
            function, k, p, k, &result, Policy())
             &&
            binomial_detail::check_dist_and_prob(
-           function, k, p, alpha, &result, Policy()))
+           function, k, p, alpha, &result, Policy())))
         { return result; }
 
         result = ibeta_invb(k + 1, p, alpha, Policy());  // returns n - k

--- a/include/boost/math/distributions/cauchy.hpp
+++ b/include/boost/math/distributions/cauchy.hpp
@@ -57,11 +57,11 @@ BOOST_MATH_GPU_ENABLED RealType cdf_imp(const cauchy_distribution<RealType, Poli
    RealType result = 0;
    RealType location = dist.location();
    RealType scale = dist.scale();
-   if(false == detail::check_location(function, location, &result, Policy()))
+   if(!detail::check_location(function, location, &result, Policy()))
    {
      return result;
    }
-   if(false == detail::check_scale(function, scale, &result, Policy()))
+   if(!detail::check_scale(function, scale, &result, Policy()))
    {
       return result;
    }
@@ -84,7 +84,7 @@ BOOST_MATH_GPU_ENABLED RealType cdf_imp(const cauchy_distribution<RealType, Poli
      return static_cast<RealType>((complement) ? 1 : 0);
    }
    #endif
-   if(false == detail::check_x(function, x, &result, Policy()))
+   if(!detail::check_x(function, x, &result, Policy()))
    { // Catches x == NaN
       return result;
    }
@@ -111,15 +111,15 @@ BOOST_MATH_GPU_ENABLED RealType quantile_imp(
    RealType result = 0;
    RealType location = dist.location();
    RealType scale = dist.scale();
-   if(false == detail::check_location(function, location, &result, Policy()))
+   if(!detail::check_location(function, location, &result, Policy()))
    {
      return result;
    }
-   if(false == detail::check_scale(function, scale, &result, Policy()))
+   if(!detail::check_scale(function, scale, &result, Policy()))
    {
       return result;
    }
-   if(false == detail::check_probability(function, p, &result, Policy()))
+   if(!detail::check_probability(function, p, &result, Policy()))
    {
       return result;
    }
@@ -224,11 +224,11 @@ BOOST_MATH_GPU_ENABLED inline RealType pdf(const cauchy_distribution<RealType, P
    RealType result = 0;
    RealType location = dist.location();
    RealType scale = dist.scale();
-   if(false == detail::check_scale(function, scale, &result, Policy()))
+   if(!detail::check_scale(function, scale, &result, Policy()))
    {
       return result;
    }
-   if(false == detail::check_location(function, location, &result, Policy()))
+   if(!detail::check_location(function, location, &result, Policy()))
    {
       return result;
    }
@@ -242,7 +242,7 @@ BOOST_MATH_GPU_ENABLED inline RealType pdf(const cauchy_distribution<RealType, P
    //  return 0;
    //}
 
-   if(false == detail::check_x(function, x, &result, Policy()))
+   if(!detail::check_x(function, x, &result, Policy()))
    { // Catches x = NaN
       return result;
    }

--- a/include/boost/math/distributions/chi_squared.hpp
+++ b/include/boost/math/distributions/chi_squared.hpp
@@ -103,7 +103,7 @@ BOOST_MATH_GPU_ENABLED RealType pdf(const chi_squared_distribution<RealType, Pol
 
    constexpr auto function = "boost::math::pdf(const chi_squared_distribution<%1%>&, %1%)";
 
-   if(false == detail::check_df(
+   if(!detail::check_df(
          function, degrees_of_freedom, &error_result, Policy()))
       return error_result;
 
@@ -142,7 +142,7 @@ BOOST_MATH_GPU_ENABLED inline RealType cdf(const chi_squared_distribution<RealTy
    RealType error_result;
    constexpr auto function = "boost::math::cdf(const chi_squared_distribution<%1%>&, %1%)";
 
-   if(false == detail::check_df(
+   if(!detail::check_df(
          function, degrees_of_freedom, &error_result, Policy()))
       return error_result;
 
@@ -180,7 +180,7 @@ BOOST_MATH_GPU_ENABLED inline RealType cdf(const complemented2_type<chi_squared_
    constexpr auto function = "boost::math::cdf(const chi_squared_distribution<%1%>&, %1%)";
    // Error check:
    RealType error_result;
-   if(false == detail::check_df(
+   if(!detail::check_df(
          function, degrees_of_freedom, &error_result, Policy()))
       return error_result;
 
@@ -201,8 +201,7 @@ BOOST_MATH_GPU_ENABLED inline RealType quantile(const complemented2_type<chi_squ
    constexpr auto function = "boost::math::quantile(const chi_squared_distribution<%1%>&, %1%)";
    // Error check:
    RealType error_result;
-   if(false == (
-     detail::check_df(function, degrees_of_freedom, &error_result, Policy())
+   if (!(detail::check_df(function, degrees_of_freedom, &error_result, Policy())
      && detail::check_probability(function, q, &error_result, Policy()))
      )
     return error_result;
@@ -310,9 +309,8 @@ BOOST_MATH_GPU_ENABLED RealType chi_squared_distribution<RealType, Policy>::find
    constexpr auto function = "boost::math::chi_squared_distribution<%1%>::find_degrees_of_freedom(%1%,%1%,%1%,%1%,%1%)";
    // Check for domain errors:
    RealType error_result;
-   if(false ==
-     detail::check_probability(function, alpha, &error_result, Policy())
-     && detail::check_probability(function, beta, &error_result, Policy()))
+   if(!(detail::check_probability(function, alpha, &error_result, Policy())
+     && detail::check_probability(function, beta, &error_result, Policy())))
    { // Either probability is outside 0 to 1.
       return error_result;
    }

--- a/include/boost/math/distributions/extreme_value.hpp
+++ b/include/boost/math/distributions/extreme_value.hpp
@@ -173,8 +173,6 @@ BOOST_MATH_GPU_ENABLED inline RealType cdf(const extreme_value_distribution<Real
       return result;
    if(0 == detail::check_finite(function, a, &result, Policy()))
       return result;
-   if(0 == detail::check_finite(function, a, &result, Policy()))
-      return result;
    if(0 == detail::check_x("boost::math::cdf(const extreme_value_distribution<%1%>&, %1%)", x, &result, Policy()))
       return result;
 
@@ -196,8 +194,6 @@ BOOST_MATH_GPU_ENABLED inline RealType logcdf(const extreme_value_distribution<R
    RealType b = dist.scale();
    RealType result = 0;
    if(0 == detail::verify_scale_b(function, b, &result, Policy()))
-      return result;
-   if(0 == detail::check_finite(function, a, &result, Policy()))
       return result;
    if(0 == detail::check_finite(function, a, &result, Policy()))
       return result;

--- a/include/boost/math/distributions/find_location.hpp
+++ b/include/boost/math/distributions/find_location.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/math/distributions/fwd.hpp> // for all distribution signatures.
 #include <boost/math/distributions/complement.hpp>
+#include <boost/math/distributions/detail/common_error_handling.hpp>
 #include <boost/math/policies/policy.hpp>
 #include <boost/math/tools/traits.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
@@ -51,10 +52,10 @@ namespace boost
        return policies::raise_domain_error<typename Dist::value_type>(
            function, "z parameter was %1%, but must be finite!", z, pol);
       }
-      if(!(boost::math::isfinite)(scale))
+      typename Dist::value_type result;
+      if(!(boost::math::detail::check_scale)(function, scale, &result, pol))
       {
-       return policies::raise_domain_error<typename Dist::value_type>(
-           function, "scale parameter was %1%, but must be finite!", scale, pol);
+       return result;
       }
         
       //cout << "z " << z << ", p " << p << ",  quantile(Dist(), p) "
@@ -94,11 +95,11 @@ namespace boost
        return policies::raise_domain_error<typename Dist::value_type>(
            function, "z parameter was %1%, but must be finite!", z, policies::policy<>());
       }
+      typename Dist::value_type result;
       typename Dist::value_type scale = c.param2;
-      if(!(boost::math::isfinite)(scale))
+      if(!(boost::math::detail::check_scale)(function, scale, &result, policies::policy<>()))
       {
-       return policies::raise_domain_error<typename Dist::value_type>(
-           function, "scale parameter was %1%, but must be finite!", scale, policies::policy<>());
+       return result;
       }
        // cout << "z " << c.dist << ", quantile (Dist(), " << c.param1 << ") * scale " << c.param2 << endl;
        return z - quantile(Dist(), p) * scale;
@@ -123,11 +124,11 @@ namespace boost
        return policies::raise_domain_error<typename Dist::value_type>(
            function, "z parameter was %1%, but must be finite!", z, c.param3);
       }
+      typename Dist::value_type result;
       typename Dist::value_type scale = c.param2;
-      if(!(boost::math::isfinite)(scale))
+      if(!(boost::math::detail::check_scale)(function, scale, &result, c.param3))
       {
-       return policies::raise_domain_error<typename Dist::value_type>(
-           function, "scale parameter was %1%, but must be finite!", scale, c.param3);
+       return result;
       }
        // cout << "z " << c.dist << ", quantile (Dist(), " << c.param1 << ") * scale " << c.param2 << endl;
        return z - quantile(Dist(), p) * scale;

--- a/test/test_arcsine.cpp
+++ b/test/test_arcsine.cpp
@@ -105,6 +105,7 @@ void test_ignore_policy(RealType)
         //std::cout << "pdf(ignore_error_arcsine(-1, +1), std::numeric_limits<RealType>::infinity()) = " << pdf(ignore_error_arcsine(-1, +1), std::numeric_limits<RealType>::infinity()) << std::endl;
         //  Outputs:  pdf(ignore_error_arcsine(-1, +1), std::numeric_limits<RealType>::infinity()) = 1.#QNAN
       }
+      // PDF
       BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_arcsine(0, 1), std::numeric_limits<RealType>::infinity()))); // x == infinity
       BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_arcsine(-1, 1), std::numeric_limits<RealType>::infinity()))); // x == infinity
       BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_arcsine(0, 1), static_cast <RealType>(-2))));  // x < xmin
@@ -120,9 +121,31 @@ void test_ignore_policy(RealType)
       BOOST_CHECK((boost::math::isnan)(logpdf(ignore_error_arcsine(0, 1), static_cast <RealType>(+2))));  // x > x_max
       BOOST_CHECK((boost::math::isnan)(logpdf(ignore_error_arcsine(-1, 1), static_cast <RealType>(+2)))); // x > x_max
 
+      // CDF
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_arcsine(0, 1), std::numeric_limits<RealType>::infinity()))); // x == infinity
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_arcsine(-1, 1), std::numeric_limits<RealType>::infinity()))); // x == infinity
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_arcsine(0, 1), static_cast <RealType>(-2))));  // x < xmin
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_arcsine(-1, 1), static_cast <RealType>(-2))));  // x < xmin
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_arcsine(0, 1), static_cast <RealType>(+2))));  // x > x_max
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_arcsine(-1, 1), static_cast <RealType>(+2)))); // x > x_max
+      BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_arcsine(0, 1), std::numeric_limits<RealType>::infinity())))); // x == infinity
+      BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_arcsine(0, 1), static_cast <RealType>(-2)))));  // x < xmin
+
+      // Quantile
+      BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_arcsine(0, 1), std::numeric_limits<RealType>::infinity()))); // p == infinity
+      BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_arcsine(0, 1), static_cast<RealType>(-1)))); // p < 0
+      BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_arcsine(0, 1), static_cast<RealType>(2)))); // p > 1
+      BOOST_CHECK((boost::math::isnan)(quantile(complement(ignore_error_arcsine(0, 1), std::numeric_limits<RealType>::infinity())))); // q == infinity
+      BOOST_CHECK((boost::math::isnan)(quantile(complement(ignore_error_arcsine(0, 1), static_cast<RealType>(-1))))); // q < 0
+      BOOST_CHECK((boost::math::isnan)(quantile(complement(ignore_error_arcsine(0, 1), static_cast<RealType>(2))))); // q > 1
+
       // Mean
       BOOST_CHECK((boost::math::isnan)(mean(ignore_error_arcsine(-nan, 0))));
       BOOST_CHECK((boost::math::isnan)(mean(ignore_error_arcsine(+nan, 0))));
+      
+      // Median
+      BOOST_CHECK((boost::math::isnan)(median(ignore_error_arcsine(-nan, 0))));
+      BOOST_CHECK((boost::math::isnan)(median(ignore_error_arcsine(+nan, 0))));
 
       if (std::numeric_limits<RealType>::has_infinity)
       {
@@ -276,7 +299,8 @@ void test_spots(RealType)
     BOOST_CHECK_EQUAL(variance(arcsine_01), 0.125); // 1/8 = 0.125
     BOOST_CHECK_CLOSE_FRACTION(standard_deviation(arcsine_01), one_div_root_two<double>() / 2, tolerance); // 1/ sqrt(s) = 0.35355339059327379
     BOOST_CHECK_EQUAL(skewness(arcsine_01), 0); //
-    BOOST_CHECK_EQUAL(kurtosis_excess(arcsine_01), -1.5); // 3/2
+    BOOST_CHECK_EQUAL(kurtosis_excess(arcsine_01), -1.5); // -3/2
+    BOOST_CHECK_EQUAL(kurtosis(arcsine_01), 1.5); // 3/2
     BOOST_CHECK_EQUAL(support(arcsine_01).first, 0); //
     BOOST_CHECK_EQUAL(range(arcsine_01).first, 0); //
     BOOST_CHECK_THROW(mode(arcsine_01), std::domain_error); //  Two modes at x_min and x_max, so throw instead.
@@ -374,8 +398,8 @@ void test_spots(RealType)
 
     BOOST_CHECK_EQUAL(variance(as_m11), 0.5); // 1 - (-1) = 2 ^ 2 = 4 /8 = 0.5
     BOOST_CHECK_EQUAL(skewness(as_m11), 0); //
-    BOOST_CHECK_EQUAL(kurtosis_excess(as_m11), -1.5); // 3/2
-
+    BOOST_CHECK_EQUAL(kurtosis_excess(as_m11), -1.5); // -3/2
+    BOOST_CHECK_EQUAL(kurtosis(as_m11), 1.5); // 3/2
 
     BOOST_CHECK_CLOSE_FRACTION(pdf(as_m11, 0.05), static_cast<RealType>(0.31870852113797122803869876869296281629727218095644L), tolerance);
     BOOST_CHECK_CLOSE_FRACTION(pdf(as_m11, 0.5), static_cast<RealType>(0.36755259694786136634088433220864629426492432024443L), tolerance);
@@ -428,7 +452,8 @@ void test_spots(RealType)
     BOOST_CHECK_EQUAL(median(as_m2m1), -1.5); // 1 / (1 + 1) = 1/2 exactly.
     BOOST_CHECK_EQUAL(variance(as_m2m1), 0.125);
     BOOST_CHECK_EQUAL(skewness(as_m2m1), 0); //
-    BOOST_CHECK_EQUAL(kurtosis_excess(as_m2m1), -1.5); // 3/2
+    BOOST_CHECK_EQUAL(kurtosis(as_m2m1), 1.5); // 3/2
+    BOOST_CHECK_EQUAL(kurtosis_excess(as_m2m1), -1.5); // -3/2
 
     BOOST_CHECK_CLOSE_FRACTION(pdf(as_m2m1, -1.95), static_cast<RealType>(1.4605059227421865250256574657088244053723856445614L), 4 * tolerance);
     BOOST_CHECK_CLOSE_FRACTION(pdf(as_m2m1, -1.5), static_cast<RealType>(0.63661977236758134307553505349005744813783858296183L), tolerance);
@@ -615,7 +640,8 @@ void test_spots(RealType)
     BOOST_CHECK_EQUAL(variance(as), 0.125); //0.125
     BOOST_CHECK_CLOSE_FRACTION(standard_deviation(as), one_div_root_two<double>() / 2, std::numeric_limits<double>::epsilon()); // 0.353553
     BOOST_CHECK_EQUAL(skewness(as), 0); //
-    BOOST_CHECK_EQUAL(kurtosis_excess(as), -1.5); // 3/2
+    BOOST_CHECK_EQUAL(kurtosis(as), 1.5); // 3/2
+    BOOST_CHECK_EQUAL(kurtosis_excess(as), -1.5); // -3/2
     BOOST_CHECK_EQUAL(support(as).first, 0); //
     BOOST_CHECK_EQUAL(range(as).first, 0); //
     BOOST_CHECK_THROW(mode(as), std::domain_error); //  Two modes at x_min and x_max, so throw instead.

--- a/test/test_bernoulli.cpp
+++ b/test/test_bernoulli.cpp
@@ -114,6 +114,11 @@ void test_spots(RealType)
     bernoulli_distribution<RealType>(static_cast<RealType>(0.4L)), static_cast<RealType>(0)),
       static_cast<RealType>(0.6L), tolerance); // Expect  1- p.
 
+  BOOST_CHECK_CLOSE_FRACTION(
+    pdf( // OK k (or n)
+    bernoulli_distribution<RealType>(static_cast<RealType>(0.4L)), static_cast<RealType>(1)),
+      static_cast<RealType>(0.4L), tolerance); // Expect  p.
+
   BOOST_CHECK_EQUAL(
        mean(bernoulli_distribution<RealType>(static_cast<RealType>(0.5L))), static_cast<RealType>(0.5L));
 
@@ -280,6 +285,46 @@ void test_spots(RealType)
      BOOST_MATH_CHECK_THROW(quantile(complement(w, +inf)), std::domain_error); // p = + inf
    } // has_infinity
    #endif
+   
+   using boost::math::policies::policy;
+   typedef policy<
+      boost::math::policies::domain_error<boost::math::policies::ignore_error>,
+      boost::math::policies::overflow_error<boost::math::policies::ignore_error>,
+      boost::math::policies::underflow_error<boost::math::policies::ignore_error>,
+      boost::math::policies::denorm_error<boost::math::policies::ignore_error>,
+      boost::math::policies::pole_error<boost::math::policies::ignore_error>,
+      boost::math::policies::evaluation_error<boost::math::policies::ignore_error>
+    > ignore_all_policy;
+
+   typedef bernoulli_distribution<RealType, ignore_all_policy> ignore_error_bernoulli;
+
+   if (std::numeric_limits<RealType>::has_quiet_NaN)
+    {
+      // PDF
+      BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_bernoulli(0.5), std::numeric_limits<RealType>::infinity()))); // k == infinity
+      BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_bernoulli(0.5), 2))); // k > 1
+      BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_bernoulli(0.5), static_cast<RealType>(0.5)))); // k != 0, 1
+      BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_bernoulli(0.5), static_cast<RealType>(-0.5)))); // k != 0, 1
+
+      // CDF
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_bernoulli(0.5), std::numeric_limits<RealType>::infinity()))); // k == infinity
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_bernoulli(0.5), 2))); // k > 1
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_bernoulli(0.5), static_cast<RealType>(0.5)))); // k != 0, 1
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_bernoulli(0.5), static_cast<RealType>(-0.5)))); // k != 0, 1
+      BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_bernoulli(0.5), std::numeric_limits<RealType>::infinity())))); // k == infinity
+      BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_bernoulli(0.5), 2)))); // k > 1
+      BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_bernoulli(0.5), static_cast<RealType>(0.5))))); // k != 0, 1
+      BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_bernoulli(0.5), static_cast<RealType>(-0.5))))); // k != 0, 1
+
+      // // Quantile
+      BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_bernoulli(0.5), std::numeric_limits<RealType>::infinity()))); // p == infinity
+      BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_bernoulli(0.5), static_cast<RealType>(-1)))); // p < 0
+      BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_bernoulli(0.5), static_cast<RealType>(2)))); // p > 1
+      BOOST_CHECK((boost::math::isnan)(quantile(complement(ignore_error_bernoulli(0.5), std::numeric_limits<RealType>::infinity())))); // q == infinity
+      BOOST_CHECK((boost::math::isnan)(quantile(complement(ignore_error_bernoulli(0.5), static_cast<RealType>(-1))))); // q < 0
+      BOOST_CHECK((boost::math::isnan)(quantile(complement(ignore_error_bernoulli(0.5), static_cast<RealType>(2))))); // q > 1
+
+    } // has_quiet_NaN
 } // template <class RealType>void test_spots(RealType)
 
 BOOST_AUTO_TEST_CASE( test_main )

--- a/test/test_beta_dist.cpp
+++ b/test/test_beta_dist.cpp
@@ -66,6 +66,18 @@ using std::numeric_limits;
 #endif
 
 template <class RealType>
+void test_find_alpha_beta(RealType mean, RealType variance){
+   BOOST_MATH_CHECK_THROW(beta_distribution<RealType>::find_alpha(mean, variance), std::domain_error);
+   BOOST_MATH_CHECK_THROW(beta_distribution<RealType>::find_beta(mean, variance), std::domain_error);
+}
+
+template <class RealType>
+void test_find_alpha_beta(RealType param, RealType x, RealType p){
+   BOOST_MATH_CHECK_THROW(beta_distribution<RealType>::find_alpha(param, x, p), std::domain_error);
+   BOOST_MATH_CHECK_THROW(beta_distribution<RealType>::find_beta(param, x, p), std::domain_error);
+}
+
+template <class RealType>
 void test_spot(
      RealType a,    // alpha a
      RealType b,    // beta b
@@ -175,7 +187,9 @@ void test_spots(RealType)
   using  ::boost::math::pdf;
 
   // Tests that should throw:
-  BOOST_MATH_CHECK_THROW(mode(beta_distribution<RealType>(static_cast<RealType>(1), static_cast<RealType>(1))), std::domain_error);
+  BOOST_MATH_CHECK_THROW(mode(beta_distribution<RealType>(static_cast<RealType>(1), static_cast<RealType>(1))), std::domain_error); // alpha = beta = 1
+  BOOST_MATH_CHECK_THROW(mode(beta_distribution<RealType>(static_cast<RealType>(2), static_cast<RealType>(1))), std::domain_error); // beta = 1
+  BOOST_MATH_CHECK_THROW(mode(beta_distribution<RealType>(static_cast<RealType>(1), static_cast<RealType>(2))), std::domain_error); // alpha = 1
   // mode is undefined, and throws domain_error!
 
  // BOOST_MATH_CHECK_THROW(median(beta_distribution<RealType>(static_cast<RealType>(1), static_cast<RealType>(1))), std::domain_error);
@@ -497,7 +511,19 @@ void test_spots(RealType)
    BOOST_MATH_CHECK_THROW(quantile(dist, -1), std::domain_error);
    BOOST_MATH_CHECK_THROW(quantile(complement(dist, -1)), std::domain_error);
 
- // No longer allow any parameter to be NaN or inf, so all these tests should throw.
+   BOOST_MATH_CHECK_THROW(pdf(beta_distribution<RealType>(static_cast<RealType>(0.5), static_cast<RealType>(1.5)), static_cast<RealType>(0)), std::overflow_error); // alpha < 1, x = 0
+   BOOST_MATH_CHECK_THROW(pdf(beta_distribution<RealType>(static_cast<RealType>(1.5), static_cast<RealType>(0.5)), static_cast<RealType>(1)), std::overflow_error); // beta < 1, x = 1
+
+   // There aren't any upper bounds on the mean/variance. Should we add these? 
+   test_find_alpha_beta(static_cast<RealType>(-1), static_cast<RealType>(1)); // mean < 0
+   test_find_alpha_beta(static_cast<RealType>(-1), static_cast<RealType>(-1)); // var < 0
+
+   test_find_alpha_beta(static_cast<RealType>(1), static_cast<RealType>(0.5), static_cast<RealType>(-0.5)); // p < 0
+   test_find_alpha_beta(static_cast<RealType>(1), static_cast<RealType>(0.5), static_cast<RealType>(1.5)); // p > 0
+   test_find_alpha_beta(static_cast<RealType>(1), static_cast<RealType>(1.5), static_cast<RealType>(0.5)); // x > 0
+   test_find_alpha_beta(static_cast<RealType>(1), static_cast<RealType>(-0.5), static_cast<RealType>(0.5)); // x < 0
+
+   // No longer allow any parameter to be NaN or inf, so all these tests should throw.
    if (std::numeric_limits<RealType>::has_quiet_NaN)
    { 
     // Attempt to construct from non-finite should throw.
@@ -545,6 +571,37 @@ void test_spots(RealType)
      BOOST_MATH_CHECK_THROW(cdf(complement(w, +inf)), std::domain_error); // x = + inf
      BOOST_MATH_CHECK_THROW(quantile(w, +inf), std::domain_error); // p = + inf
      BOOST_MATH_CHECK_THROW(quantile(complement(w, +inf)), std::domain_error); // p = + inf
+
+     test_find_alpha_beta(static_cast<RealType>(1), static_cast<RealType>(0.5), inf); // p = inf
+     test_find_alpha_beta(inf, static_cast<RealType>(0.5)); // mean = inf
+     test_find_alpha_beta(static_cast<RealType>(0.5), inf); // var = inf
+     test_find_alpha_beta(static_cast<RealType>(1), inf, static_cast<RealType>(0.5)); // x = inf
+
+     // Check isnan policies
+     using boost::math::policies::policy;
+    
+     typedef policy<
+      boost::math::policies::domain_error<boost::math::policies::ignore_error>,
+      boost::math::policies::overflow_error<boost::math::policies::ignore_error>,
+      boost::math::policies::underflow_error<boost::math::policies::ignore_error>,
+      boost::math::policies::denorm_error<boost::math::policies::ignore_error>,
+      boost::math::policies::pole_error<boost::math::policies::ignore_error>,
+      boost::math::policies::evaluation_error<boost::math::policies::ignore_error>
+     > ignore_all_policy;
+
+     typedef beta_distribution<RealType, ignore_all_policy> ignore_error_beta;
+
+     BOOST_CHECK((boost::math::isnan)(ignore_error_beta::find_alpha(inf, static_cast<RealType>(0.5)))); // mean = inf
+     BOOST_CHECK((boost::math::isnan)(ignore_error_beta::find_beta(inf, static_cast<RealType>(0.5)))); // mean = inf
+     BOOST_CHECK((boost::math::isnan)(ignore_error_beta::find_alpha(inf, static_cast<RealType>(0.5), static_cast<RealType>(0.5)))); // beta = inf
+     BOOST_CHECK((boost::math::isnan)(ignore_error_beta::find_beta(inf, static_cast<RealType>(0.5), static_cast<RealType>(0.5)))); // alpha = inf
+     BOOST_CHECK((boost::math::isnan)(mode(ignore_error_beta(static_cast<RealType>(2), static_cast<RealType>(1))))); // beta = 1
+     BOOST_CHECK((boost::math::isnan)(mode(ignore_error_beta(static_cast<RealType>(1), static_cast<RealType>(2))))); // alpha = 1
+     BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_beta(static_cast<RealType>(1), static_cast<RealType>(1)), 2))); // x > 1
+     BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_beta(static_cast<RealType>(1), static_cast<RealType>(1)), 2))); // x > 1
+     BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_beta(static_cast<RealType>(1), static_cast<RealType>(1)), 2)))); // x > 1
+     BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_beta(static_cast<RealType>(1), static_cast<RealType>(1)), 2))); // p > 1
+     BOOST_CHECK((boost::math::isnan)(quantile(complement(ignore_error_beta(static_cast<RealType>(1), static_cast<RealType>(1)), 2)))); // p > 1
    } // has_infinity
 
    // Error handling checks:
@@ -600,6 +657,8 @@ BOOST_AUTO_TEST_CASE( test_main )
    BOOST_CHECK_CLOSE_FRACTION(cdf(mybeta11, 0.5), 0.5, 2 * std::numeric_limits<double>::epsilon());
    BOOST_CHECK_CLOSE_FRACTION(cdf(mybeta11, 0.9), 0.9, 2 * std::numeric_limits<double>::epsilon());
    BOOST_CHECK_EQUAL(cdf(mybeta11, 1), 1.); // Exact unity expected.
+   BOOST_CHECK_EQUAL(cdf(complement(mybeta11, 1)), 0.0); // Exact 0 expected.
+   BOOST_CHECK_EQUAL(cdf(complement(mybeta11, 0)), 1.0); // Exact unity expected.
 
    double tol = std::numeric_limits<double>::epsilon() * 10;
    BOOST_CHECK_EQUAL(pdf(mybeta22, 1), 0); // is dome shape.
@@ -627,6 +686,11 @@ BOOST_AUTO_TEST_CASE( test_main )
    // quantile.
    BOOST_CHECK_CLOSE_FRACTION(quantile(mybeta22, 0.028), 0.1, tol);
    BOOST_CHECK_CLOSE_FRACTION(quantile(complement(mybeta22, 1 - 0.028)), 0.1, tol);
+   BOOST_CHECK_EQUAL(quantile(mybeta22, 0), 0.);
+   BOOST_CHECK_EQUAL(quantile(mybeta22, 1), 1.);
+   BOOST_CHECK_EQUAL(quantile(complement(mybeta22, 0)), 1.);
+   BOOST_CHECK_EQUAL(quantile(complement(mybeta22, 1)), 0.);
+
    BOOST_CHECK_EQUAL(kurtosis(mybeta11), 3+ kurtosis_excess(mybeta11)); // Check kurtosis_excess = kurtosis - 3;
    BOOST_CHECK_CLOSE_FRACTION(variance(mybeta22), 0.05, tol);
    BOOST_CHECK_CLOSE_FRACTION(mean(mybeta22), 0.5, tol);

--- a/test/test_binomial.cpp
+++ b/test/test_binomial.cpp
@@ -599,7 +599,74 @@ void test_spots(RealType T)
           binomial_distribution<RealType>(static_cast<RealType>(8), static_cast<RealType>(1)),
           static_cast<RealType>(7)), static_cast<RealType>(0)
        );
+    BOOST_CHECK_EQUAL(
+       cdf(
+          complement(binomial_distribution<RealType>(static_cast<RealType>(8), static_cast<RealType>(0)),
+          static_cast<RealType>(7))), static_cast<RealType>(0)
+       );
+    BOOST_CHECK_EQUAL(
+       cdf(
+          complement(binomial_distribution<RealType>(static_cast<RealType>(8), static_cast<RealType>(1)),
+          static_cast<RealType>(7))), static_cast<RealType>(1)
+       );
 
+     // Check Error handling and edge cases
+     BOOST_CHECK_EQUAL(binomial_distribution<RealType>::find_lower_bound_on_p(static_cast<RealType>(5),
+                                                                              static_cast<RealType>(0),
+                                                                              static_cast<RealType>(0.5)),
+                       static_cast<RealType>(0)); // success = 0 
+     BOOST_CHECK_THROW(binomial_distribution<RealType>::find_lower_bound_on_p(static_cast<RealType>(5),
+                                                                              static_cast<RealType>(2),
+                                                                              static_cast<RealType>(-0.5)),
+                       std::domain_error); // probability < 0 
+     BOOST_CHECK_THROW(binomial_distribution<RealType>::find_lower_bound_on_p(static_cast<RealType>(5),
+                                                                              static_cast<RealType>(2),
+                                                                              static_cast<RealType>(1.5)),
+                       std::domain_error); // probability > 1
+     BOOST_CHECK_EQUAL(binomial_distribution<RealType>::find_upper_bound_on_p(static_cast<RealType>(5),
+                                                                              static_cast<RealType>(5),
+                                                                              static_cast<RealType>(0.5)),
+                       static_cast<RealType>(1)); // trials = successes 
+     BOOST_CHECK_THROW(binomial_distribution<RealType>::find_upper_bound_on_p(static_cast<RealType>(5),
+                                                                              static_cast<RealType>(2),
+                                                                              static_cast<RealType>(-0.5)),
+                       std::domain_error); // probability < 0 
+     BOOST_CHECK_THROW(binomial_distribution<RealType>::find_upper_bound_on_p(static_cast<RealType>(5),
+                                                                              static_cast<RealType>(2),
+                                                                              static_cast<RealType>(1.5)),
+                       std::domain_error); // probability > 1
+     BOOST_CHECK_THROW(binomial_distribution<RealType>::find_minimum_number_of_trials(static_cast<RealType>(10),
+                                                                                      static_cast<RealType>(1.5),
+                                                                                      static_cast<RealType>(0.05)),
+                       std::domain_error); // probability > 1
+     BOOST_CHECK_THROW(binomial_distribution<RealType>::find_minimum_number_of_trials(static_cast<RealType>(10),
+                                                                                      static_cast<RealType>(-1),
+                                                                                      static_cast<RealType>(0.05)),
+                       std::domain_error); // probability < 0
+     BOOST_CHECK_THROW(binomial_distribution<RealType>::find_minimum_number_of_trials(static_cast<RealType>(10),
+                                                                                      static_cast<RealType>(0.5),
+                                                                                      static_cast<RealType>(-0.05)),
+                       std::domain_error); // alpha < 0
+     BOOST_CHECK_THROW(binomial_distribution<RealType>::find_minimum_number_of_trials(static_cast<RealType>(10),
+                                                                                      static_cast<RealType>(0.5),
+                                                                                      static_cast<RealType>(1.314)),
+                       std::domain_error); // alpha > 1
+     BOOST_CHECK_THROW(binomial_distribution<RealType>::find_maximum_number_of_trials(static_cast<RealType>(10),
+                                                                                      static_cast<RealType>(1.5),
+                                                                                      static_cast<RealType>(0.05)),
+                       std::domain_error); // probability > 1
+     BOOST_CHECK_THROW(binomial_distribution<RealType>::find_maximum_number_of_trials(static_cast<RealType>(10),
+                                                                                      static_cast<RealType>(-1),
+                                                                                      static_cast<RealType>(0.05)),
+                       std::domain_error); // probability < 0
+     BOOST_CHECK_THROW(binomial_distribution<RealType>::find_maximum_number_of_trials(static_cast<RealType>(10),
+                                                                                      static_cast<RealType>(0.5),
+                                                                                      static_cast<RealType>(-0.05)),
+                       std::domain_error); // alpha < 0
+     BOOST_CHECK_THROW(binomial_distribution<RealType>::find_maximum_number_of_trials(static_cast<RealType>(10),
+                                                                                      static_cast<RealType>(0.5),
+                                                                                      static_cast<RealType>(1.5)),
+                       std::domain_error); // alpha > 1
 #endif
 
   {

--- a/test/test_binomial.cpp
+++ b/test/test_binomial.cpp
@@ -667,6 +667,43 @@ void test_spots(RealType T)
                                                                                       static_cast<RealType>(0.5),
                                                                                       static_cast<RealType>(1.5)),
                        std::domain_error); // alpha > 1
+
+     if (std::numeric_limits<RealType>::has_infinity)
+     {
+     // Check isnan policies
+     using boost::math::policies::policy;
+    
+     typedef policy<
+      boost::math::policies::domain_error<boost::math::policies::ignore_error>,
+      boost::math::policies::overflow_error<boost::math::policies::ignore_error>,
+      boost::math::policies::underflow_error<boost::math::policies::ignore_error>,
+      boost::math::policies::denorm_error<boost::math::policies::ignore_error>,
+      boost::math::policies::pole_error<boost::math::policies::ignore_error>,
+      boost::math::policies::evaluation_error<boost::math::policies::ignore_error>
+     > ignore_all_policy;
+
+     typedef binomial_distribution<RealType, ignore_all_policy> ignore_error_binomial;
+
+     BOOST_CHECK((boost::math::isnan)(ignore_error_binomial::find_lower_bound_on_p(static_cast<RealType>(5),
+                                                                                             static_cast<RealType>(2),
+                                                                                             static_cast<RealType>(-0.5)))); // probability < 0
+     BOOST_CHECK((boost::math::isnan)(ignore_error_binomial::find_upper_bound_on_p(static_cast<RealType>(5),
+                                                                                             static_cast<RealType>(2),
+                                                                                             static_cast<RealType>(-0.5)))); // probability < 0
+     BOOST_CHECK((boost::math::isnan)(ignore_error_binomial::find_minimum_number_of_trials(static_cast<RealType>(10),
+                                                                                                     static_cast<RealType>(-1),
+                                                                                                     static_cast<RealType>(0.05)))); // probability < 0
+     BOOST_CHECK((boost::math::isnan)(ignore_error_binomial::find_maximum_number_of_trials(static_cast<RealType>(10),
+                                                                                                     static_cast<RealType>(-1),
+                                                                                                     static_cast<RealType>(0.05)))); // probability < 0
+     
+     BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_binomial(static_cast<RealType>(-8), static_cast<RealType>(0.25)), static_cast<RealType>(8)))); 
+     BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_binomial(static_cast<RealType>(8), static_cast<RealType>(-0.25)), static_cast<RealType>(8))));                                                                                                                                                                                                         
+     BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_binomial(static_cast<RealType>(8), static_cast<RealType>(0.25)), static_cast<RealType>(9))));
+     BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_binomial(static_cast<RealType>(8), static_cast<RealType>(0.25)), static_cast<RealType>(9))));
+     BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_binomial(static_cast<RealType>(8), static_cast<RealType>(0.25)), static_cast<RealType>(9)))));
+     BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_binomial(static_cast<RealType>(8), static_cast<RealType>(0.25)), static_cast<RealType>(-1))));
+   }
 #endif
 
   {

--- a/test/test_cauchy.cpp
+++ b/test/test_cauchy.cpp
@@ -744,7 +744,61 @@ void test_spots(RealType T)
 
    check_out_of_range<boost::math::cauchy_distribution<RealType> >(0, 1); // (All) valid constructor parameter values.
 
+   if (std::numeric_limits<RealType>::has_infinity)
+   {
+      BOOST_CHECK_EQUAL(
+         boost::math::pdf(
+            cauchy_distribution<RealType>(-2, 0.25),
+            std::numeric_limits<RealType>::infinity()), // x
+            static_cast<RealType>(0) // probability
+         );
+      BOOST_CHECK_EQUAL(
+         boost::math::cdf(
+            cauchy_distribution<RealType>(-2, 0.25),
+            std::numeric_limits<RealType>::infinity()), // x
+            static_cast<RealType>(1) // probability
+         );
+      BOOST_CHECK_EQUAL(
+         boost::math::cdf(
+            cauchy_distribution<RealType>(-2, 0.25),
+            -std::numeric_limits<RealType>::infinity()), // x
+            static_cast<RealType>(0) // probability
+         );
+      BOOST_CHECK_EQUAL(
+         boost::math::quantile(
+            cauchy_distribution<RealType>(-2, 0.25),
+            static_cast<RealType>(0.5)), // p
+            static_cast<RealType>(-2) // location
+         );
 
+      using boost::math::policies::policy;
+
+      typedef policy<
+         boost::math::policies::domain_error<boost::math::policies::ignore_error>,
+         boost::math::policies::overflow_error<boost::math::policies::ignore_error>,
+         boost::math::policies::underflow_error<boost::math::policies::ignore_error>,
+         boost::math::policies::denorm_error<boost::math::policies::ignore_error>,
+         boost::math::policies::pole_error<boost::math::policies::ignore_error>,
+         boost::math::policies::evaluation_error<boost::math::policies::ignore_error>
+      > ignore_all_policy;
+
+      typedef boost::math::cauchy_distribution<RealType, ignore_all_policy> ignore_error_cauchy;
+      
+      // PDF
+      BOOST_CHECK((boost::math::isnan)(boost::math::pdf(ignore_error_cauchy(static_cast<RealType>(0), static_cast<RealType>(-1)), static_cast<RealType>(0))));
+      BOOST_CHECK((boost::math::isnan)(boost::math::pdf(ignore_error_cauchy(std::numeric_limits<RealType>::infinity(), static_cast<RealType>(1)), static_cast<RealType>(0))));
+      BOOST_CHECK((boost::math::isnan)(boost::math::pdf(ignore_error_cauchy(static_cast<RealType>(0), static_cast<RealType>(1)), std::numeric_limits<RealType>::quiet_NaN())));
+   
+      // CDF
+      BOOST_CHECK((boost::math::isnan)(boost::math::cdf(ignore_error_cauchy(static_cast<RealType>(0), static_cast<RealType>(-1)), static_cast<RealType>(0))));
+      BOOST_CHECK((boost::math::isnan)(boost::math::cdf(ignore_error_cauchy(std::numeric_limits<RealType>::infinity(), static_cast<RealType>(1)), static_cast<RealType>(0))));
+      BOOST_CHECK((boost::math::isnan)(boost::math::cdf(ignore_error_cauchy(static_cast<RealType>(0), static_cast<RealType>(1)), std::numeric_limits<RealType>::quiet_NaN())));
+
+      // Quantile 
+      BOOST_CHECK((boost::math::isnan)(boost::math::quantile(ignore_error_cauchy(static_cast<RealType>(0), static_cast<RealType>(-1)), static_cast<RealType>(0.25))));
+      BOOST_CHECK((boost::math::isnan)(boost::math::quantile(ignore_error_cauchy(std::numeric_limits<RealType>::infinity(), static_cast<RealType>(1)), static_cast<RealType>(0.25))));
+      BOOST_CHECK((boost::math::isnan)(boost::math::quantile(ignore_error_cauchy(static_cast<RealType>(0), static_cast<RealType>(1)), static_cast<RealType>(-0.25))));
+   }
 
 } // template <class RealType>void test_spots(RealType)
 

--- a/test/test_chi_squared.cpp
+++ b/test/test_chi_squared.cpp
@@ -546,6 +546,9 @@ void test_spots(RealType T)
           chi_squared_distribution<RealType>(static_cast<RealType>(8)),
           static_cast<RealType>(1.1))), std::domain_error
        );
+    BOOST_MATH_CHECK_THROW(
+       mode(chi_squared_distribution<RealType>(static_cast<RealType>(1))), std::domain_error
+       );
 
     // This first test value is taken from an example here:
     // http://www.itl.nist.gov/div898/handbook/prc/section2/prc232.htm
@@ -566,6 +569,32 @@ void test_spots(RealType T)
 
     check_out_of_range<boost::math::chi_squared_distribution<RealType> >(1); // (All) valid constructor parameter values.
 
+    // NaN handling
+    if (std::numeric_limits<RealType>::has_infinity)
+    {
+      using boost::math::policies::policy;
+
+      typedef policy<
+         boost::math::policies::domain_error<boost::math::policies::ignore_error>,
+         boost::math::policies::overflow_error<boost::math::policies::ignore_error>,
+         boost::math::policies::underflow_error<boost::math::policies::ignore_error>,
+         boost::math::policies::denorm_error<boost::math::policies::ignore_error>,
+         boost::math::policies::pole_error<boost::math::policies::ignore_error>,
+         boost::math::policies::evaluation_error<boost::math::policies::ignore_error>
+      > ignore_all_policy;
+
+      typedef boost::math::chi_squared_distribution<RealType, ignore_all_policy> ignore_error_chi_squared;
+
+      BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_chi_squared(static_cast<RealType>(-1)), static_cast<RealType>(1))));
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_chi_squared(static_cast<RealType>(-1)), static_cast<RealType>(1))));
+      BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_chi_squared(static_cast<RealType>(-1)), static_cast<RealType>(1)))));
+      BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_chi_squared(static_cast<RealType>(-1)), static_cast<RealType>(0.5))));
+      BOOST_CHECK((boost::math::isnan)(quantile(complement(ignore_error_chi_squared(static_cast<RealType>(-1)), static_cast<RealType>(0.5)))));
+      BOOST_CHECK((boost::math::isnan)(mode(ignore_error_chi_squared(static_cast<RealType>(1)))));
+      BOOST_CHECK((boost::math::isnan)(ignore_error_chi_squared::find_degrees_of_freedom(10, -1, 0.01f, 100)));
+      BOOST_CHECK((boost::math::isnan)(ignore_error_chi_squared::find_degrees_of_freedom(10, 0.05f, -1, 100)));
+
+   }
 } // template <class RealType>void test_spots(RealType)
 
 BOOST_AUTO_TEST_CASE( test_main )

--- a/test/test_exponential_dist.cpp
+++ b/test/test_exponential_dist.cpp
@@ -362,6 +362,48 @@ void test_spots(RealType T)
       BOOST_CHECK_EQUAL(pdf(exponential_distribution<RealType>(2), inf), 0);
       BOOST_CHECK_EQUAL(cdf(exponential_distribution<RealType>(2), inf), 1);
       BOOST_CHECK_EQUAL(cdf(complement(exponential_distribution<RealType>(2), inf)), 0);
+
+      // Test NaN policies
+      using boost::math::policies::policy;
+
+      typedef policy<
+         boost::math::policies::domain_error<boost::math::policies::ignore_error>,
+         boost::math::policies::overflow_error<boost::math::policies::ignore_error>,
+         boost::math::policies::underflow_error<boost::math::policies::ignore_error>,
+         boost::math::policies::denorm_error<boost::math::policies::ignore_error>,
+         boost::math::policies::pole_error<boost::math::policies::ignore_error>,
+         boost::math::policies::evaluation_error<boost::math::policies::ignore_error>
+      > ignore_all_policy;
+
+      typedef boost::math::exponential_distribution<RealType, ignore_all_policy> ignore_error_exponential;
+
+      // PDF
+      BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_exponential(static_cast<RealType>(-1)), static_cast<RealType>(1))));
+      BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_exponential(static_cast<RealType>(1)), static_cast<RealType>(-1))));
+      BOOST_CHECK((boost::math::isnan)(logpdf(ignore_error_exponential(static_cast<RealType>(-1)), static_cast<RealType>(1))));
+      BOOST_CHECK((boost::math::isnan)(logpdf(ignore_error_exponential(static_cast<RealType>(1)), static_cast<RealType>(-1))));
+
+      // CDF
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_exponential(static_cast<RealType>(-1)), static_cast<RealType>(1))));
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_exponential(static_cast<RealType>(1)), static_cast<RealType>(-1))));
+      BOOST_CHECK((boost::math::isnan)(logcdf(ignore_error_exponential(static_cast<RealType>(-1)), static_cast<RealType>(1))));
+      BOOST_CHECK((boost::math::isnan)(logcdf(ignore_error_exponential(static_cast<RealType>(1)), static_cast<RealType>(-1))));
+      
+      // Complement CDF
+      BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_exponential(static_cast<RealType>(-1)), static_cast<RealType>(1)))));
+      BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_exponential(static_cast<RealType>(1)), static_cast<RealType>(-1)))));
+      BOOST_CHECK((boost::math::isnan)(logcdf(complement(ignore_error_exponential(static_cast<RealType>(-1)), static_cast<RealType>(1)))));
+      BOOST_CHECK((boost::math::isnan)(logcdf(complement(ignore_error_exponential(static_cast<RealType>(1)), static_cast<RealType>(-1)))));
+
+      // Quantile
+      BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_exponential(static_cast<RealType>(-1)), static_cast<RealType>(0.5))));
+      BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_exponential(static_cast<RealType>(1)), static_cast<RealType>(-0.5))));
+      BOOST_CHECK((boost::math::isnan)(quantile(complement(ignore_error_exponential(static_cast<RealType>(-1)), static_cast<RealType>(0.5)))));
+      BOOST_CHECK((boost::math::isnan)(quantile(complement(ignore_error_exponential(static_cast<RealType>(1)), static_cast<RealType>(-0.5)))));
+
+      // Mean and Standard Deviation
+      BOOST_CHECK((boost::math::isnan)(mean(ignore_error_exponential(static_cast<RealType>(-1)))));
+      BOOST_CHECK((boost::math::isnan)(standard_deviation(ignore_error_exponential(static_cast<RealType>(-1)))));
    }
 } // template <class RealType>void test_spots(RealType)
 

--- a/test/test_extreme_value.cpp
+++ b/test/test_extreme_value.cpp
@@ -253,6 +253,65 @@ void test_spots(RealType)
       BOOST_CHECK_EQUAL(cdf(complement(extreme_value_distribution<RealType>(), inf)), 0);
       BOOST_CHECK_EQUAL(logcdf(extreme_value_distribution<RealType>(), -inf), 0);
       BOOST_CHECK_EQUAL(logcdf(extreme_value_distribution<RealType>(), inf), 1);
+
+      // Test NaN policy
+      using boost::math::policies::policy;
+
+      typedef policy<
+         boost::math::policies::domain_error<boost::math::policies::ignore_error>,
+         boost::math::policies::overflow_error<boost::math::policies::ignore_error>,
+         boost::math::policies::underflow_error<boost::math::policies::ignore_error>,
+         boost::math::policies::denorm_error<boost::math::policies::ignore_error>,
+         boost::math::policies::pole_error<boost::math::policies::ignore_error>,
+         boost::math::policies::evaluation_error<boost::math::policies::ignore_error>
+      > ignore_all_policy;
+
+      typedef boost::math::extreme_value_distribution<RealType, ignore_all_policy> ignore_error_extreme;
+
+      // PDF
+      BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(-1)), static_cast<RealType>(0))));
+      BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_extreme(inf, static_cast<RealType>(1)), static_cast<RealType>(1))));
+      BOOST_CHECK((boost::math::isnan)(pdf(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(1)), std::numeric_limits<RealType>::quiet_NaN())));
+
+      // log(PDF)
+      BOOST_CHECK((boost::math::isnan)(logpdf(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(-1)), static_cast<RealType>(0))));
+      BOOST_CHECK((boost::math::isnan)(logpdf(ignore_error_extreme(inf, static_cast<RealType>(1)), static_cast<RealType>(1))));
+      BOOST_CHECK((boost::math::isnan)(logpdf(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(1)), std::numeric_limits<RealType>::quiet_NaN())));
+   
+      // CDF
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(-1)), static_cast<RealType>(0))));
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_extreme(inf, static_cast<RealType>(1)), static_cast<RealType>(1))));
+      BOOST_CHECK((boost::math::isnan)(cdf(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(1)), std::numeric_limits<RealType>::quiet_NaN())));
+      
+      BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(-1)), static_cast<RealType>(0)))));
+      BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_extreme(inf, static_cast<RealType>(1)), static_cast<RealType>(1)))));
+      BOOST_CHECK((boost::math::isnan)(cdf(complement(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(1)), std::numeric_limits<RealType>::quiet_NaN()))));
+      
+      // log(CDF)
+      BOOST_CHECK((boost::math::isnan)(logcdf(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(-1)), static_cast<RealType>(0))));
+      BOOST_CHECK((boost::math::isnan)(logcdf(ignore_error_extreme(inf, static_cast<RealType>(1)), static_cast<RealType>(1))));
+      BOOST_CHECK((boost::math::isnan)(logcdf(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(1)), std::numeric_limits<RealType>::quiet_NaN())));
+
+      BOOST_CHECK((boost::math::isnan)(logcdf(complement(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(-1)), static_cast<RealType>(0)))));
+      BOOST_CHECK((boost::math::isnan)(logcdf(complement(ignore_error_extreme(inf, static_cast<RealType>(1)), static_cast<RealType>(1)))));
+      BOOST_CHECK((boost::math::isnan)(logcdf(complement(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(1)), std::numeric_limits<RealType>::quiet_NaN()))));
+   
+      // Quantile
+      BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(-1)), static_cast<RealType>(0.5))));
+      BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_extreme(inf, static_cast<RealType>(1)), static_cast<RealType>(0.5))));
+      BOOST_CHECK((boost::math::isnan)(quantile(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(1)), static_cast<RealType>(-1))));
+      
+      BOOST_CHECK((boost::math::isnan)(quantile(complement(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(-1)), static_cast<RealType>(0.5)))));
+      BOOST_CHECK((boost::math::isnan)(quantile(complement(ignore_error_extreme(inf, static_cast<RealType>(1)), static_cast<RealType>(0.5)))));
+      BOOST_CHECK((boost::math::isnan)(quantile(complement(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(1)), static_cast<RealType>(-1)))));
+      
+      // Mean
+      BOOST_CHECK((boost::math::isnan)(mean(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(-1)))));
+      BOOST_CHECK((boost::math::isnan)(mean(ignore_error_extreme(inf, static_cast<RealType>(1)))));
+
+      // Standard deviation
+      BOOST_CHECK((boost::math::isnan)(standard_deviation(ignore_error_extreme(static_cast<RealType>(0), static_cast<RealType>(-1)))));
+      BOOST_CHECK((boost::math::isnan)(standard_deviation(ignore_error_extreme(inf, static_cast<RealType>(1)))));
    }
    //
    // Bug reports:

--- a/test/test_find_location.cpp
+++ b/test/test_find_location.cpp
@@ -74,18 +74,18 @@ void test_spots(RealType)
   BOOST_MATH_CHECK_THROW(find_location<normal>(0., 2., 0.), std::domain_error); // p above 0 to 1.
   BOOST_MATH_CHECK_THROW(find_location<normal>(numeric_limits<double>::infinity(), 0.5, 0.),
     std::domain_error); // z not finite.
-  BOOST_MATH_CHECK_THROW(find_location<normal>(numeric_limits<double>::quiet_NaN(), -1., 0.),
+  BOOST_MATH_CHECK_THROW(find_location<normal>(numeric_limits<double>::quiet_NaN(), 0.5, 0.),
     std::domain_error); // z not finite
-  BOOST_MATH_CHECK_THROW(find_location<normal>(0., -1., numeric_limits<double>::quiet_NaN()),
+  BOOST_MATH_CHECK_THROW(find_location<normal>(0., 0.5, numeric_limits<double>::quiet_NaN()),
     std::domain_error); // scale not finite
 
   BOOST_MATH_CHECK_THROW(find_location<normal>(complement(0., -1., 0.)), std::domain_error); // p below 0 to 1.
   BOOST_MATH_CHECK_THROW(find_location<normal>(complement(0., 2., 0.)), std::domain_error); // p above 0 to 1.
   BOOST_MATH_CHECK_THROW(find_location<normal>(complement(numeric_limits<double>::infinity(), 0.5, 0.)),
     std::domain_error); // z not finite.
-  BOOST_MATH_CHECK_THROW(find_location<normal>(complement(numeric_limits<double>::quiet_NaN(), -1., 0.)),
+  BOOST_MATH_CHECK_THROW(find_location<normal>(complement(numeric_limits<double>::quiet_NaN(), 0.5, 0.)),
     std::domain_error); // z not finite
-  BOOST_MATH_CHECK_THROW(find_location<normal>(complement(0., -1., numeric_limits<double>::quiet_NaN())),
+  BOOST_MATH_CHECK_THROW(find_location<normal>(complement(0., 0.5, numeric_limits<double>::quiet_NaN())),
     std::domain_error); // scale not finite
 
   //// Check for ab-use with unsuitable distribution(s) when concept check implemented.
@@ -131,11 +131,39 @@ void test_spots(RealType)
   // Check that can use the complement version.
   RealType q = 1 - p; // complement.
   // cout << "find_location<normal_distribution<RealType> >(complement(z, q, sd)) = " << endl;
+  l = find_location<normal_distribution<RealType> >(complement(z, q, sd, policy<>()));
   l = find_location<normal_distribution<RealType> >(complement(z, q, sd));
 
   normal_distribution<RealType> np95pc(l, sd); // Same standard_deviation (scale) but with mean(location) shifted
   //  cout << "Normal distribution with mean = " << l << " has " << "fraction <= " << z << " = "  << cdf(np95pc, z) << endl;
   BOOST_CHECK_CLOSE_FRACTION(q, cdf(np95pc, z), tolerance);
+
+  // Test NaN handling
+  typedef policy<
+    boost::math::policies::domain_error<ignore_error>,
+    boost::math::policies::overflow_error<ignore_error>,
+    boost::math::policies::underflow_error<ignore_error>,
+    boost::math::policies::denorm_error<ignore_error>,
+    boost::math::policies::pole_error<ignore_error>,
+    boost::math::policies::evaluation_error<ignore_error>
+  > ignore_all_policy;
+
+  if (std::numeric_limits<RealType>::has_infinity)
+  {
+    RealType inf = std::numeric_limits<RealType>::infinity(); 
+    BOOST_CHECK((boost::math::isnan)(find_location<normal_distribution<RealType> >(static_cast<RealType>(0), static_cast<RealType>(-1), static_cast<RealType>(1), ignore_all_policy())));
+    BOOST_CHECK((boost::math::isnan)(find_location<normal_distribution<RealType> >(inf, static_cast<RealType>(0.5), static_cast<RealType>(1), ignore_all_policy())));
+    BOOST_CHECK((boost::math::isnan)(find_location<normal_distribution<RealType> >(static_cast<RealType>(0), static_cast<RealType>(0.5), inf, ignore_all_policy())));
+    // Negative scale does not throw. Seems weird... waiting to see if this should be fixed
+    // BOOST_CHECK((boost::math::isnan)(find_location<normal_distribution<RealType> >(static_cast<RealType>(0), static_cast<RealType>(0.5), static_cast<RealType>(-1), ignore_all_policy())));
+  
+    // Complement
+    BOOST_CHECK((boost::math::isnan)(find_location<normal_distribution<RealType> >(complement(static_cast<RealType>(0), static_cast<RealType>(-1), static_cast<RealType>(1), ignore_all_policy()))));
+    BOOST_CHECK((boost::math::isnan)(find_location<normal_distribution<RealType> >(complement(inf, static_cast<RealType>(0.5), static_cast<RealType>(1), ignore_all_policy()))));
+    BOOST_CHECK((boost::math::isnan)(find_location<normal_distribution<RealType> >(complement(static_cast<RealType>(0), static_cast<RealType>(0.5), inf, ignore_all_policy()))));
+  }
+
+  
 
 } // template <class RealType>void test_spots(RealType)
 

--- a/test/test_find_location.cpp
+++ b/test/test_find_location.cpp
@@ -155,7 +155,7 @@ void test_spots(RealType)
     BOOST_CHECK((boost::math::isnan)(find_location<normal_distribution<RealType> >(inf, static_cast<RealType>(0.5), static_cast<RealType>(1), ignore_all_policy())));
     BOOST_CHECK((boost::math::isnan)(find_location<normal_distribution<RealType> >(static_cast<RealType>(0), static_cast<RealType>(0.5), inf, ignore_all_policy())));
     // Negative scale does not throw. Seems weird... waiting to see if this should be fixed
-    // BOOST_CHECK((boost::math::isnan)(find_location<normal_distribution<RealType> >(static_cast<RealType>(0), static_cast<RealType>(0.5), static_cast<RealType>(-1), ignore_all_policy())));
+    BOOST_CHECK((boost::math::isnan)(find_location<normal_distribution<RealType> >(static_cast<RealType>(0), static_cast<RealType>(0.5), static_cast<RealType>(-1), ignore_all_policy())));
   
     // Complement
     BOOST_CHECK((boost::math::isnan)(find_location<normal_distribution<RealType> >(complement(static_cast<RealType>(0), static_cast<RealType>(-1), static_cast<RealType>(1), ignore_all_policy()))));

--- a/test/test_find_scale.cpp
+++ b/test/test_find_scale.cpp
@@ -84,9 +84,9 @@ void test_spots(RealType)
   BOOST_MATH_CHECK_THROW(find_scale<normal>(complement(0., 2., 0.)), std::domain_error); // p above 0 to 1.
   BOOST_MATH_CHECK_THROW(find_scale<normal>(complement(numeric_limits<double>::infinity(), 0.5, 0.)),
     std::domain_error); // z not finite.
-  BOOST_MATH_CHECK_THROW(find_scale<normal>(complement(numeric_limits<double>::quiet_NaN(), -1., 0.)),
+  BOOST_MATH_CHECK_THROW(find_scale<normal>(complement(numeric_limits<double>::quiet_NaN(), 0.5, 0.)),
     std::domain_error); // z not finite
-  BOOST_MATH_CHECK_THROW(find_scale<normal>(complement(0., -1., numeric_limits<double>::quiet_NaN())),
+  BOOST_MATH_CHECK_THROW(find_scale<normal>(complement(0., 0.5, numeric_limits<double>::quiet_NaN())),
     std::domain_error); // scale not finite
 
   BOOST_MATH_CHECK_THROW(find_scale<normal>(complement(0., -1., 0.)), std::domain_error); // p below 0 to 1.
@@ -110,12 +110,36 @@ void test_spots(RealType)
 #ifndef BOOST_NO_EXCEPTIONS
   BOOST_CHECK_NO_THROW(find_scale<normal>(0, -1, 1,
     ignore_domain_policy())); // probability outside [0, 1]
-  BOOST_CHECK_NO_THROW(find_scale<normal>(numeric_limits<double>::infinity(), -1, 1,
+  BOOST_CHECK_NO_THROW(find_scale<normal>(numeric_limits<double>::infinity(), 0.5, 1,
     ignore_domain_policy())); // z not finite.
   BOOST_CHECK_NO_THROW(find_scale<normal>(complement(0, -1, 1, ignore_domain_policy()))); // probability outside [0, 1]
-  BOOST_CHECK_NO_THROW(find_scale<normal>(complement(numeric_limits<double>::infinity(), -1, 1,
+  BOOST_CHECK_NO_THROW(find_scale<normal>(complement(numeric_limits<double>::infinity(), 0.5, 1,
     ignore_domain_policy()))); // z not finite.
 #endif
+
+  // Test NaN handling
+  typedef policy<
+    boost::math::policies::domain_error<ignore_error>,
+    boost::math::policies::overflow_error<ignore_error>,
+    boost::math::policies::underflow_error<ignore_error>,
+    boost::math::policies::denorm_error<ignore_error>,
+    boost::math::policies::pole_error<ignore_error>,
+    boost::math::policies::evaluation_error<ignore_error>
+  > ignore_all_policy;
+
+  if (std::numeric_limits<RealType>::has_infinity)
+  {
+    RealType inf = std::numeric_limits<RealType>::infinity(); 
+    BOOST_CHECK((boost::math::isnan)(find_scale<normal_distribution<RealType> >(static_cast<RealType>(0), static_cast<RealType>(-1), static_cast<RealType>(1), ignore_all_policy())));
+    BOOST_CHECK((boost::math::isnan)(find_scale<normal_distribution<RealType> >(inf, static_cast<RealType>(0.5), static_cast<RealType>(1), ignore_all_policy())));
+    BOOST_CHECK((boost::math::isnan)(find_scale<normal_distribution<RealType> >(static_cast<RealType>(0), static_cast<RealType>(0.5), inf, ignore_all_policy())));
+
+    // Complement
+    BOOST_CHECK((boost::math::isnan)(find_scale<normal_distribution<RealType> >(complement(static_cast<RealType>(0), static_cast<RealType>(-1), static_cast<RealType>(1), ignore_all_policy()))));
+    BOOST_CHECK((boost::math::isnan)(find_scale<normal_distribution<RealType> >(complement(inf, static_cast<RealType>(0.5), static_cast<RealType>(1), ignore_all_policy()))));
+    BOOST_CHECK((boost::math::isnan)(find_scale<normal_distribution<RealType> >(complement(static_cast<RealType>(0), static_cast<RealType>(0.5), inf, ignore_all_policy()))));
+  }
+
   RealType l = 0.; // standard normal distribution.
   RealType sd = static_cast<RealType>(1); // normal default standard deviation = 1.
   normal_distribution<RealType> n01(l, sd); // mean(location) = 0, standard_deviation (scale) = 1.


### PR DESCRIPTION
Added tests for the following distributions to get 100% test coverage. 

- [x] arcsine
- [ ] bernoulli (97%)
- [ ] beta (99%)
    - In `find_alpha` and `find_beta`, there isn't an upper bound on the mean and variance. However, there should be. 
- [ ] binomial (98%)
- [x] cauchy
- [ ] chi-squared (98%)
- [ ] exponential (99%) 
- [ ] extreme value (98%)
- [x] find_location
    - Have a question below. The scale argument is allowed to be negative
- [x] find_scale
    - Here and in `find_location`, I think there might be redundant functions. Just a note to go back and take a look later. 
    
Here is the [code coverage report](https://app.codecov.io/gh/boostorg/math/tree/JacobHass8%2Fmath%3Adistribution-test-coverage/include%2Fboost%2Fmath%2Fdistributions) for my information. 