### PR TITLE
DOC: Correct `boost::math::statistics::first_four_moments` documentation

### DIFF
--- a/doc/statistics/univariate_statistics.qbk
+++ b/doc/statistics/univariate_statistics.qbk
@@ -288,7 +288,7 @@ This function simply subtracts 3 from the kurtosis, but it makes eminently clear
 
 [heading First four moments]
 
-Simultaneously computes the first four [@https://en.wikipedia.org/wiki/Central_moment central moments] in a single pass through the data:
+Simultaneously computes the mean and the second, third, and fourth [@https://en.wikipedia.org/wiki/Central_moment central moments] in a single pass through the data:
 
     std::vector<double> v{1,2,3,4,5};
     auto [M1, M2, M3, M4] = boost::math::statistics::first_four_moments(v);


### PR DESCRIPTION
Fixes https://github.com/boostorg/math/issues/1420