### PR TITLE
Guard cardinal quintic Hermite against out-of-bounds read at the right endpoint

### DIFF
--- a/include/boost/math/interpolators/detail/quintic_hermite_detail.hpp
+++ b/include/boost/math/interpolators/detail/quintic_hermite_detail.hpp
@@ -279,6 +279,14 @@ public:
         {
             return y_[i];
         }
+        // Rounding in (x-x0_)*inv_dx_ can place floor(s) on the final node even though
+        // x < xf, in which case index i+1 is one past the end. Evaluate on the final
+        // interval instead; t is then within a few ulps of 1.
+        if (i + 1 >= y_.size())
+        {
+            i = y_.size() - 2;
+            t = s - static_cast<Real>(i);
+        }
         Real y0 = y_[i];
         Real y1 = y_[i+1];
         Real dy0 = dy_[i];
@@ -326,6 +334,14 @@ public:
         {
             return dy_[i]*inv_dx_;
         }
+        // Rounding in (x-x0_)*inv_dx_ can place floor(s) on the final node even though
+        // x < xf, in which case index i+1 is one past the end. Evaluate on the final
+        // interval instead; t is then within a few ulps of 1.
+        if (i + 1 >= y_.size())
+        {
+            i = y_.size() - 2;
+            t = s - static_cast<Real>(i);
+        }
         Real y0 = y_[i];
         Real y1 = y_[i+1];
         Real dy0 = dy_[i];
@@ -368,6 +384,14 @@ public:
         if (t==0)
         {
             return d2y_[i]*2*inv_dx_*inv_dx_;
+        }
+        // Rounding in (x-x0_)*inv_dx_ can place floor(s) on the final node even though
+        // x < xf, in which case index i+1 is one past the end. Evaluate on the final
+        // interval instead; t is then within a few ulps of 1.
+        if (i + 1 >= y_.size())
+        {
+            i = y_.size() - 2;
+            t = s - static_cast<Real>(i);
         }
 
         Real y0 = y_[i];
@@ -462,6 +486,14 @@ public:
         {
             return data_[i][0];
         }
+        // Rounding in (x-x0_)*inv_dx_ can place floor(s) on the final node even though
+        // x < xf, in which case index i+1 is one past the end. Evaluate on the final
+        // interval instead; t is then within a few ulps of 1.
+        if (i + 1 >= data_.size())
+        {
+            i = data_.size() - 2;
+            t = s - static_cast<Real>(i);
+        }
 
         Real y0 = data_[i][0];
         Real dy0 = data_[i][1];
@@ -507,6 +539,14 @@ public:
         {
             return data_[i][1]*inv_dx_;
         }
+        // Rounding in (x-x0_)*inv_dx_ can place floor(s) on the final node even though
+        // x < xf, in which case index i+1 is one past the end. Evaluate on the final
+        // interval instead; t is then within a few ulps of 1.
+        if (i + 1 >= data_.size())
+        {
+            i = data_.size() - 2;
+            t = s - static_cast<Real>(i);
+        }
 
 
         Real y0 = data_[i][0];
@@ -550,6 +590,14 @@ public:
         Real t = s - ii;
         if (t == 0) {
             return data_[i][2]*2*inv_dx_*inv_dx_;
+        }
+        // Rounding in (x-x0_)*inv_dx_ can place floor(s) on the final node even though
+        // x < xf, in which case index i+1 is one past the end. Evaluate on the final
+        // interval instead; t is then within a few ulps of 1.
+        if (i + 1 >= data_.size())
+        {
+            i = data_.size() - 2;
+            t = s - static_cast<Real>(i);
         }
         Real y0 = data_[i][0];
         Real dy0 = data_[i][1];

--- a/test/quintic_hermite_test.cpp
+++ b/test/quintic_hermite_test.cpp
@@ -7,6 +7,8 @@
 
 #include "math_unit_test.hpp"
 #include <numeric>
+#include <cfloat>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 #include <array>
@@ -554,9 +556,93 @@ void test_cardinal_derivative_scaling()
     }
 }
 
