### PR TITLE
Check all of special functions can be included under same conditions

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -203,6 +203,7 @@ test-suite special_fun :
    [ run git_issue_1247.cpp ]
    [ run git_issue_1308.cpp /boost/test//boost_unit_test_framework ]
    [ run git_issue_1412.cpp ]
+   [ run git_issue_1412_pt_2.cpp ]
    [ run special_functions_test.cpp /boost/test//boost_unit_test_framework  ]
    [ run test_airy.cpp test_instances//test_instances pch_light /boost/test//boost_unit_test_framework  ]
    [ run test_bessel_j.cpp test_instances//test_instances pch_light /boost/test//boost_unit_test_framework  ]

--- a/test/git_issue_1412_pt_2.cpp
+++ b/test/git_issue_1412_pt_2.cpp
@@ -4,20 +4,23 @@
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 // Regression test for https://github.com/boostorg/math/issues/1412
+//
+// Part 2: Test all of #include <boost/math/special_functions.hpp> as that is what libc++ is going to use
 
 #define BOOST_MATH_NO_EXCEPTIONS
 
 // Claim the <iomanip> include guard so any later #include <iomanip> expands to nothing and std::setprecision is unavailable.
-// The original reproducer with _SSTREAM broke <complex> which iso outside our purview
+// The original reproducer with _SSTREAM broke <complex> which is outside our purview.
 #define _LIBCPP_IOMANIP        // libc++
 #define _GLIBCXX_IOMANIP 1     // libstdc++
 
-#include <boost/math/policies/error_handling.hpp>
-#include <boost/math/special_functions.hpp>
+#include "compile_test/instantiate.hpp"
 
-int main()
+int main(int argc, char* [])
 {
-    // Exercise a special function so the no-exceptions header path is
-    // instantiated, not just parsed.
-    return static_cast<int>(boost::math::laguerre(1u, 0u, 0.5));
+    if (argc > 10000)
+    {
+        instantiate(double(0));
+        instantiate_mixed(double(0));
+    }
 }

--- a/test/git_issue_1412_pt_2.cpp
+++ b/test/git_issue_1412_pt_2.cpp
@@ -1,0 +1,23 @@
+//  Copyright Matt Borland 2026
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Regression test for https://github.com/boostorg/math/issues/1412
+
+#define BOOST_MATH_NO_EXCEPTIONS
+
+// Claim the <iomanip> include guard so any later #include <iomanip> expands to nothing and std::setprecision is unavailable.
+// The original reproducer with _SSTREAM broke <complex> which iso outside our purview
+#define _LIBCPP_IOMANIP        // libc++
+#define _GLIBCXX_IOMANIP 1     // libstdc++
+
+#include <boost/math/policies/error_handling.hpp>
+#include <boost/math/special_functions.hpp>
+
+int main()
+{
+    // Exercise a special function so the no-exceptions header path is
+    // instantiated, not just parsed.
+    return static_cast<int>(boost::math::laguerre(1u, 0u, 0.5));
+}


### PR DESCRIPTION
CC: @PaulXiCao

This seems to run fine with all of special functions included. It looks like the other naked uses of `<sstream>` are in the interpolators and gradient optimizers. Those should all be outside of what you need, and are effectively isolated modules within boost.math.