### PR TITLE
Correct TOMS 748 root bracketing docs

### DIFF
--- a/doc/html/math_toolkit/roots_noderiv/TOMS748.html
+++ b/doc/html/math_toolkit/roots_noderiv/TOMS748.html
@@ -105,7 +105,7 @@
               A unary functor (or C++ lambda) that is the function whose root is
               to be solved. f(x) need not be uniformly increasing or decreasing on
               <span class="emphasis"><em>x</em></span> and may have multiple roots. However, the bounds
-              given must bracket a single root.
+              given must bracket at least one root.
             </p></dd>
 <dt><span class="term">a</span></dt>
 <dd><p>

--- a/doc/roots/roots_without_derivatives.qbk
+++ b/doc/roots/roots_without_derivatives.qbk
@@ -373,7 +373,7 @@ The __root_finding_TOMS748 parameters are:
 [variablelist
 [[f]   [A unary functor (or C++ lambda) that is the function whose root is to be solved.
        f(x) need not be uniformly increasing or decreasing on ['x] and
-       may have multiple roots.  However, the bounds given must bracket a single root.]]
+       may have multiple roots.  However, the bounds given must bracket at least one root.]]
 [[a]   [The lower bound for the initial bracket of the root.]]
 [[b]   [The upper bound for the initial bracket of the root.
        It is a precondition that ['a < b] and that ['a] and ['b]


### PR DESCRIPTION
Fixes boostorg/math#1166.

## Summary

This is a documentation-only update for the TOMS 748 root-finding docs.

The parameter description now says that the initial bounds must bracket at
least one root, rather than a single root. The `f(a) * f(b) < 0` precondition
remains documented immediately below that text.

## Rationale

- TOMS Algorithm 748 is described as enclosing a zero of a continuous function
  (Alefeld, Potra, and Shi, ACM TOMS 21(3), 1995, DOI:
  `10.1145/210089.210111`).
- Boost.Math's implementation enforces a sign-changing bracket, not uniqueness:
  `toms748_solve` rejects same-sign endpoint values, and `detail::bracket`
  updates the interval by comparing endpoint signs.
- With continuous `f`, the endpoint sign change guarantees at least one
  sign-changing root in the interval. If all roots in the interval are simple
  crossings, this implies an odd number of roots, but additional
  even-multiplicity roots may also lie in the same bounds, so uniqueness is not
  required.

## Changes

- update the Quickbook source in `doc/roots/roots_without_derivatives.qbk`
- update the corresponding pregenerated HTML page under `doc/html`

## Validation

- inspected the issue discussion and existing TOMS 748 precondition wording
- inspected `include/boost/math/tools/toms748_solve.hpp`
- compiled and ran a local smoke test showing:
  - a sign-changing interval containing two distinct roots, one crossing root
    and one even-multiplicity root, is accepted
  - an interval containing two simple roots but no endpoint sign change is
    rejected
- checked Boost.Math and Boost superproject contribution/template files; no PR
  template is present in the repo or organization-level `.github` repo
- checked official Boost requirements/submission guidance and Math README docs
  build instructions
- bootstrapped `b2` and initialized the required Boost documentation tool
  submodules/dependencies
- ran `../../../b2 -q --user-config=<repo>/user-config.jam` from `libs/math/doc`
- ran `git diff --check`
