### PR TITLE
Correct ibeta when it's an arcsine distribution.

### DIFF
--- a/include/boost/math/special_functions/beta.hpp
+++ b/include/boost/math/special_functions/beta.hpp
@@ -1285,7 +1285,7 @@ BOOST_MATH_GPU_ENABLED T ibeta_imp(T a, T b, T x, const Policy& pol, bool inv, b
       {
          *p_derivative = 1 / (constants::pi<T>() * sqrt(y * x));
       }
-      T p;
+      T p;  // LCOV_EXCL_LINE
       if (invert)
       {
           p = (y < 0.75) ? T(asin(sqrt(y)) / constants::half_pi<T>()) : T(1 - asin(sqrt(x)) / constants::half_pi<T>());

--- a/include/boost/math/special_functions/beta.hpp
+++ b/include/boost/math/special_functions/beta.hpp
@@ -1288,11 +1288,11 @@ BOOST_MATH_GPU_ENABLED T ibeta_imp(T a, T b, T x, const Policy& pol, bool inv, b
       T p;
       if (invert)
       {
-          p = (y < 0.75) ? asin(sqrt(y)) / constants::half_pi<T>() : 1 - asin(sqrt(x)) / constants::half_pi<T>();
+          p = (y < 0.75) ? T(asin(sqrt(y)) / constants::half_pi<T>()) : T(1 - asin(sqrt(x)) / constants::half_pi<T>());
       }
       else
       {
-          p = (x > 0.75) ? 1 - asin(sqrt(y)) / constants::half_pi<T>() : asin(sqrt(x)) / constants::half_pi<T>();
+          p = (x > 0.75) ? T(1 - asin(sqrt(y)) / constants::half_pi<T>()) : T(asin(sqrt(x)) / constants::half_pi<T>());
       }
       if(!normalised)
          p *= constants::pi<T>();

--- a/include/boost/math/special_functions/beta.hpp
+++ b/include/boost/math/special_functions/beta.hpp
@@ -1285,7 +1285,15 @@ BOOST_MATH_GPU_ENABLED T ibeta_imp(T a, T b, T x, const Policy& pol, bool inv, b
       {
          *p_derivative = 1 / (constants::pi<T>() * sqrt(y * x));
       }
-      T p = invert ? asin(sqrt(y)) / constants::half_pi<T>() : asin(sqrt(x)) / constants::half_pi<T>();
+      T p;
+      if (invert)
+      {
+          p = (y < 0.75) ? asin(sqrt(y)) / constants::half_pi<T>() : 1 - asin(sqrt(x)) / constants::half_pi<T>();
+      }
+      else
+      {
+          p = (x > 0.75) ? 1 - asin(sqrt(y)) / constants::half_pi<T>() : asin(sqrt(x)) / constants::half_pi<T>();
+      }
       if(!normalised)
          p *= constants::pi<T>();
       return p;

--- a/test/test_students_t.cpp
+++ b/test/test_students_t.cpp
@@ -421,6 +421,7 @@ void test_spots(RealType)
          {
             BOOST_CHECK_THROW(boost::math::quantile(students_t_distribution<RealType>((std::numeric_limits<RealType>::min)() / 2), static_cast<RealType>(0.0025f)), std::overflow_error);
          }
+         BOOST_CHECK_CLOSE(boost::math::cdf(students_t_distribution<RealType>(static_cast<RealType>(1)), ldexp(RealType(1), -30)), static_cast<RealType>(0.5000000002964491827262478614651948102240210317156775562512071908L), tolerance);
       }
 
   // Student's t pdf tests.


### PR DESCRIPTION
So we don't take the asin of values very close to 1. 
Fixes: https://github.com/boostorg/math/issues/1429.