+// A std::vector whose operator[] is bounds-checked, so that reading one element past the
+// end of the data throws std::out_of_range instead of being undefined behaviour.
+template<class T>
+struct checked_vector : std::vector<T>
+{
+    using std::vector<T>::vector;
+    T & operator[](std::size_t i) { return this->at(i); }
+    T const & operator[](std::size_t i) const { return this->at(i); }
+};
+
+// Evaluates both cardinal layouts a few ulps below the right endpoint of the domain.
+// Rounding in (x - x0)/dx can place floor() on the final node even though x < xf, which
+// used to read y[n], y'[n] and y''[n] one past the end of the data.
+template<typename Real>
+void check_cardinal_endpoint(Real x0, Real dx, std::size_t n, int & rounding_cases)
+{
+    checked_vector<Real> y(n), dydx(n, Real(1)), d2ydx2(n, Real(0));
+    checked_vector<std::array<Real, 3>> data(n);
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        y[i] = x0 + Real(i)*dx;
+        data[i] = {y[i], Real(1), Real(0)};
+    }
+    auto qh = cardinal_quintic_hermite(std::move(y), std::move(dydx), std::move(d2ydx2), x0, dx);
+    auto qh_aos = cardinal_quintic_hermite_aos(std::move(data), x0, dx);
+
+    Real eps = std::numeric_limits<Real>::epsilon();
+    Real x = qh.domain().second;
+    for (int k = 0; k < 8; ++k)
+    {
+        x = boost::math::nextafter(x, std::numeric_limits<Real>::lowest());
+        // Same arithmetic as the interpolator; counts the x that land on the final node.
+        using std::floor;
+        if (floor((x - x0)*(Real(1)/dx)) >= Real(n - 1))
+        {
+            ++rounding_cases;
+        }
+        bool in_bounds = true;
+        try
+        {
+            CHECK_MOLLIFIED_CLOSE(x, qh(x), 64*eps);
+            CHECK_MOLLIFIED_CLOSE(Real(1), qh.prime(x), 1024*eps);
+            CHECK_MOLLIFIED_CLOSE(Real(0), qh.double_prime(x), 4096*eps*(1 + 1/dx));
+            CHECK_MOLLIFIED_CLOSE(x, qh_aos(x), 64*eps);
+            CHECK_MOLLIFIED_CLOSE(Real(1), qh_aos.prime(x), 1024*eps);
+            CHECK_MOLLIFIED_CLOSE(Real(0), qh_aos.double_prime(x), 4096*eps*(1 + 1/dx));
+        }
+        catch (std::out_of_range const &)
+        {
+            in_bounds = false;
+        }
+        CHECK_TRUE(in_bounds);
+    }
+}
+
+// Grid found by fuzzing: in IEEE double arithmetic, x = nextafter(xf, -inf) satisfies x < xf
+// but floor((x - x0)/dx) == n - 1.
+void test_cardinal_endpoint_rounding_case()
+{
+    int rounding_cases = 0;
+    check_cardinal_endpoint<double>(-2.6660221376669786, 2.6599332164560212, 26, rounding_cases);
+#if FLT_EVAL_METHOD == 0
+    CHECK_TRUE(rounding_cases > 0);
+#endif
+}
+
+template<typename Real>
+void test_cardinal_endpoint_rounding()
+{
+    boost::random::mt19937 rng(1);
+    boost::random::uniform_real_distribution<Real> ux0(Real(-5), Real(5));
+    boost::random::uniform_real_distribution<Real> udx(Real(1)/Real(8), Real(3));
+    boost::random::uniform_real_distribution<Real> u01(Real(0), Real(1));
+    int rounding_cases = 0;
+    for (int trial = 0; trial < 2000; ++trial)
+    {
+        Real x0 = ux0(rng);
+        Real dx = udx(rng);
+        auto n = static_cast<std::size_t>(2 + 198*u01(rng));
+        check_cardinal_endpoint(x0, dx, n, rounding_cases);
+    }
+}
+
 int main()
 {
     test_cardinal_derivative_scaling();
+    test_cardinal_endpoint_rounding_case();
     #ifdef __STDCPP_FLOAT32_T__
     test_constant<std::float32_t>();
     test_linear<std::float32_t>();
@@ -570,6 +656,7 @@ int main()
     test_cardinal_quadratic<std::float32_t>();
     test_cardinal_cubic<std::float32_t>();
     test_cardinal_quartic<std::float32_t>();
+    test_cardinal_endpoint_rounding<std::float32_t>();
     #else
     test_constant<float>();
     test_linear<float>();
@@ -583,6 +670,7 @@ int main()
     test_cardinal_quadratic<float>();
     test_cardinal_cubic<float>();
     test_cardinal_quartic<float>();
+    test_cardinal_endpoint_rounding<float>();
     #endif
 
     #ifdef __STDCPP_FLOAT64_T__
@@ -598,6 +686,7 @@ int main()
     test_cardinal_quadratic<std::float64_t>();
     test_cardinal_cubic<std::float64_t>();
     test_cardinal_quartic<std::float64_t>();
+    test_cardinal_endpoint_rounding<std::float64_t>();
     #else
     test_constant<double>();
     test_linear<double>();
@@ -611,6 +700,7 @@ int main()
     test_cardinal_quadratic<double>();
     test_cardinal_cubic<double>();
     test_cardinal_quartic<double>();
+    test_cardinal_endpoint_rounding<double>();
     #endif
 
     test_constant<long double>();
@@ -625,6 +715,7 @@ int main()
     test_cardinal_quadratic<long double>();
     test_cardinal_cubic<long double>();
     test_cardinal_quartic<long double>();
+    test_cardinal_endpoint_rounding<long double>();
 
     #ifdef BOOST_HAS_FLOAT128
     test_constant<float128>();


### PR DESCRIPTION
Fixes #<issue number, to be filed>

## Problem

`cardinal_quintic_hermite` and `cardinal_quintic_hermite_aos` read one element past the end of `y_`, `dy_` and `d2y_` for some `x` that are strictly inside `domain()`. `operator()` guards `x <= xf` with `xf = x0_ + (n-1)/inv_dx_` and returns early only for `x == xf`, but the interval lookup computes `s = (x - x0_)*inv_dx_` independently, and for `x` a few ulps below `xf` this can round to `n-1 + O(1e-14)`. Then `floor(s) == n-1`, `t != 0`, and `y_[i+1]` is out of bounds. It only occurs when `dx` is not a power of two, which is why the existing tests (`dx = 1` and `1/8`) never see it. In a random sweep over `x0 in (-5,5)`, `dx in (1e-3,3)`, `n in [2,200]`, about 0.26% of grids trigger it within 4 ulps of the right endpoint, for `float`, `double` and `long double` alike.

The basis-function formulas are correct: both cardinal layouts agree with the non-cardinal `quintic_hermite` and with scipy's `BPoly.from_derivatives` to ~4e-15 (value), ~1.5e-13 (first derivative) and ~1.4e-11 (second derivative) on a 12-node grid with `dx = 0.1`, and reproduce `x^5` exactly.

Minimal reproducer (aborts with `-D_GLIBCXX_ASSERTIONS`, or reports heap-buffer-overflow at `quintic_hermite_detail.hpp:283` under `-fsanitize=address`):

```cpp
#include <boost/math/interpolators/quintic_hermite.hpp>
#include <cmath>
#include <vector>
int main()
{
    const double x0 = -2.6660221376669786, dx = 2.6599332164560212;
    const std::size_t n = 26;
    std::vector<double> y(n), dy(n), d2y(n);
    for (std::size_t i = 0; i < n; ++i) { double x = x0 + i*dx; y[i] = std::sin(x); dy[i] = std::cos(x); d2y[i] = -std::sin(x); }
    auto qh = boost::math::interpolators::cardinal_quintic_hermite(std::move(y), std::move(dy), std::move(d2y), x0, dx);
    double x = std::nextafter(qh.domain().second, -INFINITY);   // x < xf, but (x - x0)*(1/dx) == 25.000000000000004
    return qh(x) > 2;                                             // reads y_[26]
}
```

## Fix

In all six `unchecked_*` evaluators (three per data layout), after the existing `t == 0` fast path, clamp to the final interval when `i + 1 >= size()`: `i = size() - 2`, `t = s - i`. `t` is then within a few ulps of 1, so the result is continuous with the endpoint value.

## Tests

* `test_cardinal_endpoint_rounding_case`: the fuzz-found grid above, evaluated for both layouts on a `checked_vector` whose `operator[]` calls `at()`, so the out-of-range read throws `std::out_of_range` deterministically without a sanitizer. With the old header this reports 25 failures across the new tests; with the fix, none.
* `test_cardinal_endpoint_rounding<Real>`: 2000 random grids per type for `float`, `double`, `long double`, walking 8 ulps below the right endpoint, checking values against linear data.
* Existing `quintic_hermite_test` passes unchanged under `-fsanitize=address,undefined`; the header still builds as C++14 with `-Wall -Wextra -Wpedantic`.

## Note

`cardinal_cubic_hermite_detail*` and `cardinal_septic_hermite_detail*` use the same interval lookup and are very likely affected in the same way; this PR is deliberately limited to the quintic interpolator. `daubechies_scaling`/`daubechies_wavelet` construct the AoS variant with `x0 = 0`, `dx = 2^-r`, for which the arithmetic is exact, so they are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
