### PR TITLE
Fix student's T for quantile of very small values.

### DIFF
--- a/include/boost/math/distributions/students_t.hpp
+++ b/include/boost/math/distributions/students_t.hpp
@@ -466,7 +466,7 @@ BOOST_MATH_GPU_ENABLED RealType calculate_hill_df_guess(
    RealType za = quantile(complement(n, alpha));
    RealType zb = quantile(complement(n, beta));
 
-   RealType v_norm = pow((za + zb) * sd / difference_from_mean, 2) - 1;
+   RealType v_norm = static_cast<RealType>(pow((za + zb) * sd / difference_from_mean, 2) - 1);
    RealType hint = v_norm + (za * za - za * zb + zb * zb + 1) / 2;
 
    return (hint <= 0) ? RealType(1) : hint;

--- a/include/boost/math/special_functions/detail/t_distribution_inv.hpp
+++ b/include/boost/math/special_functions/detail/t_distribution_inv.hpp
@@ -509,7 +509,14 @@ BOOST_MATH_GPU_ENABLED T fast_students_t_quantile_imp(T df, T p, const Policy& p
    // Get cdf from incomplete beta result:
    T p0 = f0 / 2  - p;
    // Get pdf from derivative:
-   T p1 = f1 * sqrt(y * xb * xb * xb / df);
+   T rxb = sqrt(xb);
+   T p1 = f1 * sqrt(y / df);
+   p1 *= rxb;
+   p1 *= rxb;
+   p1 *= rxb;
+   // If p1 has underflowed, all subsequent calculations will fail:
+   if (p1 < tools::min_value<T>())
+       return t;
    //
    // Second derivative divided by p1:
    //

--- a/test/test_students_t.cpp
+++ b/test/test_students_t.cpp
@@ -426,12 +426,19 @@ void test_spots(RealType)
          // We have quite limited precision in this area:
          if (boost::math::tools::digits<RealType>() > boost::math::tools::digits<float>())
          {
+             using std::ldexp;
              BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(3)), ldexp(RealType(1), -800)), static_cast<RealType>(-1.94452005735447553162080266906e+80L), 1e-8);
-             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(3)), ldexp(RealType(1), -1000)), static_cast<RealType>(-2.27760708321880957407749124767e+100), 1e-8);
-             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(5)), ldexp(RealType(1), -1000)), static_cast<RealType>(-2.52030967154944272146770707689e+60), 1e-8);
-             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(7)), ldexp(RealType(1), -1000)), static_cast<RealType>(-2.02884419021075115948274137329e+43), 1e-8);
-             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(10)), ldexp(RealType(1), -1000)), static_cast<RealType>(-3.25092256692541451558538754799e+30), 1e-8);
-             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(30)), ldexp(RealType(1), -1000)), static_cast<RealType>(-54306462721.8246714347211540407), 1e-8);
+             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(3)), ldexp(RealType(1), -1000)), static_cast<RealType>(-2.27760708321880957407749124767e+100L), 1e-8);
+             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(5)), ldexp(RealType(1), -1000)), static_cast<RealType>(-2.52030967154944272146770707689e+60L), 1e-8);
+             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(7)), ldexp(RealType(1), -1000)), static_cast<RealType>(-2.02884419021075115948274137329e+43L), 1e-8);
+             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(10)), ldexp(RealType(1), -1000)), static_cast<RealType>(-3.25092256692541451558538754799e+30L), 1e-8);
+             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(30)), ldexp(RealType(1), -1000)), static_cast<RealType>(-54306462721.8246714347211540407L), 1e-8);
+             using nopromote = boost::math::policies::policy<boost::math::policies::promote_double<false>>;
+             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType, nopromote>(static_cast<RealType>(30)), ldexp(RealType(1), -1000)), static_cast<RealType>(-54306462721.8246714347211540407L), 1e-8);
+             if (boost::math::tools::digits<RealType>() > boost::math::tools::digits<double>())
+             {
+                 BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(30)), ldexp(RealType(1), -16000)), static_cast<RealType>(-1.77766265021682828433490865393e+161L), 1e-8);
+             }
          }
       }
 

--- a/test/test_students_t.cpp
+++ b/test/test_students_t.cpp
@@ -422,6 +422,17 @@ void test_spots(RealType)
             BOOST_CHECK_THROW(boost::math::quantile(students_t_distribution<RealType>((std::numeric_limits<RealType>::min)() / 2), static_cast<RealType>(0.0025f)), std::overflow_error);
          }
          BOOST_CHECK_CLOSE(boost::math::cdf(students_t_distribution<RealType>(static_cast<RealType>(1)), ldexp(RealType(1), -30)), static_cast<RealType>(0.5000000002964491827262478614651948102240210317156775562512071908L), tolerance);
+         // https://github.com/boostorg/math/issues/1436
+         // We have quite limited precision in this area:
+         if (boost::math::tools::digits<RealType>() > boost::math::tools::digits<float>())
+         {
+             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(3)), ldexp(RealType(1), -800)), static_cast<RealType>(-1.94452005735447553162080266906e+80L), 1e-8);
+             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(3)), ldexp(RealType(1), -1000)), static_cast<RealType>(-2.27760708321880957407749124767e+100), 1e-8);
+             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(5)), ldexp(RealType(1), -1000)), static_cast<RealType>(-2.52030967154944272146770707689e+60), 1e-8);
+             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(7)), ldexp(RealType(1), -1000)), static_cast<RealType>(-2.02884419021075115948274137329e+43), 1e-8);
+             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(10)), ldexp(RealType(1), -1000)), static_cast<RealType>(-3.25092256692541451558538754799e+30), 1e-8);
+             BOOST_CHECK_CLOSE_FRACTION(boost::math::quantile(students_t_distribution<RealType>(static_cast<RealType>(30)), ldexp(RealType(1), -1000)), static_cast<RealType>(-54306462721.8246714347211540407), 1e-8);
+         }
       }
 
   // Student's t pdf tests.


### PR DESCRIPTION
By preventing underflow in the calculation where possible. Fixes: https://github.com/boostorg/math/issues/1436