### PR TITLE
Clear the four -Wdocumentation warnings

### DIFF
--- a/include/boost/math/distributions/find_scale.hpp
+++ b/include/boost/math/distributions/find_scale.hpp
@@ -60,8 +60,8 @@ namespace boost
       }
 
       //cout << "z " << z << ", p " << p << ",  quantile(Dist(), p) "
-      //<< quantile(Dist(), p) << ", z - mean " << z - location 
-      //<<", sd " << (z - location)  / quantile(Dist(), p) << endl;
+      // << quantile(Dist(), p) << ", z - mean " << z - location
+      // <<", sd " << (z - location)  / quantile(Dist(), p) << endl;
 
       //quantile(N01, 0.001) -3.09023
       //quantile(N01, 0.01) -2.32635

--- a/include/boost/math/distributions/hyperexponential.hpp
+++ b/include/boost/math/distributions/hyperexponential.hpp
@@ -54,7 +54,7 @@ template <typename RealT, typename PolicyT>
 class hyperexponential_distribution;
 
 
-namespace /*<unnamed>*/ { namespace hyperexp_detail {
+namespace /* <unnamed> */ { namespace hyperexp_detail {
 
 template <typename T>
 void normalize(std::vector<T>& v)

--- a/include/boost/math/special_functions/lambert_w.hpp
+++ b/include/boost/math/special_functions/lambert_w.hpp
@@ -778,7 +778,7 @@ struct lambert_w0_small_z_series_term
 {
   using result_type = T;
   //! \param _z Lambert W argument z.
-  //! \param -term  -pow<18>(z) / 6402373705728000uLL
+  //! \param _term  -pow<18>(z) / 6402373705728000uLL
   //! \param _k number of terms == initially 18
 
   //  Note *after* evaluating N terms, its internal state has k = N and term = (-1)^N z^N.

--- a/include/boost/math/special_functions/lambert_w.hpp
+++ b/include/boost/math/special_functions/lambert_w.hpp
@@ -780,7 +780,7 @@ struct lambert_w0_small_z_series_term
 {
   using result_type = T;
   //! \param _z Lambert W argument z.
-  //! \param -term  -pow<18>(z) / 6402373705728000uLL
+  //! \param _term  -pow<18>(z) / 6402373705728000uLL
   //! \param _k number of terms == initially 18
 
   //  Note *after* evaluating N terms, its internal state has k = N and term = (-1)^N z^N.


### PR DESCRIPTION
Building the two aggregate headers with `-Wdocumentation` gives four warnings. This clears them.

```console
$ clang++ -Wdocumentation -fsyntax-only -I include -std=c++14 agg.cpp
special_functions/lambert_w.hpp:781:14: warning: parameter '-term' not found in the function declaration
distributions/find_scale.hpp:63:7: warning: not a Doxygen trailing comment
distributions/find_scale.hpp:64:7: warning: not a Doxygen trailing comment
distributions/hyperexponential.hpp:57:11: warning: not a Doxygen trailing comment
```

Two different things behind them.

### One real documentation mismatch

`lambert_w.hpp:781`

```cpp
//! \param _z Lambert W argument z.
//! \param -term  -pow<18>(z) / 6402373705728000uLL
//! \param _k number of terms == initially 18

lambert_w0_small_z_series_term(T _z, T _term, int _k)
```

A hyphen where the other two have an underscore. Doxygen looks for a parameter named `-term`, does not find it, and `_term` ends up undocumented.

### Three accidental Doxygen markers

`//<` and `/*<` are how Doxygen marks a trailing comment, and in these three places the sequence turns up by accident.

In `find_scale.hpp` it is inside commented-out debug output, where a line that used to begin with `<< quantile(...)` became `//<< quantile(...)`:

```cpp
//cout << "z " << z << ", p " << p << ",  quantile(Dist(), p) "
//<< quantile(Dist(), p) << ", z - mean " << z - location
```

In `hyperexponential.hpp` it is the note on the unnamed namespace, `namespace /*<unnamed>*/ {`.

Neither is a documentation error, just a character sequence that reads as one. A space fixes both and the comments say the same thing.

I checked through `boost/math/special_functions.hpp` and `boost/math/distributions.hpp`, so this covers what those two pull in rather than every header in the library. `-fsyntax-only` stays clean after the change.
